### PR TITLE
Implement manifest-driven Champagne page builder

### DIFF
--- a/apps/web/app/(champagne)/_builder/ChampagnePageBuilder.tsx
+++ b/apps/web/app/(champagne)/_builder/ChampagnePageBuilder.tsx
@@ -1,0 +1,55 @@
+import type { CSSProperties } from "react";
+import { BaseChampagneSurface, ChampagneHeroFrame } from "@champagne/hero";
+import {
+  champagneMachineManifest,
+  getHeroManifest,
+  getPageManifestBySlug,
+} from "@champagne/manifests";
+import { ChampagneSectionRenderer } from "@champagne/sections";
+
+export interface ChampagnePageBuilderProps {
+  slug: string;
+}
+
+function resolveManifest(slug: string) {
+  return (
+    getPageManifestBySlug(slug) ||
+    champagneMachineManifest.pages?.[slug] ||
+    champagneMachineManifest.treatments?.[slug]
+  );
+}
+
+const surfaceStyle: CSSProperties = {
+  padding: "clamp(1.25rem, 3vw, 2.5rem)",
+  border: "1px solid var(--champagne-keyline-gold, rgba(255, 215, 137, 0.28))",
+  background:
+    "radial-gradient(circle at 14% 18%, color-mix(in srgb, var(--smh-white, #ffffff) 12%, transparent), transparent 40%), linear-gradient(145deg, color-mix(in srgb, var(--bg-ink, #06070c) 90%, transparent), color-mix(in srgb, var(--bg-ink-soft, #0c0f16) 82%, transparent))",
+};
+
+const gridStyle: CSSProperties = {
+  display: "grid",
+  gap: "clamp(1.25rem, 3vw, 2.5rem)",
+};
+
+export function ChampagnePageBuilder({ slug }: ChampagnePageBuilderProps) {
+  const manifest = resolveManifest(slug);
+  const pagePath = manifest?.path ?? (slug.startsWith("/") ? slug : `/${slug}`);
+  const heroManifest = getHeroManifest(pagePath) ?? getHeroManifest(slug);
+  const heroId = heroManifest?.id ?? (typeof manifest?.hero === "string" ? manifest.hero : manifest?.id ?? pagePath);
+  const heroPreset = heroManifest?.preset ?? manifest?.hero;
+
+  return (
+    <BaseChampagneSurface variant="inkGlass" style={surfaceStyle}>
+      <div style={gridStyle}>
+        <ChampagneHeroFrame
+          heroId={heroId ?? pagePath}
+          preset={heroPreset}
+          headline={manifest?.label as string | undefined}
+        />
+        <ChampagneSectionRenderer pageSlug={pagePath} />
+      </div>
+    </BaseChampagneSurface>
+  );
+}
+
+export default ChampagnePageBuilder;

--- a/apps/web/app/(champagne)/treatments/clear-aligners/page.tsx
+++ b/apps/web/app/(champagne)/treatments/clear-aligners/page.tsx
@@ -1,12 +1,5 @@
-import { ChampagneHeroFrame, getHeroBySlug } from "@champagne/hero";
-import { ChampagneSectionRenderer } from "@champagne/sections";
+import ChampagnePageBuilder from "../../_builder/ChampagnePageBuilder";
 
 export default function Page() {
-  const hero = getHeroBySlug("/treatments/clear-aligners");
-  return (
-    <main className="space-y-8">
-      <ChampagneHeroFrame heroId={hero.id} headline={hero.label ?? "Clear aligners surface"} />
-      <ChampagneSectionRenderer pageSlug="/treatments/clear-aligners" />
-    </main>
-  );
+  return <ChampagnePageBuilder slug="clear-aligners" />;
 }

