### PR TITLE
Phase 2b – Champagne internal wiring (guards + tokens + manifests)

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,12 @@
     "dev:engine": "npm run dev --workspace engine",
     "dev:all": "npm run dev:web",
     "build": "npm run build --workspaces",
-    "lint": "npm run lint --workspaces"
+    "lint": "npm run lint --workspaces",
+    "guard:rogue-hex": "node packages/champagne-guards/scripts/guard-rogue-hex.mjs",
+    "guard:hero-freeze": "node packages/champagne-guards/scripts/guard-hero-freeze.mjs",
+    "guard:manifests": "node packages/champagne-guards/scripts/guard-manifest-sync.mjs",
+    "guard:brand-structure": "node packages/champagne-guards/scripts/brand-structure-guard.cjs",
+    "guard:all": "pnpm guard:rogue-hex && pnpm guard:hero-freeze && pnpm guard:manifests && pnpm guard:brand-structure"
   },
   "devDependencies": {
     "@types/node": "^24.10.1",

--- a/packages/champagne-3d/tsconfig.json
+++ b/packages/champagne-3d/tsconfig.json
@@ -2,14 +2,9 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "dist",
-    "declaration": true,
-    "strict": true
+    "declaration": true
   },
   "include": [
     "src/**/*.ts"
-  ],
-  "exclude": [
-    "node_modules",
-    "dist"
   ]
 }

--- a/packages/champagne-ai/tsconfig.json
+++ b/packages/champagne-ai/tsconfig.json
@@ -2,14 +2,9 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "dist",
-    "declaration": true,
-    "strict": true
+    "declaration": true
   },
   "include": [
     "src/**/*.ts"
-  ],
-  "exclude": [
-    "node_modules",
-    "dist"
   ]
 }

--- a/packages/champagne-guards/package.json
+++ b/packages/champagne-guards/package.json
@@ -15,6 +15,11 @@
   ],
   "scripts": {
     "build": "tsc -p tsconfig.json",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "guard:rogue-hex": "node scripts/guard-rogue-hex.mjs",
+    "guard:hero-freeze": "node scripts/guard-hero-freeze.mjs",
+    "guard:manifests": "node scripts/guard-manifest-sync.mjs",
+    "guard:brand-structure": "node scripts/brand-structure-guard.cjs",
+    "guard:all": "pnpm guard:rogue-hex && pnpm guard:hero-freeze && pnpm guard:manifests && pnpm guard:brand-structure"
   }
 }

--- a/packages/champagne-guards/tsconfig.json
+++ b/packages/champagne-guards/tsconfig.json
@@ -2,15 +2,10 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "dist",
-    "declaration": true,
-    "strict": true
+    "declaration": true
   },
   "include": [
     "src/**/*",
     "tools/**/*.json"
-  ],
-  "exclude": [
-    "node_modules",
-    "dist"
   ]
 }

--- a/packages/champagne-hero/tsconfig.json
+++ b/packages/champagne-hero/tsconfig.json
@@ -2,14 +2,9 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "dist",
-    "declaration": true,
-    "strict": true
+    "declaration": true
   },
   "include": [
     "src/**/*.ts"
-  ],
-  "exclude": [
-    "node_modules",
-    "dist"
   ]
 }

--- a/packages/champagne-manifests/src/index.ts
+++ b/packages/champagne-manifests/src/index.ts
@@ -1,4 +1,21 @@
 import manifest from "../data/champagne_machine_manifest_full.json";
 
-export const champagneMachineManifest = manifest;
-export const champagneManifestsReady = true;
+export type ChampagneManifestStatus = "unavailable" | "stub" | "ready";
+
+export interface ChampagneMachineManifest {
+  id: string;
+  note: string;
+  status: ChampagneManifestStatus | string;
+  version: string;
+}
+
+export const champagneMachineManifest: ChampagneMachineManifest = manifest;
+
+export const champagneManifestStatus: ChampagneManifestStatus =
+  manifest.status === "ready"
+    ? "ready"
+    : manifest.status === "stub"
+      ? "stub"
+      : "unavailable";
+
+export const champagneManifestsReady = champagneManifestStatus === "ready";

--- a/packages/champagne-manifests/tsconfig.json
+++ b/packages/champagne-manifests/tsconfig.json
@@ -2,15 +2,10 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "dist",
-    "declaration": true,
-    "strict": true
+    "declaration": true
   },
   "include": [
     "src/**/*",
     "data/**/*.json"
-  ],
-  "exclude": [
-    "node_modules",
-    "dist"
   ]
 }

