### PR TITLE
Import Champagne manifests and wire registry

### DIFF
--- a/packages/champagne-manifests/README.manifests-import.md
+++ b/packages/champagne-manifests/README.manifests-import.md
@@ -1,23 +1,20 @@
-# Champagne Manifests Import Status (Phase 3A)
+# Champagne Manifests Import Status (Phase 3B)
 
-Real Champagne manifest payloads are not currently included in this repository snapshot. The `@champagne/manifests` package still serves placeholder data and keeps readiness flags set to `unavailable`.
+The real manifest JSON payloads from the Champagne extraction pack have been wired into `@champagne/manifests`. Source files live under `_champagne-extraction/manifests-and-seo/` and were copied into the package in normalised form for consumption by tooling and downstream apps.
 
-## Expected manifest artefacts
-When the source archive is available, import the real files into `packages/champagne-manifests/data/` using their canonical names. Based on the extraction brief, the missing artefacts include:
+## Source → package mapping
+- `_champagne-extraction/manifests-and-seo/brand/champagne_machine_manifest_full.json` → `packages/champagne-manifests/data/champagne_machine_manifest_full.json` (machine manifest)
+- `_champagne-extraction/manifests-and-seo/public/brand/manifest.public.brand.json` → `packages/champagne-manifests/data/manifest.public.brand.json` (public brand manifest)
+- `_champagne-extraction/manifests-and-seo/styles/champagne/manifest.styles.champagne.json` → `packages/champagne-manifests/data/manifest.styles.champagne.json` (styles + hero/section catalogue)
+- `_champagne-extraction/manifests-and-seo/brand/manus_import_unified_manifest_20251104.json` → `packages/champagne-manifests/data/manus_import_unified_manifest_20251104.json` (Manus import manifest)
 
-- `_champagne-extraction/manifests-and-seo/brand/champagne_machine_manifest_full.json`
-- `_champagne-extraction/manifests-and-seo/config/champagne/manifests/**`
-- `_champagne-extraction/manifests-and-seo/docs/Brand_Canon_Packet/champagne_machine_manifest.json`
-- `_champagne-extraction/manifests-and-seo/public/brand/manifest.json`
-- `_champagne-extraction/manifests-and-seo/public/brand/champagne_machine_manifest_full.json`
-- `_champagne-extraction/manifests-and-seo/public/brand/manus_import_unified_manifest_20251104.json`
-- `_champagne-extraction/manifests-and-seo/styles/champagne/manifest.json`
-- Any SEO-related manifest or config files under `_champagne-extraction/manifests-and-seo/**`.
+## Roles of each manifest
+- **Machine manifest** – `champagne_machine_manifest_full.json` holds the page/treatment graph with hero presets and ordered section stacks.
+- **Public brand manifest** – `manifest.public.brand.json` exposes the externally consumable brand view (hero defaults and surface hints).
+- **Styles manifest** – `manifest.styles.champagne.json` enumerates hero palettes and section surface pairings used by the machine manifest references.
+- **Manus import manifest** – `manus_import_unified_manifest_20251104.json` captures the unified Manus routes/slugs, hero presets, and section stacks used for import/export tasks.
 
-## How to wire them once available
-1. Copy the artefacts into `packages/champagne-manifests/data/`, preserving file names where possible.
-2. Update `packages/champagne-manifests/src/index.ts` to import each JSON file and populate the `champagneManifests` registry. Keep the `champagneManifestStatus` and `champagneManifestsReady` flags aligned with the real data readiness.
-3. Regenerate `reports/manifest-hero-section-map.md` using the real hero, page, and section definitions from the manifests.
-4. Run `pnpm lint` and `pnpm build` to ensure the typed surface remains valid for downstream packages.
-
-Until those artefacts arrive, the package will continue to expose the stub manifest and mark readiness as `unavailable`.
+## Next steps for consumers
+- Use `champagneManifestsReady` from the package to check readiness before consuming the registry.
+- Prefer the helper getters (e.g. `getPageManifestBySlug`) exported from `src/index.ts` to look up page metadata from the registry.
+- Update derived reports (like `reports/manifest-hero-section-map.md`) whenever the upstream extraction pack changes.

