### PR TITLE
Enhance treatment layout structure

### DIFF
--- a/apps/web/app/treatments/page.tsx
+++ b/apps/web/app/treatments/page.tsx
@@ -24,7 +24,7 @@ function inferFamily(slug: string) {
 
 function buildDescription(label?: string) {
   if (!label) return "Explore this treatment.";
-  return `Explore ${label.toLowerCase()}.`;
+  return `Learn more about ${label.toLowerCase()}.`;
 }
 
 export default function TreatmentsPage() {
@@ -41,39 +41,55 @@ export default function TreatmentsPage() {
     items: (grouped[key] ?? []).sort((a, b) => (a.label ?? a.slug).localeCompare(b.label ?? b.slug)),
   })).filter((group) => group.items.length > 0);
 
+  const cardStyle = {
+    display: "grid",
+    gap: "0.35rem",
+    padding: "1rem 1.1rem",
+    borderRadius: "var(--radius-lg)",
+    border: "1px solid var(--champagne-keyline-gold, rgba(255,215,137,0.22))",
+    background: "linear-gradient(145deg, rgba(12,15,22,0.8), rgba(8,9,14,0.76))",
+  } as const;
+
   return (
-    <div className="mx-auto max-w-6xl space-y-6 py-8">
-      <header className="space-y-2 px-2 sm:px-0">
+    <div className="mx-auto max-w-6xl space-y-6 py-8 px-2 sm:px-0">
+      <header className="space-y-2">
         <p className="text-xs uppercase tracking-[0.2em] text-neutral-400">Treatments</p>
         <h1 className="text-3xl font-semibold text-neutral-50">Clinical care, mapped to the canon</h1>
         <p className="max-w-3xl text-neutral-300">
-          Browse the current Champagne treatment set. Each page is powered by the manifest canon and routes into the
-          Champagne builder experience.
+          Browse the current Champagne treatment set. Each page is powered by the manifest canon and routes into the Champagne builder experience.
         </p>
       </header>
 
       <BaseChampagneSurface
         variant="inkGlass"
-        className="border border-neutral-800/70 p-6 shadow-lg sm:p-8"
-        style={{ background: "linear-gradient(145deg, rgba(12,15,22,0.9), rgba(8,9,14,0.8))" }}
+        className="border border-neutral-800/70 shadow-lg"
+        style={{ background: "linear-gradient(145deg, rgba(12,15,22,0.9), rgba(8,9,14,0.82))", padding: "1.5rem 1.75rem" }}
       >
         <div className="space-y-8">
           {orderedGroups.map((group) => (
-            <section key={group.key} className="space-y-3">
-              <div className="flex items-baseline justify-between gap-4">
-                <h2 className="text-xl font-semibold text-neutral-50">{group.label}</h2>
-                <span className="text-xs uppercase tracking-[0.2em] text-neutral-400">{group.items.length} pages</span>
+            <section key={group.key} className="space-y-4">
+              <div className="flex flex-wrap items-baseline justify-between gap-4">
+                <div>
+                  <p className="text-[0.8rem] uppercase tracking-[0.18em] text-neutral-400">{group.items.length} pages</p>
+                  <h2 className="text-xl font-semibold text-neutral-50">{group.label}</h2>
+                </div>
               </div>
               <div className="grid gap-4 sm:grid-cols-2">
                 {group.items.map((treatment) => (
-                  <Link
-                    key={treatment.slug}
-                    href={`/treatments/${treatment.slug}`}
-                    className="group rounded-lg border border-neutral-800/70 bg-neutral-900/40 p-5 transition hover:border-neutral-700 hover:bg-neutral-900/70"
-                  >
-                    <p className="text-lg font-semibold text-neutral-50">{treatment.label ?? treatment.slug}</p>
-                    <p className="text-sm text-neutral-300">{buildDescription(treatment.label)}</p>
-                  </Link>
+                  <BaseChampagneSurface key={treatment.slug} variant="glass" className="h-full">
+                    <Link
+                      href={`/treatments/${treatment.slug}`}
+                      className="group block h-full"
+                      style={{ textDecoration: "none", color: "inherit" }}
+                    >
+                      <div style={cardStyle} className="transition hover:-translate-y-0.5">
+                        <p className="text-lg font-semibold text-neutral-50 group-hover:text-white">
+                          {treatment.label ?? treatment.slug.replace(/-/g, " ")}
+                        </p>
+                        <p className="text-sm text-neutral-300">{buildDescription(treatment.label)}</p>
+                      </div>
+                    </Link>
+                  </BaseChampagneSurface>
                 ))}
               </div>
             </section>

--- a/packages/champagne-hero/src/ChampagneHeroFrame.tsx
+++ b/packages/champagne-hero/src/ChampagneHeroFrame.tsx
@@ -11,6 +11,8 @@ export interface ChampagneHeroFrameProps {
   preset?: string | Record<string, unknown>;
   headline?: string;
   subheadline?: string;
+  eyebrow?: string;
+  strapline?: string;
   cta?: { label: string; href: string };
 }
 
@@ -49,7 +51,7 @@ function resolveSubtitle(preset?: HeroPreset, fallback?: string) {
   return fallback;
 }
 
-export function ChampagneHeroFrame({ heroId, preset, headline, subheadline, cta }: ChampagneHeroFrameProps) {
+export function ChampagneHeroFrame({ heroId, preset, headline, subheadline, eyebrow, strapline, cta }: ChampagneHeroFrameProps) {
   const [showDebug, setShowDebug] = useState(false);
   const [resolvedHero, setResolvedHero] = useState<HeroRegistryEntry>(() => resolveHeroVariant(heroId));
 
@@ -71,7 +73,10 @@ export function ChampagneHeroFrame({ heroId, preset, headline, subheadline, cta 
   const heroType = deriveHeroType(heroId, mergedPreset);
   const layers = extractLayerTokens(mergedPreset);
   const resolvedHeadline = resolveTitle(mergedPreset, headline ?? resolvedHero.label ?? "Champagne hero");
-  const resolvedSubheadline = resolveSubtitle(mergedPreset, subheadline);
+  const resolvedSubheadline = resolveSubtitle(mergedPreset, strapline ?? subheadline);
+  const resolvedEyebrow = eyebrow ?? (mergedPreset && typeof mergedPreset === "object" && typeof mergedPreset.palette === "string"
+    ? `${mergedPreset.palette} treatment`
+    : "Champagne treatment");
 
   const heroBackground = layers.background
     ?? (heroType === "gilded"
@@ -98,21 +103,23 @@ export function ChampagneHeroFrame({ heroId, preset, headline, subheadline, cta 
       <div aria-hidden style={{ position: "absolute", inset: 0, zIndex: 0, background: vignetteLayer, mixBlendMode: "multiply" }} />
       <div aria-hidden style={{ position: "absolute", inset: 0, zIndex: 0, background: waveLayer, opacity: 0.8 }} />
 
-      <div style={{ display: "grid", gap: "1.15rem" }}>
-        <div style={{ display: "grid", gap: "0.6rem", maxWidth: "720px" }}>
-          <span style={{
-            fontSize: "0.92rem",
-            letterSpacing: "0.1em",
-            textTransform: "uppercase",
-            color: "var(--text-medium, rgba(255,255,255,0.7))",
-          }}>
-            {heroType} hero
-          </span>
-          <h1 style={{ fontSize: "clamp(1.8rem, 3vw, 2.6rem)", fontWeight: 800, lineHeight: 1.18 }}>
+      <div style={{ display: "grid", gap: "1.15rem", maxWidth: "960px" }}>
+        <div style={{ display: "grid", gap: "0.55rem", maxWidth: "780px" }}>
+          {resolvedEyebrow && (
+            <span style={{
+              fontSize: "0.92rem",
+              letterSpacing: "0.1em",
+              textTransform: "uppercase",
+              color: "var(--text-medium, rgba(255,255,255,0.7))",
+            }}>
+              {resolvedEyebrow}
+            </span>
+          )}
+          <h1 style={{ fontSize: "clamp(1.9rem, 3.1vw, 2.8rem)", fontWeight: 800, lineHeight: 1.15 }}>
             {resolvedHeadline ?? "Placeholder hero headline"}
           </h1>
           {resolvedSubheadline && (
-            <p style={{ fontSize: "1.05rem", color: "var(--text-medium, rgba(255,255,255,0.78))", lineHeight: 1.6 }}>
+            <p style={{ fontSize: "1.08rem", color: "var(--text-medium, rgba(255,255,255,0.82))", lineHeight: 1.65 }}>
               {resolvedSubheadline}
             </p>
           )}

--- a/packages/champagne-manifests/reports/treatment-canon-map.md
+++ b/packages/champagne-manifests/reports/treatment-canon-map.md
@@ -35,6 +35,8 @@ Snapshot of treatment routes in the Champagne manifests. Hero and section indica
 ## Phase 5 wiring
 
 - /treatments index now renders directly from the manifest canon (no hard-coded lists).
+- Hero presets now resolve IDs through `manifest.styles.champagne.json` so treatment heroes render with a palette/motion preset even when only an ID is present in the page manifest.
+- Section stacks flow through the adapter in `@champagne/sections`, which fills neutral copy for sparse manifest entries while keeping the canon order intact.
 - Treatment slugs routed through the Champagne builder:
   - 3d-dentistry-and-technology
   - 3d-implant-restorations

--- a/packages/champagne-manifests/reports/treatment-layout-usage.md
+++ b/packages/champagne-manifests/reports/treatment-layout-usage.md
@@ -1,0 +1,29 @@
+# Treatment layout usage (phase 5)
+
+This note traces how treatment slugs now flow through the builder into the hero and section layout. It also calls out the key files to adjust when wiring new content.
+
+## Flow from slug to rendered page
+
+1. **Slug lookup**
+   - `/treatments/[slug]` resolves the manifest entry via `getTreatmentManifest` (`apps/web/app/treatments/[slug]/page.tsx`).
+   - `ChampagnePageBuilder` receives the resolved `pageSlug` and manifest reference.
+2. **Hero resolution**
+   - `ChampagnePageBuilder` derives the page label/eyebrow/strapline from the manifest (or the slug as a fallback) and fetches hero data with `getHeroManifest`.
+   - `getHeroManifest` now merges the hero preset from `manifest.styles.champagne.json` when the hero is declared by ID, so style tokens land inside `ChampagneHeroFrame` even if the page manifest only stores the ID.
+3. **Section stack**
+   - Section IDs/types come from the machine manifest (`getSectionStackForPage`).
+   - `packages/champagne-sections/src/SectionRegistry.ts` adapts raw entries into a clean internal shape (`kind`, `title`, `body`, `items`, etc.), filling sensible fallbacks when content is light.
+4. **Render**
+   - `ChampagneHeroFrame` renders eyebrow → title → strapline within a BaseChampagneSurface shell.
+   - `ChampagneSectionRenderer` walks the normalized stack and maps `kind` to the available section components (`Section_TextBlock`, `Section_MediaBlock`, `Section_FeatureList`), inserting mid-page CTAs when configured.
+
+## Where to adjust things
+
+- **Add a new treatment**: add an entry to `packages/champagne-manifests/data/champagne_machine_manifest_full.json` (or the feeder manifest) with `path`, `hero`, and `sections`. The `/treatments` index and `[slug]` route will pick it up automatically.
+- **Change section order or composition**: edit the `sections` array for the treatment in the manifest data. The registry adapter will normalize types and fallbacks without further wiring.
+- **Adjust hero copy**: update `label`, `eyebrow/overline`, or `strapline/intro/summary` fields on the page manifest. If only a hero ID exists, styles will still be pulled from `manifest.styles.champagne.json`; add richer hero metadata there if needed.
+
+## Notes on current gaps
+
+- Many treatment sections only ship IDs/types today; the adapter supplies neutral, accessible placeholder copy to keep layouts complete until full text arrives.
+- Hero presets from the styles manifest currently provide palette/motion metadata. If a hero-specific title/subtitle is ever authored there, `ChampagneHeroFrame` will display it automatically.

--- a/packages/champagne-manifests/src/core.ts
+++ b/packages/champagne-manifests/src/core.ts
@@ -57,7 +57,14 @@ export interface ChampagneManifestRegistry {
   manusImport?: unknown;
 }
 
+export interface ChampagneStylesManifest {
+  heroes?: Record<string, unknown>;
+  sections?: Record<string, unknown>;
+  [key: string]: unknown;
+}
+
 const champagneMachineManifest: ChampagneMachineManifest = machineManifestData;
+const champagneStylesManifest: ChampagneStylesManifest = stylesManifest;
 
 const registry: ChampagneManifestRegistry = {
   core: champagneMachineManifest,
@@ -86,6 +93,7 @@ export const champagneManifestStatus: ChampagneManifestStatus = allReady
 export const champagneManifestsReady = champagneManifestStatus === "ready";
 
 export const champagneManifestRegistry: ChampagneManifestRegistry = registry;
+export { champagneStylesManifest };
 
 const pageCollections = [
   champagneMachineManifest.pages ?? {},

--- a/packages/champagne-manifests/src/index.ts
+++ b/packages/champagne-manifests/src/index.ts
@@ -3,6 +3,7 @@ export {
   champagneManifestRegistry,
   champagneManifestStatus,
   champagneManifestsReady,
+  champagneStylesManifest,
   getPageManifestBySlug,
   getHeroPresetForPage,
   getSectionStackForPage,
@@ -13,6 +14,7 @@ export {
   type ChampagneManifestStatus,
   type ChampagnePageManifest,
   type ChampagnePageSection,
+  type ChampagneStylesManifest,
 } from "./core";
 
 export {
@@ -22,6 +24,7 @@ export {
   getPageManifest,
   getSectionManifest,
   getSectionCTAReferences,
+  getSectionStyle,
   getTreatmentManifest,
   getTreatmentPages,
   type ChampagneHeroManifest,

--- a/packages/champagne-sections/src/ChampagneSectionRenderer.tsx
+++ b/packages/champagne-sections/src/ChampagneSectionRenderer.tsx
@@ -25,7 +25,8 @@ const typeMap: Record<string, SectionComponent> = {
 };
 
 function renderSection(section: SectionRegistryEntry) {
-  const component = section.type ? typeMap[section.type] : undefined;
+  const key = section.kind ?? section.type;
+  const component = key ? typeMap[key] : undefined;
   if (component) return component({ section });
 
   if (["copy-block", "story", "faq", "accordion"].includes(section.type ?? "")) {
@@ -47,29 +48,39 @@ export function ChampagneSectionRenderer({ pageSlug, midPageCTAs, previewMode }:
   const midInsertIndex = hasMidPageCTAs ? Math.max(1, Math.ceil(sections.length / 2)) : -1;
 
   return (
-    <div style={{ display: "grid", gap: "clamp(1rem, 2vw, 1.75rem)", marginTop: "0.5rem" }}>
-      {sections.map((section, index) => (
-        <Fragment key={section.id ?? section.type ?? `${pageSlug}-section-${index}`}>
-          <div>{renderSection(section)}</div>
-          {hasMidPageCTAs && index === midInsertIndex - 1 && (
-            <ChampagneCTAGroup
-              ctas={midPageCTAs}
-              label="Mid-page CTAs"
-              showDebug={previewMode}
-              defaultPreset="secondary"
-            />
-          )}
-        </Fragment>
-      ))}
-      {sections.length === 0 && <Section_TextBlock />}
-      {sections.length === 0 && hasMidPageCTAs && (
-        <ChampagneCTAGroup
-          ctas={midPageCTAs}
-          label="Mid-page CTAs"
-          showDebug={previewMode}
-          defaultPreset="secondary"
-        />
-      )}
+    <div style={{ display: "grid", gap: "clamp(1.2rem, 2.4vw, 2rem)", marginTop: "0.5rem" }}>
+      <div
+        style={{
+          display: "grid",
+          gap: "clamp(1rem, 2vw, 1.75rem)",
+          maxWidth: "1080px",
+          margin: "0 auto",
+          width: "100%",
+        }}
+      >
+        {sections.map((section, index) => (
+          <Fragment key={section.id ?? section.type ?? `${pageSlug}-section-${index}`}>
+            <div>{renderSection(section)}</div>
+            {hasMidPageCTAs && index === midInsertIndex - 1 && (
+              <ChampagneCTAGroup
+                ctas={midPageCTAs}
+                label="Mid-page CTAs"
+                showDebug={previewMode}
+                defaultPreset="secondary"
+              />
+            )}
+          </Fragment>
+        ))}
+        {sections.length === 0 && <Section_TextBlock />}
+        {sections.length === 0 && hasMidPageCTAs && (
+          <ChampagneCTAGroup
+            ctas={midPageCTAs}
+            label="Mid-page CTAs"
+            showDebug={previewMode}
+            defaultPreset="secondary"
+          />
+        )}
+      </div>
     </div>
   );
 }

--- a/packages/champagne-sections/src/SectionRegistry.ts
+++ b/packages/champagne-sections/src/SectionRegistry.ts
@@ -1,24 +1,86 @@
 import type { ChampagnePageSection } from "@champagne/manifests";
-import { getSectionStackForPage } from "@champagne/manifests";
+import { getSectionStackForPage, getSectionStyle } from "@champagne/manifests";
 
 export interface SectionRegistryEntry {
   id: string;
   type?: string;
+  kind?: "text" | "media" | "features";
+  title?: string;
+  body?: string;
+  eyebrow?: string;
+  items?: string[];
+  mediaHint?: string;
   definition?: ChampagnePageSection | string;
+}
+
+function sentenceCase(input?: string) {
+  if (!input) return "";
+  return input
+    .replace(/[-_]/g, " ")
+    .split(" ")
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+function deriveKind(type?: string): SectionRegistryEntry["kind"] {
+  if (!type) return "text";
+  if (["text", "copy", "copy-block", "story", "faq", "accordion"].includes(type)) return "text";
+  if (["media", "gallery", "carousel", "map", "slider", "lab"].includes(type)) return "media";
+  if (["feature-grid", "steps", "features", "feature-list", "pricing"].includes(type)) return "features";
+  return "text";
+}
+
+function normalizeDefinition(section: ChampagnePageSection | string, pageSlug: string, index: number) {
+  const isString = typeof section === "string";
+  const sectionId = isString ? (section as string) : section.id ?? `${pageSlug}-section-${index}`;
+  const style = getSectionStyle(sectionId);
+  const rawType = isString ? style?.type : section.type ?? style?.type;
+  const kind = deriveKind(rawType);
+  const fallbackTitle = sentenceCase(sectionId || `Section ${index + 1}`);
+  const definition = isString ? {} : (section as ChampagnePageSection);
+  const title = (definition.title as string | undefined)
+    ?? (definition.label as string | undefined)
+    ?? fallbackTitle;
+  const body = (definition.copy as string | undefined)
+    ?? (definition.body as string | undefined)
+    ?? `Learn more about ${fallbackTitle.toLowerCase()} in this treatment overview.`;
+  const eyebrow = (definition.label as string | undefined)
+    ?? (definition.eyebrow as string | undefined)
+    ?? (kind === "features" ? "What to know" : "Treatment detail");
+  const items = Array.isArray(definition.items)
+    ? definition.items.map(String)
+    : kind === "features"
+      ? [
+          "Comfort-first planning and diagnostics",
+          "Technology-backed visual previews",
+          "Clear next steps and aftercare",
+        ]
+      : undefined;
+
+  return {
+    id: sectionId,
+    type: rawType,
+    kind,
+    title,
+    body,
+    eyebrow,
+    items,
+    mediaHint: (definition.mediaHint as string | undefined) ?? sentenceCase(style?.surface),
+    definition: {
+      ...definition,
+      id: sectionId,
+      type: rawType,
+      title,
+      copy: body,
+      label: eyebrow,
+      items,
+    },
+  } satisfies SectionRegistryEntry;
 }
 
 export function getSectionStack(pageSlug: string): SectionRegistryEntry[] {
   const rawSections = getSectionStackForPage(pageSlug) ?? [];
 
-  return rawSections.map((section, index) => {
-    if (typeof section === "string") {
-      return { id: section, definition: section };
-    }
-
-    return {
-      id: section.id ?? `${pageSlug}-section-${index}`,
-      type: section.type,
-      definition: section,
-    };
-  });
+  return rawSections.map((section, index) => normalizeDefinition(section, pageSlug, index));
 }

--- a/packages/champagne-sections/src/Section_FeatureList.tsx
+++ b/packages/champagne-sections/src/Section_FeatureList.tsx
@@ -62,13 +62,19 @@ const subtextStyle: CSSProperties = {
 
 export function Section_FeatureList({ section }: SectionFeatureListProps = {}) {
   const definition = (section?.definition as Record<string, unknown> | undefined) ?? {};
-  const features = (definition.items as string[] | undefined) ?? [
-    "Clinically precise planning with Champagne variable system",
-    "Soft-focus overlays to keep eyes on the smile story",
-    "Comfort-first spacing and rhythm across every breakpoint",
-  ];
-  const heading = (definition.title as string | undefined) ?? "Hallmarks of Champagne care";
-  const eyebrow = (definition.label as string | undefined) ?? "Treatment signatures";
+  const features = section?.items
+    ?? (definition.items as string[] | undefined)
+    ?? [
+      "Clinically precise planning with Champagne variable system",
+      "Soft-focus overlays to keep eyes on the smile story",
+      "Comfort-first spacing and rhythm across every breakpoint",
+    ];
+  const heading = section?.title
+    ?? (definition.title as string | undefined)
+    ?? "Hallmarks of Champagne care";
+  const eyebrow = section?.eyebrow
+    ?? (definition.label as string | undefined)
+    ?? "Treatment signatures";
 
   return (
     <section style={wrapperStyle}>

--- a/packages/champagne-sections/src/Section_MediaBlock.tsx
+++ b/packages/champagne-sections/src/Section_MediaBlock.tsx
@@ -62,10 +62,14 @@ const eyebrowStyle: CSSProperties = {
 
 export function Section_MediaBlock({ section }: SectionMediaBlockProps = {}) {
   const definition = (section?.definition as Record<string, unknown> | undefined) ?? {};
-  const headline = (definition.title as string | undefined)
+  const headline = section?.title
+    ?? (definition.title as string | undefined)
     ?? "Visual proof with Champagne clarity";
-  const eyebrow = (definition.label as string | undefined) ?? "Treatment media";
-  const caption = (definition.copy as string | undefined)
+  const eyebrow = section?.eyebrow
+    ?? (definition.label as string | undefined)
+    ?? "Treatment media";
+  const caption = section?.body
+    ?? (definition.copy as string | undefined)
     ?? "Media panels use ink/glass layering with soft-gold edges to keep imagery vivid without sacrificing contrast.";
 
   return (

--- a/packages/champagne-sections/src/Section_TextBlock.tsx
+++ b/packages/champagne-sections/src/Section_TextBlock.tsx
@@ -52,13 +52,16 @@ const bodyStyle: CSSProperties = {
 
 export function Section_TextBlock({ section }: SectionComponentProps = {}) {
   const definition = (section?.definition as Record<string, unknown> | undefined) ?? {};
-  const heading = (definition.title as string | undefined)
+  const heading = section?.title
+    ?? (definition.title as string | undefined)
     ?? (definition.headline as string | undefined)
     ?? "Precision-crafted smiles built on gentle engineering.";
-  const eyebrow = (definition.label as string | undefined)
+  const eyebrow = section?.eyebrow
+    ?? (definition.label as string | undefined)
     ?? (definition.eyebrow as string | undefined)
     ?? "Champagne narrative";
-  const copy = (definition.copy as string | undefined)
+  const copy = section?.body
+    ?? (definition.copy as string | undefined)
     ?? (definition.body as string | undefined)
     ?? "Every surface is tuned with Champagne tokens to keep contrast crisp, spacing breathable, and details soft-gold without overwhelming the eye.";
 


### PR DESCRIPTION
## Summary
- Wire treatment builder to derive hero copy, hero presets, and section stacks from manifest data with normalization helpers
- Update hero frame and section components to render structured treatment content with Champagne surface styling
- Polish the treatments index cards and document the treatment layout flow for future additions

## Testing
- pnpm lint
- pnpm build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693646ad949083328bf451040ce92547)