### PR TITLE
feat(web): add neutral marketing skeleton and routing

### DIFF
--- a/apps/web/app/_components/Footer.tsx
+++ b/apps/web/app/_components/Footer.tsx
@@ -1,0 +1,12 @@
+export function Footer() {
+  const currentYear = new Date().getFullYear();
+
+  return (
+    <footer className="border-t border-neutral-800 bg-neutral-900/50">
+      <div className="mx-auto flex max-w-5xl flex-col gap-2 px-6 py-6 text-sm text-neutral-300">
+        <p>© {currentYear} St Mary&apos;s House Dental. All rights reserved.</p>
+        <p className="text-neutral-400">Champagne Ecosystem – neutral skeleton build.</p>
+      </div>
+    </footer>
+  );
+}

--- a/apps/web/app/_components/Header.tsx
+++ b/apps/web/app/_components/Header.tsx
@@ -1,0 +1,32 @@
+import Link from "next/link";
+
+const navLinks = [
+  { href: "/", label: "Home" },
+  { href: "/treatments", label: "Treatments" },
+  { href: "/team", label: "Team" },
+  { href: "/contact", label: "Contact" },
+  { href: "/patient-portal", label: "Patient Portal" },
+];
+
+export function Header() {
+  return (
+    <header className="border-b border-neutral-800 bg-neutral-900/50">
+      <div className="mx-auto flex max-w-5xl items-center justify-between px-6 py-4">
+        <Link href="/" className="text-lg font-semibold tracking-tight text-neutral-50">
+          St Mary&apos;s House Dental
+        </Link>
+        <nav className="flex items-center gap-4 text-sm text-neutral-200">
+          {navLinks.map((link) => (
+            <Link
+              key={link.href}
+              href={link.href}
+              className="rounded px-2 py-1 transition hover:bg-neutral-800 hover:text-neutral-50"
+            >
+              {link.label}
+            </Link>
+          ))}
+        </nav>
+      </div>
+    </header>
+  );
+}

--- a/apps/web/app/contact/page.tsx
+++ b/apps/web/app/contact/page.tsx
@@ -1,0 +1,16 @@
+export default function ContactPage() {
+  return (
+    <div className="mx-auto flex max-w-4xl flex-col gap-4">
+      <h1 className="text-3xl font-semibold text-neutral-50">Contact the practice</h1>
+      <p className="text-neutral-300">
+        We&apos;re setting up the official contact channels for the new site. Soon you&apos;ll be able to submit enquiries,
+        request appointments, and reach the team directly through the Champagne Ecosystem tools.
+      </p>
+      <ul className="list-disc space-y-2 pl-6 text-neutral-300">
+        <li>Dedicated phone and email links for rapid replies</li>
+        <li>Secure messaging for patient questions</li>
+        <li>Directions and parking information for your visit</li>
+      </ul>
+    </div>
+  );
+}

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -1,17 +1,24 @@
-import type { Metadata } from "next";
+import type { ReactNode } from "react";
 import "./globals.css";
+import { Footer } from "./_components/Footer";
+import { Header } from "./_components/Header";
 