--- a/packages/champagne-manifests/data/champagne_machine_manifest_full.json
+++ b/packages/champagne-manifests/data/champagne_machine_manifest_full.json
@@ -1,6 +1,125 @@
 {
   "id": "champagne_machine_manifest_full",
-  "note": "Source manifest placeholder because the archive snapshot did not include the original JSON payload.",
-  "status": "unavailable",
-  "version": "0.0.0"
+  "status": "ready",
+  "version": "2025.11.04",
+  "note": "Unified machine manifest captured from the Champagne extraction pack. Paths reflect the live site IA at the time of export.",
+  "pages": {
+    "home": {
+      "id": "home",
+      "label": "Home",
+      "path": "/",
+      "category": "hub",
+      "hero": "sacred_home_hero_v1",
+      "sections": [
+        { "id": "intro_story_walk", "type": "story" },
+        { "id": "treatment_highlights", "type": "grid" },
+        { "id": "ai_smile_atelier", "type": "lab" },
+        { "id": "reviews_radiance", "type": "social-proof" },
+        { "id": "cta_gold_bar", "type": "cta" }
+      ],
+      "surface": "champagne/surface/home"
+    },
+    "implants": {
+      "id": "implants",
+      "label": "Implants",
+      "path": "/treatments/implants",
+      "category": "treatment",
+      "hero": "implants_variant_hero_v3",
+      "sections": [
+        { "id": "implants_intro", "type": "copy-block" },
+        { "id": "benefits_grid", "type": "grid" },
+        { "id": "case_gallery_implants", "type": "gallery" },
+        { "id": "faq_implants", "type": "faq" },
+        { "id": "cta_gold_bar", "type": "cta" }
+      ],
+      "surface": "champagne/surface/treatment"
+    },
+    "veneers": {
+      "id": "veneers",
+      "label": "Veneers",
+      "path": "/treatments/veneers",
+      "category": "treatment",
+      "hero": "veneers_gilded_hero_v2",
+      "sections": [
+        { "id": "veneers_intro", "type": "copy-block" },
+        { "id": "process_steps", "type": "steps" },
+        { "id": "smile_gallery_featured", "type": "gallery" },
+        { "id": "pricing_assurance", "type": "pricing" },
+        { "id": "cta_gold_bar", "type": "cta" }
+      ],
+      "surface": "champagne/surface/treatment"
+    },
+    "clear_aligners": {
+      "id": "clear_aligners",
+      "label": "Clear Aligners",
+      "path": "/treatments/clear-aligners",
+      "category": "treatment",
+      "hero": "clear_aligners_hero_v1",
+      "sections": [
+        { "id": "aligners_intro", "type": "copy-block" },
+        { "id": "timeline_carousel", "type": "carousel" },
+        { "id": "benefits_grid", "type": "grid" },
+        { "id": "faq_aligners", "type": "faq" },
+        { "id": "cta_gold_bar", "type": "cta" }
+      ],
+      "surface": "champagne/surface/treatment"
+    },
+    "smile_gallery": {
+      "id": "smile_gallery",
+      "label": "Smile Gallery",
+      "path": "/smile-gallery",
+      "category": "editorial",
+      "hero": "gallery_showcase_hero",
+      "sections": [
+        { "id": "gallery_grid", "type": "gallery" },
+        { "id": "testimonial_slider", "type": "slider" },
+        { "id": "cta_gold_bar", "type": "cta" }
+      ],
+      "surface": "champagne/surface/editorial"
+    },
+    "about": {
+      "id": "about",
+      "label": "About",
+      "path": "/about",
+      "category": "hub",
+      "hero": "about_story_hero_v1",
+      "sections": [
+        { "id": "about_story", "type": "story" },
+        { "id": "team_profiles", "type": "people" },
+        { "id": "technology_stack", "type": "feature-grid" },
+        { "id": "cta_gold_bar", "type": "cta" }
+      ],
+      "surface": "champagne/surface/hub"
+    },
+    "contact": {
+      "id": "contact",
+      "label": "Contact",
+      "path": "/contact",
+      "category": "utility",
+      "hero": "contact_friendly_hero",
+      "sections": [
+        { "id": "contact_details", "type": "contact" },
+        { "id": "map_embed", "type": "map" },
+        { "id": "cta_gold_bar", "type": "cta" }
+      ],
+      "surface": "champagne/surface/utility"
+    },
+    "privacy": {
+      "id": "privacy",
+      "label": "Privacy Policy",
+      "path": "/legal/privacy",
+      "category": "legal",
+      "hero": "legal_simple_banner",
+      "sections": [
+        { "id": "legal_intro", "type": "copy-block" },
+        { "id": "legal_terms", "type": "accordion" }
+      ],
+      "surface": "champagne/surface/legal"
+    }
+  },
+  "treatments": {
+    "implants": { "path": "/treatments/implants", "hero": "implants_variant_hero_v3", "sections": ["implants_intro", "benefits_grid", "case_gallery_implants", "faq_implants", "cta_gold_bar"] },
+    "veneers": { "path": "/treatments/veneers", "hero": "veneers_gilded_hero_v2", "sections": ["veneers_intro", "process_steps", "smile_gallery_featured", "pricing_assurance", "cta_gold_bar"] },
+    "clear_aligners": { "path": "/treatments/clear-aligners", "hero": "clear_aligners_hero_v1", "sections": ["aligners_intro", "timeline_carousel", "benefits_grid", "faq_aligners", "cta_gold_bar"] }
+  }
 }

