### PR TITLE
Wire treatments through manifest-driven Champagne surface

### DIFF
--- a/apps/web/app/(champagne)/_builder/ChampagnePageBuilder.tsx
+++ b/apps/web/app/(champagne)/_builder/ChampagnePageBuilder.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import type { CSSProperties } from "react";
 import { BaseChampagneSurface, ChampagneHeroFrame } from "@champagne/hero";
 import {
@@ -33,6 +34,32 @@ const gridStyle: CSSProperties = {
   display: "grid",
   gap: "clamp(1.25rem, 3vw, 2.5rem)",
 };
+
+function TreatmentBreadcrumb({ label, href }: { label?: string; href: string }) {
+  return (
+    <nav
+      aria-label="Breadcrumb"
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: "0.65rem",
+        fontSize: "0.95rem",
+        color: "var(--text-medium, rgba(230,230,230,0.82))",
+        letterSpacing: "0.02em",
+      }}
+    >
+      <Link href="/" className="hover:underline">
+        Home
+      </Link>
+      <span aria-hidden>/</span>
+      <Link href="/treatments" className="hover:underline">
+        Treatments
+      </Link>
+      <span aria-hidden>/</span>
+      <span>{label ?? href.replace("/treatments/", "").replace(/-/g, " ")}</span>
+    </nav>
+  );
+}
 
 function DebugPanel({
   path,
@@ -92,10 +119,12 @@ export function ChampagnePageBuilder({ slug, previewMode = false }: ChampagnePag
   const midPageCTAs = resolveCTAList(ctaSlots.midPageCTAs, "secondary");
   const footerCTAs = resolveCTAList(ctaSlots.footerCTAs, "ghost");
   const sections = getSectionStack(pagePath);
+  const isTreatmentPage = pagePath.startsWith("/treatments/");
 
   return (
     <BaseChampagneSurface variant="inkGlass" style={surfaceStyle}>
       <div style={gridStyle}>
+        {isTreatmentPage && <TreatmentBreadcrumb label={manifest?.label as string | undefined} href={pagePath} />}
         <div style={{ display: "grid", gap: "0.8rem" }}>
           <ChampagneHeroFrame
             heroId={heroId ?? pagePath}

--- a/apps/web/app/treatments/page.tsx
+++ b/apps/web/app/treatments/page.tsx
@@ -1,36 +1,85 @@
 import Link from "next/link";
+import { BaseChampagneSurface } from "@champagne/hero";
+import { getTreatmentPages } from "@champagne/manifests";
 
-const treatments = [
-  { slug: "dental-implants", name: "Dental Implants" },
-  { slug: "clear-aligners", name: "Clear aligner orthodontics (Spark and other systems)" },
-  { slug: "smile-makeovers", name: "Smile Makeovers" },
-  { slug: "teeth-whitening", name: "Teeth Whitening" },
-  { slug: "3d-dentistry-scanning", name: "3D Dentistry & Scanning" },
-];
+const FAMILY_LABELS: Record<string, string> = {
+  implants: "Implants",
+  whitening: "Whitening",
+  "3d-tech": "3D & tech",
+  aligners: "Orthodontics & aligners",
+  other: "More care options",
+};
+
+const FAMILY_ORDER = ["implants", "whitening", "3d-tech", "aligners", "other"];
+
+function inferFamily(slug: string) {
+  if (slug.startsWith("implants")) return "implants";
+  if (slug.includes("whitening")) return "whitening";
+  if (slug === "clear-aligners" || slug === "orthodontics") return "aligners";
+  if (slug.startsWith("3d-") || slug.includes("3d-")) return "3d-tech";
+  if (slug.startsWith("cbct")) return "3d-tech";
+  if (slug === "digital-smile-design") return "3d-tech";
+  return "other";
+}
+
+function buildDescription(label?: string) {
+  if (!label) return "Explore this treatment.";
+  return `Explore ${label.toLowerCase()}.`;
+}
 
 export default function TreatmentsPage() {
+  const treatments = getTreatmentPages();
+  const grouped = treatments.reduce<Record<string, typeof treatments>>((acc, treatment) => {
+    const key = inferFamily(treatment.slug);
+    acc[key] = acc[key] ? [...acc[key], treatment] : [treatment];
+    return acc;
+  }, {});
+
+  const orderedGroups = FAMILY_ORDER.map((key) => ({
+    key,
+    label: FAMILY_LABELS[key],
+    items: (grouped[key] ?? []).sort((a, b) => (a.label ?? a.slug).localeCompare(b.label ?? b.slug)),
+  })).filter((group) => group.items.length > 0);
+
   return (
-    <div className="mx-auto flex max-w-5xl flex-col gap-6">
-      <header className="space-y-2">
-        <p className="text-sm uppercase tracking-[0.2em] text-neutral-400">Treatments</p>
-        <h1 className="text-3xl font-semibold text-neutral-50">Explore our care options</h1>
-        <p className="max-w-2xl text-neutral-300">
-          A snapshot of the services planned for St Mary&apos;s House Dental. Select a treatment to learn more.
+    <div className="mx-auto max-w-6xl space-y-6 py-8">
+      <header className="space-y-2 px-2 sm:px-0">
+        <p className="text-xs uppercase tracking-[0.2em] text-neutral-400">Treatments</p>
+        <h1 className="text-3xl font-semibold text-neutral-50">Clinical care, mapped to the canon</h1>
+        <p className="max-w-3xl text-neutral-300">
+          Browse the current Champagne treatment set. Each page is powered by the manifest canon and routes into the
+          Champagne builder experience.
         </p>
       </header>
 
-      <div className="grid gap-4 sm:grid-cols-2">
-        {treatments.map((treatment) => (
-          <Link
-            key={treatment.slug}
-            href={`/treatments/${treatment.slug}`}
-            className="rounded-lg border border-neutral-800 bg-neutral-900/40 p-5 transition hover:border-neutral-700 hover:bg-neutral-900"
-          >
-            <p className="text-lg font-semibold text-neutral-50">{treatment.name}</p>
-            <p className="text-sm text-neutral-300">Learn more about {treatment.name.toLowerCase()}.</p>
-          </Link>
-        ))}
-      </div>
+      <BaseChampagneSurface
+        variant="inkGlass"
+        className="border border-neutral-800/70 p-6 shadow-lg sm:p-8"
+        style={{ background: "linear-gradient(145deg, rgba(12,15,22,0.9), rgba(8,9,14,0.8))" }}
+      >
+        <div className="space-y-8">
+          {orderedGroups.map((group) => (
+            <section key={group.key} className="space-y-3">
+              <div className="flex items-baseline justify-between gap-4">
+                <h2 className="text-xl font-semibold text-neutral-50">{group.label}</h2>
+                <span className="text-xs uppercase tracking-[0.2em] text-neutral-400">{group.items.length} pages</span>
+              </div>
+              <div className="grid gap-4 sm:grid-cols-2">
+                {group.items.map((treatment) => (
+                  <Link
+                    key={treatment.slug}
+                    href={`/treatments/${treatment.slug}`}
+                    className="group rounded-lg border border-neutral-800/70 bg-neutral-900/40 p-5 transition hover:border-neutral-700 hover:bg-neutral-900/70"
+                  >
+                    <p className="text-lg font-semibold text-neutral-50">{treatment.label ?? treatment.slug}</p>
+                    <p className="text-sm text-neutral-300">{buildDescription(treatment.label)}</p>
+                  </Link>
+                ))}
+              </div>
+            </section>
+          ))}
+        </div>
+      </BaseChampagneSurface>
     </div>
   );
 }

--- a/packages/champagne-manifests/reports/treatment-canon-map.md
+++ b/packages/champagne-manifests/reports/treatment-canon-map.md
@@ -31,3 +31,35 @@ Snapshot of treatment routes in the Champagne manifests. Hero and section indica
 | whitening | Teeth whitening | ✅ | ✅ |
 | whitening-at-home | Whitening at home | ✅ | ✅ |
 | whitening-in-surgery | In-surgery whitening | ✅ | ✅ |
+
+## Phase 5 wiring
+
+- /treatments index now renders directly from the manifest canon (no hard-coded lists).
+- Treatment slugs routed through the Champagne builder:
+  - 3d-dentistry-and-technology
+  - 3d-implant-restorations
+  - 3d-printed-veneers
+  - 3d-printing-lab
+  - cbct-3d-scanning
+  - childrens-dentistry
+  - clear-aligners
+  - composite-bonding
+  - crowns-bridges-restorative
+  - digital-smile-design
+  - emergency-dentistry
+  - endodontics-root-canal
+  - extractions-and-oral-surgery
+  - full-smile-makeover
+  - implants
+  - implants-full-arch
+  - implants-multiple-teeth
+  - implants-single-tooth
+  - orthodontics
+  - periodontal-gum-care
+  - preventative-and-general-dentistry
+  - senior-mature-smile-care
+  - tmj-jaw-comfort
+  - veneers
+  - whitening
+  - whitening-at-home
+  - whitening-in-surgery

--- a/packages/champagne-manifests/src/index.ts
+++ b/packages/champagne-manifests/src/index.ts
@@ -22,7 +22,10 @@ export {
   getPageManifest,
   getSectionManifest,
   getSectionCTAReferences,
+  getTreatmentManifest,
+  getTreatmentPages,
   type ChampagneHeroManifest,
   type ChampagneCTASlots,
   type ChampagneSectionManifest,
+  type ChampagneTreatmentPage,
 } from "./helpers";


### PR DESCRIPTION
## Summary
- add manifest helpers to enumerate and resolve treatment pages and export them for app use
- rebuild the /treatments index as a canon-driven grid grouped by treatment family and wire the slug route into the Champagne builder with metadata fallbacks
- layer breadcrumbs and manifest-derived rendering into treatment pages and document the wired slugs in the canon report

## Testing
- pnpm lint
- pnpm build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693640cf87d483328454e5cf1d355fd0)