--- a/apps/web/app/(champagne)/treatments/implants/page.tsx
+++ b/apps/web/app/(champagne)/treatments/implants/page.tsx
@@ -1,12 +1,5 @@
-import { ChampagneHeroFrame, getHeroBySlug } from "@champagne/hero";
-import { ChampagneSectionRenderer } from "@champagne/sections";
+import ChampagnePageBuilder from "../../_builder/ChampagnePageBuilder";
 
 export default function Page() {
-  const hero = getHeroBySlug("/treatments/implants");
-  return (
-    <main className="space-y-8">
-      <ChampagneHeroFrame heroId={hero.id} headline={hero.label ?? "Implants surface"} />
-      <ChampagneSectionRenderer pageSlug="/treatments/implants" />
-    </main>
-  );
+  return <ChampagnePageBuilder slug="implants" />;
 }

--- a/apps/web/app/(champagne)/treatments/veneers/page.tsx
+++ b/apps/web/app/(champagne)/treatments/veneers/page.tsx
@@ -1,12 +1,5 @@
-import { ChampagneHeroFrame, getHeroBySlug } from "@champagne/hero";
-import { ChampagneSectionRenderer } from "@champagne/sections";
+import ChampagnePageBuilder from "../../_builder/ChampagnePageBuilder";
 
 export default function Page() {
-  const hero = getHeroBySlug("/treatments/veneers");
-  return (
-    <main className="space-y-8">
-      <ChampagneHeroFrame heroId={hero.id} headline={hero.label ?? "Veneers surface"} />
-      <ChampagneSectionRenderer pageSlug="/treatments/veneers" />
-    </main>
-  );
+  return <ChampagnePageBuilder slug="veneers" />;
 }

--- a/packages/champagne-hero/src/ChampagneHeroFrame.tsx
+++ b/packages/champagne-hero/src/ChampagneHeroFrame.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import type { HeroRegistryEntry } from "./HeroRegistry";
 import { BaseChampagneSurface } from "./BaseChampagneSurface";
 import { HeroPreviewDebug } from "./HeroPreviewDebug";
@@ -8,12 +8,48 @@ import { resolveHeroVariant } from "./HeroRegistry";
 
 export interface ChampagneHeroFrameProps {
   heroId: string;
+  preset?: string | Record<string, unknown>;
   headline?: string;
   subheadline?: string;
   cta?: { label: string; href: string };
 }
 