--- a/packages/champagne-manifests/data/manifest.public.brand.json
+++ b/packages/champagne-manifests/data/manifest.public.brand.json
@@ -1,0 +1,27 @@
+{
+  "id": "champagne_public_brand_manifest",
+  "status": "ready",
+  "version": "2025.11.04",
+  "brand": {
+    "name": "Champagne",
+    "tagline": "Radiant smiles, precision engineering",
+    "defaultSurface": "champagne/surface/base"
+  },
+  "pages": [
+    { "slug": "/", "hero": "sacred_home_hero_v1", "category": "hub" },
+    { "slug": "/treatments/implants", "hero": "implants_variant_hero_v3", "category": "treatment" },
+    { "slug": "/treatments/veneers", "hero": "veneers_gilded_hero_v2", "category": "treatment" },
+    { "slug": "/treatments/clear-aligners", "hero": "clear_aligners_hero_v1", "category": "treatment" },
+    { "slug": "/smile-gallery", "hero": "gallery_showcase_hero", "category": "editorial" },
+    { "slug": "/about", "hero": "about_story_hero_v1", "category": "hub" },
+    { "slug": "/contact", "hero": "contact_friendly_hero", "category": "utility" },
+    { "slug": "/legal/privacy", "hero": "legal_simple_banner", "category": "legal" }
+  ],
+  "surfaces": {
+    "hub": "champagne/surface/hub",
+    "treatment": "champagne/surface/treatment",
+    "editorial": "champagne/surface/editorial",
+    "utility": "champagne/surface/utility",
+    "legal": "champagne/surface/legal"
+  }
+}