-export const metadata: Metadata = {
-  title: "SMH Dental – Web App Placeholder",
-  description: "Placeholder shell for the web app in the champagne-core monorepo.",
+export const metadata = {
+  title: "St Mary’s House Dental – Champagne Core",
+  description: "Neutral skeleton for the Champagne Ecosystem marketing site.",
 };
 
-export default function RootLayout({ children }: { children: React.ReactNode }) {
-  // NOTE: This marketing-only shell; do not handle or store PHI here.
+export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="en">
-      <body className="min-h-screen">
-        {children}
+      <body className="min-h-screen bg-neutral-950 text-neutral-100 antialiased">
+        <div className="flex min-h-screen flex-col">
+          <Header />
+          <main className="flex-1 px-6 py-10">
+            {children}
+          </main>
+          <Footer />
+        </div>
       </body>
     </html>
   );

--- a/apps/web/app/not-found.tsx
+++ b/apps/web/app/not-found.tsx
@@ -1,0 +1,26 @@
+import Link from "next/link";
+
+export default function NotFound() {
+  return (
+    <div className="mx-auto flex max-w-3xl flex-col gap-4 text-center">
+      <h1 className="text-4xl font-semibold text-neutral-50">Page not found</h1>
+      <p className="text-neutral-300">
+        We couldn&apos;t find the page you were looking for. Use the links below to continue exploring the site.
+      </p>
+      <div className="flex flex-wrap items-center justify-center gap-3 text-sm">
+        <Link
+          href="/"
+          className="rounded-md border border-neutral-800 px-4 py-2 font-medium text-neutral-100 transition hover:border-neutral-700 hover:bg-neutral-900"
+        >
+          Return home
+        </Link>
+        <Link
+          href="/treatments"
+          className="rounded-md border border-neutral-800 px-4 py-2 font-medium text-neutral-100 transition hover:border-neutral-700 hover:bg-neutral-900"
+        >
+          View treatments
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,10 +1,57 @@
+import Link from "next/link";
+
+const quickLinks = [
+  {
+    title: "Treatments",
+    description: "Explore the full range of restorative and cosmetic care we offer.",
+    href: "/treatments",
+  },
+  {
+    title: "Patient stories",
+    description: "Hear how we support patients on their journey (coming soon).",
+    href: "#",
+  },
+  {
+    title: "Patient portal",
+    description: "Manage appointments, forms, and communication in one place.",
+    href: "/patient-portal",
+  },
+];
+
 export default function Page() {
   return (
-    <main className="flex min-h-screen flex-col items-center justify-center gap-4 p-6">
-      <h1 className="text-2xl font-semibold">SMH Dental – Web App Placeholder</h1>
-      <p className="max-w-xl text-center text-sm text-neutral-300">
-        This is the placeholder shell for the <code>web</code> app inside the champagne-core monorepo.
-      </p>
-    </main>
+    <div className="mx-auto flex max-w-5xl flex-col gap-12">
+      <section className="space-y-4">
+        <p className="text-sm uppercase tracking-[0.2em] text-neutral-400">St Mary&apos;s House Dental</p>
+        <h1 className="text-4xl font-semibold tracking-tight text-neutral-50 sm:text-5xl">
+          High-quality dental care in a calm, modern setting.
+        </h1>
+        <p className="max-w-2xl text-lg text-neutral-300">
+          This neutral shell previews the future Champagne Ecosystem site for St Mary&apos;s House Dental.
+          Everything here is placeholder content while we prepare the full experience.
+        </p>
+      </section>
+
+      <section className="space-y-6">
+        <h2 className="text-2xl font-semibold text-neutral-50">Quick links</h2>
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {quickLinks.map((link) => (
+            <Link
+              key={link.title}
+              href={link.href}
+              className="group rounded-lg border border-neutral-800 bg-neutral-900/40 p-5 transition hover:border-neutral-700 hover:bg-neutral-900"
+            >
+              <div className="flex items-center justify-between gap-3">
+                <div>
+                  <p className="text-lg font-semibold text-neutral-50">{link.title}</p>
+                  <p className="text-sm text-neutral-300">{link.description}</p>
+                </div>
+                <span className="text-neutral-500 transition group-hover:text-neutral-200">→</span>
+              </div>
+            </Link>
+          ))}
+        </div>
+      </section>
+    </div>
   );
 }

--- a/apps/web/app/patient-portal/page.tsx
+++ b/apps/web/app/patient-portal/page.tsx
@@ -1,0 +1,16 @@
+export default function PatientPortalPage() {
+  return (
+    <div className="mx-auto flex max-w-4xl flex-col gap-4">
+      <h1 className="text-3xl font-semibold text-neutral-50">Patient portal</h1>
+      <p className="text-neutral-300">
+        The patient portal will become your hub for appointments, treatment plans, and forms. This placeholder page
+        previews how St Mary&apos;s House Dental will connect through the Champagne Ecosystem.
+      </p>
+      <ul className="list-disc space-y-2 pl-6 text-neutral-300">
+        <li>Online booking and reminders</li>
+        <li>Secure document sharing and consent forms</li>
+        <li>Updates on treatment progress</li>
+      </ul>
+    </div>
+  );
+}

--- a/apps/web/app/team/page.tsx
+++ b/apps/web/app/team/page.tsx
@@ -1,0 +1,16 @@
+export default function TeamPage() {
+  return (
+    <div className="mx-auto flex max-w-4xl flex-col gap-4">
+      <h1 className="text-3xl font-semibold text-neutral-50">Meet the team</h1>
+      <p className="text-neutral-300">
+        Our clinical team profile pages are coming soon. Expect introductions to the dentists, hygienists, and support
+        staff who care for every patient at St Mary&apos;s House Dental.
+      </p>
+      <ul className="list-disc space-y-2 pl-6 text-neutral-300">
+        <li>Backgrounds and qualifications for each clinician</li>
+        <li>Photos and short bios to help patients feel welcome</li>
+        <li>Contact options for booking or follow-up questions</li>
+      </ul>
+    </div>
+  );
+}

--- a/apps/web/app/treatments/[slug]/page.tsx
+++ b/apps/web/app/treatments/[slug]/page.tsx
@@ -1,0 +1,48 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+
+type PageProps = {
+  params: Promise<{ slug: string }>;
+};
+
+const allowedTreatments: Record<string, string> = {
+  "dental-implants": "Dental Implants",
+  "invisalign-orthodontics": "Invisalign & Orthodontics",
+  "smile-makeovers": "Smile Makeovers",
+  "teeth-whitening": "Teeth Whitening",
+  "3d-dentistry-scanning": "3D Dentistry & Scanning",
+};
+
+export default async function TreatmentPage({ params }: PageProps) {
+  const { slug } = await params;
+  const title = allowedTreatments[slug];
+
+  if (!title) {
+    return notFound();
+  }
+
+  return (
+    <div className="mx-auto flex max-w-4xl flex-col gap-6">
+      <div className="space-y-2">
+        <p className="text-sm uppercase tracking-[0.2em] text-neutral-400">Treatment</p>
+        <h1 className="text-3xl font-semibold text-neutral-50">{title}</h1>
+        <p className="text-neutral-300">
+          This page is a placeholder for the full details about {title.toLowerCase()}. The complete experience will
+          include clinical information, patient guidance, and how it integrates with the Champagne Ecosystem.
+        </p>
+      </div>
+
+      <div className="rounded-lg border border-neutral-800 bg-neutral-900/40 p-4 text-sm text-neutral-300">
+        <p className="font-semibold text-neutral-100">Routing info</p>
+        <p>Slug: {slug}</p>
+      </div>
+
+      <Link
+        href="/treatments"
+        className="w-fit rounded-md border border-neutral-800 px-4 py-2 text-sm font-medium text-neutral-100 transition hover:border-neutral-700 hover:bg-neutral-900"
+      >
+        ← Back to treatments
+      </Link>
+    </div>
+  );
+}

--- a/apps/web/app/treatments/page.tsx
+++ b/apps/web/app/treatments/page.tsx
@@ -1,0 +1,36 @@
+import Link from "next/link";
+
+const treatments = [
+  { slug: "dental-implants", name: "Dental Implants" },
+  { slug: "invisalign-orthodontics", name: "Invisalign & Orthodontics" },
+  { slug: "smile-makeovers", name: "Smile Makeovers" },
+  { slug: "teeth-whitening", name: "Teeth Whitening" },
+  { slug: "3d-dentistry-scanning", name: "3D Dentistry & Scanning" },
+];
+
+export default function TreatmentsPage() {
+  return (
+    <div className="mx-auto flex max-w-5xl flex-col gap-6">
+      <header className="space-y-2">
+        <p className="text-sm uppercase tracking-[0.2em] text-neutral-400">Treatments</p>
+        <h1 className="text-3xl font-semibold text-neutral-50">Explore our care options</h1>
+        <p className="max-w-2xl text-neutral-300">
+          A snapshot of the services planned for St Mary&apos;s House Dental. Select a treatment to learn more.
+        </p>
+      </header>
+
+      <div className="grid gap-4 sm:grid-cols-2">
+        {treatments.map((treatment) => (
+          <Link
+            key={treatment.slug}
+            href={`/treatments/${treatment.slug}`}
+            className="rounded-lg border border-neutral-800 bg-neutral-900/40 p-5 transition hover:border-neutral-700 hover:bg-neutral-900"
+          >
+            <p className="text-lg font-semibold text-neutral-50">{treatment.name}</p>
+            <p className="text-sm text-neutral-300">Learn more about {treatment.name.toLowerCase()}.</p>
+          </Link>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/next-env.d.ts
+++ b/apps/web/next-env.d.ts
@@ -1,2 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference path="./.next/types/routes.d.ts" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -1,7 +1,20 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "baseUrl": "."
+    "baseUrl": ".",
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
+    "allowJs": true,
+    "noEmit": true,
+    "incremental": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ]
   },
   "include": [
     "next-env.d.ts",


### PR DESCRIPTION
## Summary
- add shared header/footer layout using neutral styling
- build placeholder marketing pages including home, treatments, team, contact, and patient portal
- implement treatment slug handling and a basic 404 experience

## Testing
- npm run lint
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6935dac5ae808332bcfe3f1f11a20f83)