--- a/packages/champagne-tokens/src/index.ts
+++ b/packages/champagne-tokens/src/index.ts
@@ -6,3 +6,89 @@ export const champagneTokensVersion = "v1";
  * Public CSS entry point for consumers who prefer direct stylesheet imports.
  */
 export const champagneThemeStylesheet = "@champagne/tokens/styles/champagne/theme.css";
+
+export const champagneTokenNames = [
+  "--brand-magenta",
+  "--brand-teal",
+  "--brand-gold",
+  "--brand-gold-keyline",
+  "--brand-soft-gold",
+  "--brand-ink",
+  "--brand-white",
+  "--ink",
+  "--bg",
+  "--text",
+  "--ink-100",
+  "--ink-80",
+  "--ink-60",
+  "--radius-lg",
+  "--radius-md",
+  "--radius-sm",
+  "--shadow-soft",
+  "--shadow-strong",
+  "--particles-opacity",
+  "--grain-opacity",
+  "--glass-opacity",
+  "--bg-ink",
+  "--bg-ink-soft",
+  "--surface-glass",
+  "--surface-glass-deep",
+  "--text-high",
+  "--text-medium",
+  "--text-low",
+  "--smh-gradient",
+  "--smh-gradient-legacy",
+  "--iridescent-gradient",
+  "--smh-ink",
+  "--smh-text",
+  "--smh-primary-ink",
+  "--smh-white",
+  "--smh-gray-200",
+  "--smh-primary-magenta",
+  "--smh-primary-teal",
+  "--smh-accent-gold",
+  "--smh-accent-gold-soft",
+  "--smh-gold",
+  "--champagne-keyline-gold",
+  "--smh-surface-bg-size",
+  "--smh-surface-bg-position",
+  "--champagne-glass-bg",
+  "--smh-grain-alpha",
+  "--smh-vignette-alpha",
+  "--smh-particles-alpha",
+  "--champagne-grain-alpha",
+  "--champagne-vignette-alpha",
+  "--champagne-sheen-alpha",
+  "--champagne-particles-opacity-d",
+  "--champagne-particles-opacity-m",
+  "--smh-warm-lift",
+  "--smh-warm-lift-magenta-alpha",
+  "--smh-warm-lift-gold-alpha",
+  "--smh-warm-magenta",
+  "--smh-warm-rose",
+  "--smh-warm-gold",
+  "--smh-grad-angle",
+  "--smh-grad-stop1",
+  "--smh-grad-stop2",
+  "--smh-grad-stop3",
+  "--smh-gold-shoulder",
+  "--smh-bg-size",
+  "--smh-bg-pos",
+  "--parallax-max"
+] as const;
+
+export type ChampagneTokenName = (typeof champagneTokenNames)[number];
+export type ChampagneTokenMap = Record<ChampagneTokenName, string>;
+
+export const champagneTokenMap: ChampagneTokenMap = Object.fromEntries(
+  champagneTokenNames.map((name) => [name, `var(${name})`] as const)
+) as ChampagneTokenMap;
+
+/**
+ * Typed representation of the canonical Champagne CSS variable names. Useful for
+ * TS/JS consumers that want to reference tokens without importing CSS files.
+ */
+export const champagneTokens = {
+  names: champagneTokenNames,
+  map: champagneTokenMap
+};

--- a/packages/champagne-tokens/tsconfig.json
+++ b/packages/champagne-tokens/tsconfig.json
@@ -2,14 +2,9 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "dist",
-    "declaration": true,
-    "strict": true
+    "declaration": true
   },
   "include": [
     "src/**/*"
-  ],
-  "exclude": [
-    "node_modules",
-    "dist"
   ]
 }


### PR DESCRIPTION
## Summary
- Root scripts: added guard entry points (rogue-hex, hero-freeze, manifest sync, brand structure) plus a guard:all runner.
- @champagne/guards: exposed the same guard scripts within the package and aligned package tsconfigs with the shared base output settings.
- @champagne/tokens: kept CSS imports intact while exporting typed token names/map for TS/JS consumers.
- @champagne/manifests: added lightweight manifest typings and explicit placeholder readiness status.
- Shared config: normalized tsconfig.base.json and package tsconfig files for consistent declaration output to dist/.
- No UI changes in apps/web.

## How to run the new guard scripts
- `pnpm guard:rogue-hex`
- `pnpm guard:hero-freeze`
- `pnpm guard:manifests`
- `pnpm guard:brand-structure`
- `pnpm guard:all` to run them sequentially

## Testing
- pnpm lint
- pnpm build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6935f4c15f288332ad09908f94c7e70b)