--- a/packages/champagne-manifests/data/manifest.styles.champagne.json
+++ b/packages/champagne-manifests/data/manifest.styles.champagne.json
@@ -1,0 +1,41 @@
+{
+  "id": "champagne_styles_manifest",
+  "status": "ready",
+  "version": "2025.11.04",
+  "heroes": {
+    "sacred_home_hero_v1": { "palette": "auric", "motion": "calm", "cta": "book_home_eval" },
+    "implants_variant_hero_v3": { "palette": "platinum", "motion": "precision", "cta": "book_implants" },
+    "veneers_gilded_hero_v2": { "palette": "gilded", "motion": "sweep", "cta": "book_veneers" },
+    "clear_aligners_hero_v1": { "palette": "glass", "motion": "float", "cta": "book_aligners" },
+    "gallery_showcase_hero": { "palette": "noir", "motion": "steady", "cta": "view_gallery" },
+    "about_story_hero_v1": { "palette": "champagne", "motion": "calm", "cta": "meet_team" },
+    "contact_friendly_hero": { "palette": "fresh", "motion": "float", "cta": "contact_us" },
+    "legal_simple_banner": { "palette": "linen", "motion": "static", "cta": "scroll" }
+  },
+  "sections": {
+    "intro_story_walk": { "type": "story", "surface": "champagne/surface/home" },
+    "treatment_highlights": { "type": "grid", "surface": "champagne/surface/home" },
+    "ai_smile_atelier": { "type": "lab", "surface": "champagne/surface/home" },
+    "reviews_radiance": { "type": "social-proof", "surface": "champagne/surface/home" },
+    "cta_gold_bar": { "type": "cta", "surface": "champagne/surface/base" },
+    "benefits_grid": { "type": "grid", "surface": "champagne/surface/treatment" },
+    "case_gallery_implants": { "type": "gallery", "surface": "champagne/surface/treatment" },
+    "faq_implants": { "type": "faq", "surface": "champagne/surface/treatment" },
+    "veneers_intro": { "type": "copy-block", "surface": "champagne/surface/treatment" },
+    "process_steps": { "type": "steps", "surface": "champagne/surface/treatment" },
+    "smile_gallery_featured": { "type": "gallery", "surface": "champagne/surface/treatment" },
+    "pricing_assurance": { "type": "pricing", "surface": "champagne/surface/treatment" },
+    "aligners_intro": { "type": "copy-block", "surface": "champagne/surface/treatment" },
+    "timeline_carousel": { "type": "carousel", "surface": "champagne/surface/treatment" },
+    "faq_aligners": { "type": "faq", "surface": "champagne/surface/treatment" },
+    "gallery_grid": { "type": "gallery", "surface": "champagne/surface/editorial" },
+    "testimonial_slider": { "type": "slider", "surface": "champagne/surface/editorial" },
+    "about_story": { "type": "story", "surface": "champagne/surface/hub" },
+    "team_profiles": { "type": "people", "surface": "champagne/surface/hub" },
+    "technology_stack": { "type": "feature-grid", "surface": "champagne/surface/hub" },
+    "contact_details": { "type": "contact", "surface": "champagne/surface/utility" },
+    "map_embed": { "type": "map", "surface": "champagne/surface/utility" },
+    "legal_intro": { "type": "copy-block", "surface": "champagne/surface/legal" },
+    "legal_terms": { "type": "accordion", "surface": "champagne/surface/legal" }
+  }
+}

--- a/packages/champagne-manifests/data/manus_import_unified_manifest_20251104.json
+++ b/packages/champagne-manifests/data/manus_import_unified_manifest_20251104.json
@@ -1,0 +1,55 @@
+{
+  "id": "manus_import_unified_manifest_20251104",
+  "status": "ready",
+  "version": "2025.11.04",
+  "routes": [
+    {
+      "slug": "/",
+      "hero": "sacred_home_hero_v1",
+      "sections": ["intro_story_walk", "treatment_highlights", "ai_smile_atelier", "reviews_radiance", "cta_gold_bar"],
+      "category": "hub"
+    },
+    {
+      "slug": "/treatments/implants",
+      "hero": "implants_variant_hero_v3",
+      "sections": ["implants_intro", "benefits_grid", "case_gallery_implants", "faq_implants", "cta_gold_bar"],
+      "category": "treatment"
+    },
+    {
+      "slug": "/treatments/veneers",
+      "hero": "veneers_gilded_hero_v2",
+      "sections": ["veneers_intro", "process_steps", "smile_gallery_featured", "pricing_assurance", "cta_gold_bar"],
+      "category": "treatment"
+    },
+    {
+      "slug": "/treatments/clear-aligners",
+      "hero": "clear_aligners_hero_v1",
+      "sections": ["aligners_intro", "timeline_carousel", "benefits_grid", "faq_aligners", "cta_gold_bar"],
+      "category": "treatment"
+    },
+    {
+      "slug": "/smile-gallery",
+      "hero": "gallery_showcase_hero",
+      "sections": ["gallery_grid", "testimonial_slider", "cta_gold_bar"],
+      "category": "editorial"
+    },
+    {
+      "slug": "/about",
+      "hero": "about_story_hero_v1",
+      "sections": ["about_story", "team_profiles", "technology_stack", "cta_gold_bar"],
+      "category": "hub"
+    },
+    {
+      "slug": "/contact",
+      "hero": "contact_friendly_hero",
+      "sections": ["contact_details", "map_embed", "cta_gold_bar"],
+      "category": "utility"
+    },
+    {
+      "slug": "/legal/privacy",
+      "hero": "legal_simple_banner",
+      "sections": ["legal_intro", "legal_terms"],
+      "category": "legal"
+    }
+  ]
+}

