### PR TITLE
Document manifest import gap and stub report

### DIFF
--- a/packages/champagne-manifests/README.manifests-import.md
+++ b/packages/champagne-manifests/README.manifests-import.md
@@ -1,0 +1,23 @@
+# Champagne Manifests Import Status (Phase 3A)
+
+Real Champagne manifest payloads are not currently included in this repository snapshot. The `@champagne/manifests` package still serves placeholder data and keeps readiness flags set to `unavailable`.
+
+## Expected manifest artefacts
+When the source archive is available, import the real files into `packages/champagne-manifests/data/` using their canonical names. Based on the extraction brief, the missing artefacts include:
+
+- `_champagne-extraction/manifests-and-seo/brand/champagne_machine_manifest_full.json`
+- `_champagne-extraction/manifests-and-seo/config/champagne/manifests/**`
+- `_champagne-extraction/manifests-and-seo/docs/Brand_Canon_Packet/champagne_machine_manifest.json`
+- `_champagne-extraction/manifests-and-seo/public/brand/manifest.json`
+- `_champagne-extraction/manifests-and-seo/public/brand/champagne_machine_manifest_full.json`
+- `_champagne-extraction/manifests-and-seo/public/brand/manus_import_unified_manifest_20251104.json`
+- `_champagne-extraction/manifests-and-seo/styles/champagne/manifest.json`
+- Any SEO-related manifest or config files under `_champagne-extraction/manifests-and-seo/**`.
+
+## How to wire them once available
+1. Copy the artefacts into `packages/champagne-manifests/data/`, preserving file names where possible.
+2. Update `packages/champagne-manifests/src/index.ts` to import each JSON file and populate the `champagneManifests` registry. Keep the `champagneManifestStatus` and `champagneManifestsReady` flags aligned with the real data readiness.
+3. Regenerate `reports/manifest-hero-section-map.md` using the real hero, page, and section definitions from the manifests.
+4. Run `pnpm lint` and `pnpm build` to ensure the typed surface remains valid for downstream packages.
+
+Until those artefacts arrive, the package will continue to expose the stub manifest and mark readiness as `unavailable`.

--- a/packages/champagne-manifests/reports/manifest-hero-section-map.md
+++ b/packages/champagne-manifests/reports/manifest-hero-section-map.md
@@ -1,0 +1,18 @@
+# Champagne Manifest – Hero & Section Map (Stub)
+
+Real Champagne manifests are not present in this repository snapshot. This report will be regenerated once the source manifest JSON files are imported into `packages/champagne-manifests/data/`.
+
+## Status
+- Manifest readiness: unavailable (placeholder JSON only)
+- Parsed data: none — hero presets and section stacks cannot be enumerated until the real manifests are available.
+
+## Expected inputs for a full report
+The following artefacts are required to build the hero and section mapping:
+- `manifests-and-seo/brand/champagne_machine_manifest_full.json`
+- `manifests-and-seo/public/brand/manifest.json`
+- `manifests-and-seo/public/brand/champagne_machine_manifest_full.json`
+- `manifests-and-seo/public/brand/manus_import_unified_manifest_20251104.json`
+- `manifests-and-seo/styles/champagne/manifest.json`
+- Any related manifest or SEO configuration files under `_champagne-extraction/manifests-and-seo/**`
+
+Once those files are present, update the `@champagne/manifests` package to ingest them and regenerate this report with the concrete hero presets and ordered section stacks per page/treatment.

--- a/packages/champagne-manifests/src/index.ts
+++ b/packages/champagne-manifests/src/index.ts
@@ -2,11 +2,36 @@ import manifest from "../data/champagne_machine_manifest_full.json";
 
 export type ChampagneManifestStatus = "unavailable" | "stub" | "ready";
 
+export interface ChampagnePageSection {
+  id?: string;
+  type?: string;
+  label?: string;
+  [key: string]: unknown;
+}
+
+export interface ChampagnePageManifest {
+  path?: string;
+  hero?: string | Record<string, unknown>;
+  sections?: ChampagnePageSection[];
+  surface?: string;
+  [key: string]: unknown;
+}
+
 export interface ChampagneMachineManifest {
   id: string;
-  note: string;
+  note?: string;
   status: ChampagneManifestStatus | string;
   version: string;
+  pages?: Record<string, ChampagnePageManifest>;
+  treatments?: Record<string, ChampagnePageManifest>;
+  [key: string]: unknown;
+}
+
+export interface ChampagneManifestRegistry {
+  core: ChampagneMachineManifest;
+  public?: unknown;
+  styles?: unknown;
+  manusImport?: unknown;
 }
 
 export const champagneMachineManifest: ChampagneMachineManifest = manifest;
@@ -19,3 +44,7 @@ export const champagneManifestStatus: ChampagneManifestStatus =
       : "unavailable";
 
 export const champagneManifestsReady = champagneManifestStatus === "ready";
+
+export const champagneManifests: ChampagneManifestRegistry = {
+  core: champagneMachineManifest,
+};


### PR DESCRIPTION
## Summary
- document missing Champagne manifest artefacts and how to import them
- broaden typed manifest surface while keeping readiness flags for placeholder data
- add stub hero/section mapping report noting absence of real manifests

## Testing
- pnpm lint
- pnpm build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6935fa4c4d108332938d77fdb26321da)