-export function ChampagneHeroFrame({ heroId, headline, subheadline, cta }: ChampagneHeroFrameProps) {
+type HeroPreset = string | (Record<string, unknown> & { type?: string; title?: string; subtitle?: string });
+
+type LayerTokens = {
+  background?: string;
+  vignette?: string;
+  wave?: string;
+};
+
+function deriveHeroType(heroId: string, preset?: HeroPreset) {
+  if (preset && typeof preset === "object" && typeof preset.type === "string") return preset.type;
+  if (heroId.includes("gilded")) return "gilded";
+  if (heroId.includes("soft")) return "soft-focus";
+  if (heroId.includes("glass")) return "gradient";
+  return "gradient";
+}
+
+function extractLayerTokens(preset?: HeroPreset): LayerTokens {
+  if (!preset || typeof preset !== "object") return {};
+  return {
+    background: typeof preset.background === "string" ? preset.background : undefined,
+    vignette: typeof preset.vignette === "string" ? preset.vignette : undefined,
+    wave: typeof preset.wave === "string" ? preset.wave : undefined,
+  };
+}
+
+function resolveTitle(preset?: HeroPreset, fallback?: string) {
+  if (preset && typeof preset === "object" && typeof preset.title === "string") return preset.title;
+  return fallback;
+}
+
+function resolveSubtitle(preset?: HeroPreset, fallback?: string) {
+  if (preset && typeof preset === "object" && typeof preset.subtitle === "string") return preset.subtitle;
+  return fallback;
+}
+
+export function ChampagneHeroFrame({ heroId, preset, headline, subheadline, cta }: ChampagneHeroFrameProps) {
   const [showDebug, setShowDebug] = useState(false);
   const [resolvedHero, setResolvedHero] = useState<HeroRegistryEntry>(() => resolveHeroVariant(heroId));
 
@@ -27,30 +63,57 @@ export function ChampagneHeroFrame({ heroId, headline, subheadline, cta }: Champ
     setShowDebug(params.get("heroDebug") === "true" || params.has("heroDebug"));
   }, []);
 
+  const mergedPreset: HeroPreset | undefined = useMemo(
+    () => preset ?? (resolvedHero.preset as HeroPreset | undefined),
+    [preset, resolvedHero.preset],
+  );
+
+  const heroType = deriveHeroType(heroId, mergedPreset);
+  const layers = extractLayerTokens(mergedPreset);
+  const resolvedHeadline = resolveTitle(mergedPreset, headline ?? resolvedHero.label ?? "Champagne hero");
+  const resolvedSubheadline = resolveSubtitle(mergedPreset, subheadline);
+
+  const heroBackground = layers.background
+    ?? (heroType === "gilded"
+      ? "linear-gradient(145deg, color-mix(in srgb, var(--champagne-keyline-gold, #ffd789) 34%, transparent), color-mix(in srgb, var(--bg-ink, #06070c) 90%, transparent))"
+      : heroType === "soft-focus"
+        ? "radial-gradient(circle at 22% 18%, color-mix(in srgb, var(--smh-white, #ffffff) 18%, transparent), transparent 36%), linear-gradient(160deg, color-mix(in srgb, var(--bg-ink, #06070c) 86%, transparent), color-mix(in srgb, var(--bg-ink-soft, #0c0f16) 78%, transparent))"
+        : "linear-gradient(135deg, var(--smh-gradient-legacy, rgba(255,255,255,0.08)), color-mix(in srgb, var(--bg-ink, #06070c) 75%, transparent))");
+
+  const vignetteLayer = layers.vignette
+    ?? "radial-gradient(circle at 50% 50%, transparent 35%, rgba(0,0,0,0.55))";
+
+  const waveLayer = layers.wave
+    ?? "linear-gradient(135deg, rgba(255,255,255,0.04), rgba(255,255,255,0)), linear-gradient(15deg, rgba(255,255,255,0.06), transparent 65%)";
+
   return (
     <BaseChampagneSurface
       variant="inkGlass"
       style={{
-        padding: "2.5rem",
-        border: "1px solid var(--champagne-keyline-gold, rgba(255, 215, 137, 0.45))",
+        padding: "clamp(2rem, 4vw, 3rem)",
+        border: "1px solid var(--champagne-keyline-gold, rgba(255, 215, 137, 0.35))",
+        background: heroBackground,
       }}
     >
-      <div style={{ display: "flex", flexDirection: "column", gap: "1rem" }}>
-        <div style={{ display: "flex", flexDirection: "column", gap: "0.5rem" }}>
+      <div aria-hidden style={{ position: "absolute", inset: 0, zIndex: 0, background: vignetteLayer, mixBlendMode: "multiply" }} />
+      <div aria-hidden style={{ position: "absolute", inset: 0, zIndex: 0, background: waveLayer, opacity: 0.8 }} />
+
+      <div style={{ display: "grid", gap: "1.15rem" }}>
+        <div style={{ display: "grid", gap: "0.6rem", maxWidth: "720px" }}>
           <span style={{
-            fontSize: "0.9rem",
-            letterSpacing: "0.08em",
+            fontSize: "0.92rem",
+            letterSpacing: "0.1em",
             textTransform: "uppercase",
             color: "var(--text-medium, rgba(255,255,255,0.7))",
           }}>
-            Champagne Hero Surface
+            {heroType} hero
           </span>
-          <h1 style={{ fontSize: "2rem", fontWeight: 700, lineHeight: 1.2 }}>
-            {headline ?? "Placeholder hero headline"}
+          <h1 style={{ fontSize: "clamp(1.8rem, 3vw, 2.6rem)", fontWeight: 800, lineHeight: 1.18 }}>
+            {resolvedHeadline ?? "Placeholder hero headline"}
           </h1>
-          {subheadline && (
-            <p style={{ fontSize: "1.1rem", color: "var(--text-medium, rgba(255,255,255,0.78))" }}>
-              {subheadline}
+          {resolvedSubheadline && (
+            <p style={{ fontSize: "1.05rem", color: "var(--text-medium, rgba(255,255,255,0.78))", lineHeight: 1.6 }}>
+              {resolvedSubheadline}
             </p>
           )}
         </div>
@@ -60,12 +123,13 @@ export function ChampagneHeroFrame({ heroId, headline, subheadline, cta }: Champ
             href={cta.href}
             style={{
               alignSelf: "flex-start",
-              padding: "0.75rem 1.5rem",
+              padding: "0.85rem 1.6rem",
               borderRadius: "var(--radius-md)",
-              background: "var(--champagne-keyline-gold, rgba(255, 215, 137, 0.18))",
+              background: "rgba(255, 215, 137, 0.14)",
               color: "var(--text-high)",
               textDecoration: "none",
-              border: "1px solid var(--champagne-keyline-gold, rgba(255, 215, 137, 0.45))",
+              border: "1px solid var(--champagne-keyline-gold, rgba(255, 215, 137, 0.35))",
+              boxShadow: "0 12px 30px rgba(0,0,0,0.35)",
             }}
           >
             {cta.label}

--- a/packages/champagne-sections/src/ChampagneSectionRenderer.tsx
+++ b/packages/champagne-sections/src/ChampagneSectionRenderer.tsx
@@ -4,44 +4,48 @@ import { Section_FeatureList } from "./Section_FeatureList";
 import { Section_MediaBlock } from "./Section_MediaBlock";
 import { Section_TextBlock } from "./Section_TextBlock";
 import { getSectionStack } from "./SectionRegistry";
+import type { SectionRegistryEntry } from "./SectionRegistry";
 
 export interface ChampagneSectionRendererProps {
   pageSlug: string;
 }
 
-const typeMap: Record<string, () => ReactNode> = {
-  text: () => <Section_TextBlock />,
-  copy: () => <Section_TextBlock />,
-  media: () => <Section_MediaBlock />,
-  gallery: () => <Section_MediaBlock />,
-  features: () => <Section_FeatureList />,
+type SectionComponent = (props: { section: SectionRegistryEntry }) => ReactNode;
+
+const typeMap: Record<string, SectionComponent> = {
+  text: (props) => <Section_TextBlock {...props} />,
+  copy: (props) => <Section_TextBlock {...props} />,
+  media: (props) => <Section_MediaBlock {...props} />,
+  gallery: (props) => <Section_MediaBlock {...props} />,
+  features: (props) => <Section_FeatureList {...props} />,
 };
 
-function renderSection(type?: string) {
-  if (!type) return <Section_TextBlock />;
-  if (typeMap[type]) return typeMap[type]();
+function renderSection(section: SectionRegistryEntry) {
+  const component = section.type ? typeMap[section.type] : undefined;
+  if (component) return component({ section });
 
-  // Coerce common manifest types to placeholders
-  if (["copy-block", "story", "faq", "accordion"].includes(type)) return <Section_TextBlock />;
-  if (["grid", "gallery", "carousel", "map", "slider"].includes(type)) return <Section_MediaBlock />;
-  if (["feature-grid", "steps"].includes(type)) return <Section_FeatureList />;
+  if (["copy-block", "story", "faq", "accordion"].includes(section.type ?? "")) {
+    return <Section_TextBlock section={section} />;
+  }
+  if (["grid", "gallery", "carousel", "map", "slider"].includes(section.type ?? "")) {
+    return <Section_MediaBlock section={section} />;
+  }
+  if (["feature-grid", "steps"].includes(section.type ?? "")) {
+    return <Section_FeatureList section={section} />;
+  }
 
-  return <Section_TextBlock />;
+  return <Section_TextBlock section={section} />;
 }
 
 export function ChampagneSectionRenderer({ pageSlug }: ChampagneSectionRendererProps) {
   const sections = getSectionStack(pageSlug);
 
   return (
-    <div style={{ display: "grid", gap: "1rem", marginTop: "2rem" }}>
+    <div style={{ display: "grid", gap: "clamp(1rem, 2vw, 1.75rem)", marginTop: "0.5rem" }}>
       {sections.map((section) => (
-        <div key={section.id ?? section.type}>
-          {renderSection(section.type)}
-        </div>
+        <div key={section.id ?? section.type}>{renderSection(section)}</div>
       ))}
-      {sections.length === 0 && (
-        <Section_TextBlock />
-      )}
+      {sections.length === 0 && <Section_TextBlock />}
     </div>
   );
 }

--- a/packages/champagne-sections/src/Section_FeatureList.tsx
+++ b/packages/champagne-sections/src/Section_FeatureList.tsx
@@ -1,35 +1,95 @@
 import type { CSSProperties } from "react";
 import "@champagne/tokens";
+import type { SectionRegistryEntry } from "./SectionRegistry";
+
+export interface SectionFeatureListProps {
+  section?: SectionRegistryEntry;
+}
 
 const wrapperStyle: CSSProperties = {
-  borderRadius: "var(--radius-md)",
-  padding: "1.5rem",
-  background: "rgba(255,255,255,0.02)",
+  borderRadius: "var(--radius-lg)",
+  padding: "clamp(1.25rem, 2.8vw, 2rem)",
+  background:
+    "linear-gradient(120deg, color-mix(in srgb, var(--bg-ink, #06070c) 88%, transparent), color-mix(in srgb, var(--bg-ink-soft, #0c0f16) 78%, transparent)), radial-gradient(circle at 10% 20%, color-mix(in srgb, var(--smh-white, #ffffff) 10%, transparent), transparent 32%)",
   color: "var(--text-high)",
-  border: "1px solid rgba(255,255,255,0.08)",
+  border: "1px solid rgba(255,255,255,0.12)",
+  boxShadow: "var(--shadow-soft, 0 10px 36px rgba(0,0,0,0.32))",
 };
 
 const listStyle: CSSProperties = {
   display: "grid",
-  gap: "0.5rem",
+  gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))",
+  gap: "clamp(0.75rem, 2vw, 1.25rem)",
   marginTop: "0.75rem",
 };
 
 const pillStyle: CSSProperties = {
-  padding: "0.6rem 0.9rem",
-  borderRadius: "999px",
-  border: "1px solid var(--champagne-keyline-gold, rgba(255, 215, 137, 0.3))",
-  background: "linear-gradient(90deg, rgba(255,255,255,0.08), rgba(255,255,255,0))",
+  padding: "0.8rem 1rem",
+  borderRadius: "var(--radius-md)",
+  border: "1px solid var(--champagne-keyline-gold, rgba(255, 215, 137, 0.24))",
+  background:
+    "linear-gradient(90deg, color-mix(in srgb, var(--smh-white, #ffffff) 6%, transparent), color-mix(in srgb, var(--smh-white, #ffffff) 0%, transparent)), radial-gradient(circle at 20% 20%, color-mix(in srgb, var(--smh-white, #ffffff) 10%, transparent), transparent 40%)",
+  display: "grid",
+  gridTemplateColumns: "auto 1fr",
+  gap: "0.65rem",
+  alignItems: "center",
 };
 
-export function Section_FeatureList() {
+const badgeStyle: CSSProperties = {
+  width: "38px",
+  height: "38px",
+  borderRadius: "50%",
+  background: "radial-gradient(circle at 30% 30%, color-mix(in srgb, var(--smh-white, #ffffff) 24%, transparent), color-mix(in srgb, var(--smh-white, #ffffff) 8%, transparent))",
+  border: "1px solid rgba(255,255,255,0.12)",
+  display: "grid",
+  placeItems: "center",
+  color: "var(--text-high)",
+  fontWeight: 700,
+  letterSpacing: "0.02em",
+  boxShadow: "0 10px 28px rgba(0,0,0,0.28)",
+};
+
+const headingStyle: CSSProperties = {
+  fontSize: "clamp(1.15rem, 2vw, 1.45rem)",
+  fontWeight: 700,
+};
+
+const subtextStyle: CSSProperties = {
+  color: "var(--text-medium, rgba(255,255,255,0.78))",
+  lineHeight: 1.55,
+  fontSize: "0.98rem",
+};
+
+export function Section_FeatureList({ section }: SectionFeatureListProps = {}) {
+  const definition = (section?.definition as Record<string, unknown> | undefined) ?? {};
+  const features = (definition.items as string[] | undefined) ?? [
+    "Clinically precise planning with Champagne variable system",
+    "Soft-focus overlays to keep eyes on the smile story",
+    "Comfort-first spacing and rhythm across every breakpoint",
+  ];
+  const heading = (definition.title as string | undefined) ?? "Hallmarks of Champagne care";
+  const eyebrow = (definition.label as string | undefined) ?? "Treatment signatures";
+
   return (
     <section style={wrapperStyle}>
-      <p style={{ fontSize: "1.125rem", fontWeight: 600 }}>Feature List Placeholder</p>
+      <div style={{ display: "grid", gap: "0.45rem" }}>
+        {eyebrow && (
+          <span style={{
+            fontSize: "0.85rem",
+            letterSpacing: "0.1em",
+            textTransform: "uppercase",
+            color: "var(--text-medium, rgba(255,255,255,0.7))",
+          }}>
+            {eyebrow}
+          </span>
+        )}
+        <h3 style={headingStyle}>{heading}</h3>
+      </div>
       <div style={listStyle}>
-        {["Token-aware surface", "Awaiting live content", "Neutral placeholder"].map((item) => (
-          <div key={item} style={pillStyle}>
-            {item}
+        {features.map((item, index) => (
+          <div key={item + index} style={pillStyle}>
+            <span style={badgeStyle}>{index + 1}</span>
+            <span style={subtextStyle}>{item}</span>
           </div>
         ))}
       </div>

--- a/packages/champagne-sections/src/Section_MediaBlock.tsx
+++ b/packages/champagne-sections/src/Section_MediaBlock.tsx
@@ -1,37 +1,102 @@
 import type { CSSProperties } from "react";
 import "@champagne/tokens";
+import type { SectionRegistryEntry } from "./SectionRegistry";
+
+export interface SectionMediaBlockProps {
+  section?: SectionRegistryEntry;
+}
 
 const wrapperStyle: CSSProperties = {
-  borderRadius: "var(--radius-md)",
-  border: "1px dashed var(--champagne-keyline-gold, rgba(255, 215, 137, 0.3))",
-  padding: "1.5rem",
-  background: "rgba(10,12,18,0.4)",
-  color: "var(--text-high)",
+  borderRadius: "var(--radius-lg)",
+  border: "1px solid var(--champagne-keyline-gold, rgba(255, 215, 137, 0.22))",
+  padding: "clamp(1.25rem, 2.8vw, 2.25rem)",
+  background:
+    "linear-gradient(140deg, color-mix(in srgb, var(--bg-ink, #06070c) 88%, transparent), color-mix(in srgb, var(--bg-ink-soft, #0c0f16) 78%, transparent)), radial-gradient(circle at 88% 20%, color-mix(in srgb, var(--smh-white, #ffffff) 8%, transparent), transparent 30%)",
+  display: "grid",
+  gap: "clamp(1rem, 2vw, 1.5rem)",
 };
 
-const mediaPlaceholder: CSSProperties = {
-  width: "100%",
-  height: "180px",
-  borderRadius: "var(--radius-sm)",
-  background: "linear-gradient(135deg, rgba(255,255,255,0.08), rgba(255,255,255,0.02))",
+const layoutStyle: CSSProperties = {
   display: "grid",
-  placeItems: "center",
-  color: "var(--text-medium, rgba(255,255,255,0.65))",
+  gap: "clamp(1rem, 2.5vw, 1.75rem)",
+  gridTemplateColumns: "repeat(auto-fit, minmax(260px, 1fr))",
+  alignItems: "center",
+};
+
+const mediaShell: CSSProperties = {
+  position: "relative",
+  borderRadius: "var(--radius-md)",
+  overflow: "hidden",
+  background: "var(--surface-glass, rgba(255,255,255,0.06))",
+  minHeight: "220px",
+  boxShadow: "var(--shadow-soft, 0 10px 36px rgba(0,0,0,0.35))",
   border: "1px solid rgba(255,255,255,0.08)",
 };
 
-export function Section_MediaBlock() {
+const mediaGradient: CSSProperties = {
+  position: "absolute",
+  inset: 0,
+  background:
+    "linear-gradient(135deg, color-mix(in srgb, var(--champagne-keyline-gold, #ffd789) 14%, transparent), color-mix(in srgb, var(--smh-white, #ffffff) 0%, transparent)), radial-gradient(circle at 30% 20%, color-mix(in srgb, var(--smh-white, #ffffff) 16%, transparent), transparent 36%)",
+  mixBlendMode: "screen",
+};
+
+const captionStyle: CSSProperties = {
+  fontSize: "0.95rem",
+  color: "var(--text-medium, rgba(255,255,255,0.76))",
+  lineHeight: 1.6,
+};
+
+const headlineStyle: CSSProperties = {
+  fontSize: "clamp(1.25rem, 2vw, 1.65rem)",
+  fontWeight: 700,
+  lineHeight: 1.3,
+};
+
+const eyebrowStyle: CSSProperties = {
+  fontSize: "0.85rem",
+  letterSpacing: "0.1em",
+  textTransform: "uppercase",
+  color: "var(--text-medium, rgba(255,255,255,0.7))",
+};
+
+export function Section_MediaBlock({ section }: SectionMediaBlockProps = {}) {
+  const definition = (section?.definition as Record<string, unknown> | undefined) ?? {};
+  const headline = (definition.title as string | undefined)
+    ?? "Visual proof with Champagne clarity";
+  const eyebrow = (definition.label as string | undefined) ?? "Treatment media";
+  const caption = (definition.copy as string | undefined)
+    ?? "Media panels use ink/glass layering with soft-gold edges to keep imagery vivid without sacrificing contrast.";
+
   return (
     <section style={wrapperStyle}>
-      <p style={{ fontSize: "1.125rem", fontWeight: 600 }}>Media Block Placeholder</p>
-      <div style={{ marginTop: "0.75rem" }}>
-        <div style={mediaPlaceholder}>
-          Future media surface
+      <div style={layoutStyle}>
+        <div style={{ display: "grid", gap: "0.65rem" }}>
+          {eyebrow && <span style={eyebrowStyle}>{eyebrow}</span>}
+          <h3 style={headlineStyle}>{headline}</h3>
+          <p style={captionStyle}>{caption}</p>
+        </div>
+        <div style={mediaShell}>
+          <div aria-hidden style={mediaGradient} />
+          <div
+            style={{
+              position: "absolute",
+              inset: "12% 10%",
+              borderRadius: "var(--radius-md)",
+              border: "1px solid rgba(255,255,255,0.14)",
+              background: "linear-gradient(160deg, color-mix(in srgb, var(--smh-white, #ffffff) 10%, transparent), color-mix(in srgb, var(--bg-ink, #06070c) 70%, transparent))",
+              boxShadow: "0 24px 60px rgba(0,0,0,0.48)",
+              display: "grid",
+              placeItems: "center",
+              color: "var(--text-high)",
+              fontWeight: 600,
+              letterSpacing: "0.03em",
+            }}
+          >
+            Champagne media canvas
+          </div>
         </div>
       </div>
-      <p style={{ color: "var(--text-medium, rgba(255,255,255,0.75))", marginTop: "0.75rem", lineHeight: 1.6 }}>
-        Imagery, video, or interactive components will appear here using the Champagne media system.
-      </p>
     </section>
   );
 }

--- a/packages/champagne-sections/src/Section_TextBlock.tsx
+++ b/packages/champagne-sections/src/Section_TextBlock.tsx
@@ -1,22 +1,75 @@
 import type { CSSProperties } from "react";
 import "@champagne/tokens";
+import type { SectionRegistryEntry } from "./SectionRegistry";
+
+export interface SectionComponentProps {
+  section?: SectionRegistryEntry;
+}
 
 const containerStyle: CSSProperties = {
-  borderRadius: "var(--radius-md)",
-  border: "1px solid var(--champagne-keyline-gold, rgba(255, 215, 137, 0.25))",
-  padding: "1.5rem",
-  background: "rgba(6,7,12,0.35)",
-  color: "var(--text-high)",
+  position: "relative",
+  borderRadius: "var(--radius-lg)",
+  border: "1px solid var(--champagne-keyline-gold, rgba(255, 215, 137, 0.28))",
+  padding: "clamp(1.5rem, 3vw, 2.5rem)",
+  background:
+    "linear-gradient(180deg, color-mix(in srgb, var(--bg-ink, #06070c) 86%, transparent), color-mix(in srgb, var(--bg-ink-soft, #0c0f16) 82%, transparent)), radial-gradient(circle at 18% 12%, color-mix(in srgb, var(--smh-white, #ffffff) 14%, transparent), transparent 38%)",
+  boxShadow: "var(--shadow-soft, 0 10px 36px rgba(0,0,0,0.35))",
+  overflow: "hidden",
 };
 
-export function Section_TextBlock() {
+const accentBar: CSSProperties = {
+  position: "absolute",
+  inset: "0 0 auto 0",
+  height: "3px",
+  background:
+    "linear-gradient(90deg, color-mix(in srgb, var(--champagne-keyline-gold, #ffd789) 40%, transparent), color-mix(in srgb, var(--champagne-keyline-gold, #ffd789) 8%, transparent))",
+};
+
+const gridStyle: CSSProperties = {
+  display: "grid",
+  gap: "0.75rem",
+  maxWidth: "68ch",
+};
+
+const eyebrowStyle: CSSProperties = {
+  fontSize: "0.9rem",
+  letterSpacing: "0.08em",
+  textTransform: "uppercase",
+  color: "var(--text-medium, rgba(255,255,255,0.72))",
+};
+
+const headingStyle: CSSProperties = {
+  fontSize: "clamp(1.35rem, 2vw, 1.8rem)",
+  fontWeight: 700,
+  lineHeight: 1.3,
+};
+
+const bodyStyle: CSSProperties = {
+  fontSize: "1.05rem",
+  lineHeight: 1.7,
+  color: "var(--text-medium, rgba(255,255,255,0.78))",
+};
+
+export function Section_TextBlock({ section }: SectionComponentProps = {}) {
+  const definition = (section?.definition as Record<string, unknown> | undefined) ?? {};
+  const heading = (definition.title as string | undefined)
+    ?? (definition.headline as string | undefined)
+    ?? "Precision-crafted smiles built on gentle engineering.";
+  const eyebrow = (definition.label as string | undefined)
+    ?? (definition.eyebrow as string | undefined)
+    ?? "Champagne narrative";
+  const copy = (definition.copy as string | undefined)
+    ?? (definition.body as string | undefined)
+    ?? "Every surface is tuned with Champagne tokens to keep contrast crisp, spacing breathable, and details soft-gold without overwhelming the eye.";
+
   return (
     <section style={containerStyle}>
-      <p style={{ fontSize: "1.125rem", fontWeight: 600 }}>Text Block Placeholder</p>
-      <p style={{ color: "var(--text-medium, rgba(255,255,255,0.75))", marginTop: "0.5rem", lineHeight: 1.6 }}>
-        This neutral surface represents a future storytelling or descriptive text section.
-        Content, media, and layout will be attached once the Champagne section system is fully activated.
-      </p>
+      <div aria-hidden style={accentBar} />
+      <div style={gridStyle}>
+        {eyebrow && <span style={eyebrowStyle}>{eyebrow}</span>}
+        <h2 style={headingStyle}>{heading}</h2>
+        <p style={bodyStyle}>{copy}</p>
+      </div>
     </section>
   );
 }


### PR DESCRIPTION
## Summary
- add a reusable ChampagnePageBuilder that pulls manifests, hero presets, and sections for Champagne pages
- hook the treatment routes into the builder so they render manifest-driven heroes and sections
- refresh hero and section components with token-aware Champagne styling for the first real pass

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6936097ba9c88332b7fce046028cc861)