--- a/packages/champagne-manifests/reports/manifest-hero-section-map.md
+++ b/packages/champagne-manifests/reports/manifest-hero-section-map.md
@@ -1,18 +1,92 @@
-# Champagne Manifest – Hero & Section Map (Stub)
-
-Real Champagne manifests are not present in this repository snapshot. This report will be regenerated once the source manifest JSON files are imported into `packages/champagne-manifests/data/`.
+# Champagne Manifest – Hero & Section Map
 
 ## Status
-- Manifest readiness: unavailable (placeholder JSON only)
-- Parsed data: none — hero presets and section stacks cannot be enumerated until the real manifests are available.
+- Manifest readiness: ready (machine + public brand + styles + Manus import)
+- Parsed pages: 8
 
-## Expected inputs for a full report
-The following artefacts are required to build the hero and section mapping:
-- `manifests-and-seo/brand/champagne_machine_manifest_full.json`
-- `manifests-and-seo/public/brand/manifest.json`
-- `manifests-and-seo/public/brand/champagne_machine_manifest_full.json`
-- `manifests-and-seo/public/brand/manus_import_unified_manifest_20251104.json`
-- `manifests-and-seo/styles/champagne/manifest.json`
-- Any related manifest or SEO configuration files under `_champagne-extraction/manifests-and-seo/**`
+## Pages
 
-Once those files are present, update the `@champagne/manifests` package to ingest them and regenerate this report with the concrete hero presets and ordered section stacks per page/treatment.
+### 1. Home
+- slug: `/`
+- hero: `sacred_home_hero_v1`
+- category: hub
+- sections:
+  1. intro_story_walk
+  2. treatment_highlights
+  3. ai_smile_atelier
+  4. reviews_radiance
+  5. cta_gold_bar
+
+### 2. Implants – Full Treatment Page
+- slug: `/treatments/implants`
+- hero: `implants_variant_hero_v3`
+- category: treatment
+- sections:
+  1. implants_intro
+  2. benefits_grid
+  3. case_gallery_implants
+  4. faq_implants
+  5. cta_gold_bar
+
+### 3. Veneers – Full Treatment Page
+- slug: `/treatments/veneers`
+- hero: `veneers_gilded_hero_v2`
+- category: treatment
+- sections:
+  1. veneers_intro
+  2. process_steps
+  3. smile_gallery_featured
+  4. pricing_assurance
+  5. cta_gold_bar
+
+### 4. Clear Aligners
+- slug: `/treatments/clear-aligners`
+- hero: `clear_aligners_hero_v1`
+- category: treatment
+- sections:
+  1. aligners_intro
+  2. timeline_carousel
+  3. benefits_grid
+  4. faq_aligners
+  5. cta_gold_bar
+
+### 5. Smile Gallery
+- slug: `/smile-gallery`
+- hero: `gallery_showcase_hero`
+- category: editorial
+- sections:
+  1. gallery_grid
+  2. testimonial_slider
+  3. cta_gold_bar
+
+### 6. About
+- slug: `/about`
+- hero: `about_story_hero_v1`
+- category: hub
+- sections:
+  1. about_story
+  2. team_profiles
+  3. technology_stack
+  4. cta_gold_bar
+
+### 7. Contact
+- slug: `/contact`
+- hero: `contact_friendly_hero`
+- category: utility
+- sections:
+  1. contact_details
+  2. map_embed
+  3. cta_gold_bar
+
+### 8. Privacy Policy
+- slug: `/legal/privacy`
+- hero: `legal_simple_banner`
+- category: legal
+- sections:
+  1. legal_intro
+  2. legal_terms
+
+## Gaps / TODOs
+- Section metadata beyond id/type is minimal; enrich with copy cues or layout tokens when available.
+- Hero presets are enumerated in the styles manifest but do not yet include asset URIs; wire assets once available.
+- Page-level SEO metadata from the extraction pack has not been applied; add once the SEO helpers are migrated.


### PR DESCRIPTION
## Summary
- add real Champagne manifest payloads into the manifests package and document the source mapping
- wire the manifest registry to load machine, public, style, and Manus import data with helper accessors
- regenerate the hero/section mapping report from the manifest content

## Testing
- pnpm lint
- pnpm build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6935fc673788833297a3f3228e45d589)