### PR TITLE
Add CTA package and wire manifest CTAs

### DIFF
--- a/apps/chat-ui/tsconfig.json
+++ b/apps/chat-ui/tsconfig.json
@@ -10,6 +10,14 @@
     "allowJs": true,
     "noEmit": true,
     "incremental": true,
+    "paths": {
+      "@champagne/tokens": ["../../packages/champagne-tokens/src"],
+      "@champagne/guards": ["../../packages/champagne-guards/src"],
+      "@champagne/manifests": ["../../packages/champagne-manifests/src"],
+      "@champagne/hero": ["../../packages/champagne-hero/src"],
+      "@champagne/sections": ["../../packages/champagne-sections/src"],
+      "@champagne/cta": ["../../packages/champagne-cta/src"]
+    },
     "plugins": [
       {
         "name": "next"

--- a/apps/portal/tsconfig.json
+++ b/apps/portal/tsconfig.json
@@ -10,6 +10,14 @@
     "allowJs": true,
     "noEmit": true,
     "incremental": true,
+    "paths": {
+      "@champagne/tokens": ["../../packages/champagne-tokens/src"],
+      "@champagne/guards": ["../../packages/champagne-guards/src"],
+      "@champagne/manifests": ["../../packages/champagne-manifests/src"],
+      "@champagne/hero": ["../../packages/champagne-hero/src"],
+      "@champagne/sections": ["../../packages/champagne-sections/src"],
+      "@champagne/cta": ["../../packages/champagne-cta/src"]
+    },
     "plugins": [
       {
         "name": "next"

--- a/apps/web/app/(champagne)/_builder/ChampagnePageBuilder.tsx
+++ b/apps/web/app/(champagne)/_builder/ChampagnePageBuilder.tsx
@@ -163,21 +163,17 @@ export function ChampagnePageBuilder({ slug, previewMode = false }: ChampagnePag
             <ChampagneCTAGroup
               ctas={heroCTAs}
               label="Hero CTAs"
-              defaultPreset="primary"
+              defaultVariant="primary"
               showDebug={previewMode}
             />
           )}
         </div>
-        <ChampagneSectionRenderer pageSlug={pagePath} midPageCTAs={midPageCTAs} previewMode={previewMode} />
-        {footerCTAs.length > 0 && (
-          <ChampagneCTAGroup
-            ctas={footerCTAs}
-            label="Footer CTAs"
-            direction="row"
-            defaultPreset="ghost"
-            showDebug={previewMode}
-          />
-        )}
+        <ChampagneSectionRenderer
+          pageSlug={pagePath}
+          midPageCTAs={midPageCTAs}
+          footerCTAs={footerCTAs}
+          previewMode={previewMode}
+        />
         {previewMode && (
           <DebugPanel
             path={pagePath}

--- a/apps/web/tailwind.config.cjs
+++ b/apps/web/tailwind.config.cjs
@@ -1,6 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
-  content: ["./app/**/*.{ts,tsx}"],
+  content: ["./app/**/*.{ts,tsx}", "../../packages/**/*.{ts,tsx}"],
   theme: {
     extend: {},
   },

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -10,6 +10,14 @@
     "allowJs": true,
     "noEmit": true,
     "incremental": true,
+    "paths": {
+      "@champagne/tokens": ["../../packages/champagne-tokens/src"],
+      "@champagne/guards": ["../../packages/champagne-guards/src"],
+      "@champagne/manifests": ["../../packages/champagne-manifests/src"],
+      "@champagne/hero": ["../../packages/champagne-hero/src"],
+      "@champagne/sections": ["../../packages/champagne-sections/src"],
+      "@champagne/cta": ["../../packages/champagne-cta/src"]
+    },
     "plugins": [
       {
         "name": "next"

--- a/packages/champagne-cta/package.json
+++ b/packages/champagne-cta/package.json
@@ -2,8 +2,9 @@
   "name": "@champagne/cta",
   "private": true,
   "version": "0.0.1",
-  "main": "src/index.ts",
-  "types": "src/index.ts",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "sideEffects": false,
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "lint": "eslint ."

--- a/packages/champagne-cta/src/ChampagneCTAButton.tsx
+++ b/packages/champagne-cta/src/ChampagneCTAButton.tsx
@@ -1,63 +1,42 @@
-import type { CSSProperties } from "react";
 import "@champagne/tokens";
-import type { ChampagneCTAConfig, CTAStylePreset } from "./types";
+import type { ChampagneCTAConfig, ChampagneCTAVariant } from "./types";
 
 export interface ChampagneCTAButtonProps {
   cta: ChampagneCTAConfig;
   align?: "start" | "center" | "end";
 }
 
-const baseButtonStyle: CSSProperties = {
-  display: "inline-flex",
-  alignItems: "center",
-  justifyContent: "center",
-  gap: "0.5rem",
-  padding: "0.85rem 1.4rem",
-  borderRadius: "var(--radius-md)",
-  border: "1px solid var(--champagne-keyline-gold, rgba(249, 232, 195, 0.55))",
-  color: "var(--text-high, #f6f7fb)",
-  textDecoration: "none",
-  letterSpacing: "0.01em",
-  fontWeight: 600,
-  fontSize: "1rem",
-  boxShadow: "0 14px 28px rgba(0,0,0,0.3)",
-  position: "relative",
-  overflow: "hidden",
+const baseButtonClasses =
+  "inline-flex items-center justify-center gap-2 rounded-md border px-4 py-3 font-semibold leading-none no-underline " +
+  "transition duration-200 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 tracking-tight";
+
+const alignClasses: Record<NonNullable<ChampagneCTAButtonProps["align"]>, string> = {
+  start: "self-start",
+  center: "self-center",
+  end: "self-end",
 };
 
-const presetStyles: Record<CTAStylePreset, CSSProperties> = {
-  primary: {
-    background: "linear-gradient(135deg, var(--smh-gradient, rgba(255,255,255,0.08)), color-mix(in srgb, var(--bg-ink, #06070c) 82%, transparent))",
-    borderColor: "var(--champagne-keyline-gold, rgba(249, 232, 195, 0.65))",
-  },
-  secondary: {
-    background: "color-mix(in srgb, var(--bg-ink-soft, #0c0f16) 85%, transparent)",
-    borderColor: "color-mix(in srgb, var(--champagne-keyline-gold, rgba(249, 232, 195, 0.35)) 70%, transparent)",
-  },
-  "luxury-gold": {
-    background: "linear-gradient(125deg, rgba(249,232,195,0.85), rgba(255,215,137,0.75))",
-    color: "var(--bg-ink, #06070c)",
-    borderColor: "rgba(255, 215, 137, 0.85)",
-    boxShadow: "0 18px 34px rgba(0,0,0,0.4)",
-  },
-  ghost: {
-    background: "transparent",
-    color: "var(--text-medium, rgba(245, 247, 251, 0.7))",
-    borderColor: "color-mix(in srgb, var(--champagne-keyline-gold, rgba(249, 232, 195, 0.4)) 55%, transparent)",
-    boxShadow: "none",
-  },
+const variantClasses: Record<ChampagneCTAVariant, string> = {
+  primary:
+    "glass-soft champagne-gradient text-[var(--bg-ink)] border-transparent shadow-md " +
+    "hover:opacity-95 focus-visible:outline-[color-mix(in_srgb,var(--brand-soft-gold)_60%,transparent)]",
+  secondary:
+    "glass-card text-[var(--text-high)] border-[color-mix(in_srgb,var(--champagne-keyline-gold)_55%,transparent)] " +
+    "hover:bg-[color-mix(in_srgb,var(--surface-glass)_70%,transparent)] " +
+    "focus-visible:outline-[color-mix(in_srgb,var(--brand-soft-gold)_45%,transparent)]",
+  ghost:
+    "bg-transparent text-[var(--text-medium)] border-[color-mix(in_srgb,var(--champagne-keyline-gold)_40%,transparent)] " +
+    "hover:border-[color-mix(in_srgb,var(--champagne-keyline-gold)_60%,transparent)] " +
+    "focus-visible:outline-[color-mix(in_srgb,var(--brand-soft-gold)_40%,transparent)]",
 };
 
 export function ChampagneCTAButton({ cta, align = "start" }: ChampagneCTAButtonProps) {
-  const presetStyle = presetStyles[cta.preset as CTAStylePreset] ?? presetStyles.ghost;
+  const variant: ChampagneCTAVariant = cta.variant ?? "ghost";
   return (
     <a
       href={cta.href}
-      style={{
-        ...baseButtonStyle,
-        ...presetStyle,
-        alignSelf: align === "center" ? "center" : align === "end" ? "flex-end" : "flex-start",
-      }}
+      data-variant={variant}
+      className={`${baseButtonClasses} ${variantClasses[variant]} ${alignClasses[align]}`}
     >
       <span>{cta.label}</span>
     </a>

--- a/packages/champagne-cta/src/ChampagneCTAGroup.tsx
+++ b/packages/champagne-cta/src/ChampagneCTAGroup.tsx
@@ -1,30 +1,27 @@
-import { Fragment } from "react";
-import type { ChampagneCTAConfig, CTAReference, CTAStylePreset } from "./types";
+import type { ChampagneCTAConfig, ChampagneCTAInput, ChampagneCTAVariant } from "./types";
 import { ChampagneCTAButton } from "./ChampagneCTAButton";
 import { resolveCTAList } from "./CTARegistry";
 
 export interface ChampagneCTAGroupProps {
-  ctas?: (ChampagneCTAConfig | CTAReference)[];
+  ctas?: (ChampagneCTAConfig | ChampagneCTAInput)[];
   align?: "start" | "center" | "end";
   direction?: "row" | "column";
   gap?: string;
   showDebug?: boolean;
   label?: string;
-  defaultPreset?: CTAStylePreset;
+  defaultVariant?: ChampagneCTAVariant;
 }
 
-function normalizeCTAs(
-  ctas: (ChampagneCTAConfig | CTAReference)[] = [],
-  defaultPreset: CTAStylePreset = "ghost",
-): ChampagneCTAConfig[] {
-  const resolved = ctas.map((cta) => {
-    if (typeof cta === "string") return cta;
-    if ((cta as ChampagneCTAConfig).href && (cta as ChampagneCTAConfig).label) return cta as ChampagneCTAConfig;
-    return cta;
-  });
+const directionClasses: Record<NonNullable<ChampagneCTAGroupProps["direction"]>, string> = {
+  row: "flex-row flex-wrap",
+  column: "flex-col",
+};
 
-  return resolveCTAList(resolved, defaultPreset);
-}
+const alignClasses: Record<NonNullable<ChampagneCTAGroupProps["align"]>, string> = {
+  start: "items-start",
+  center: "items-center",
+  end: "items-end",
+};
 
 export function ChampagneCTAGroup({
   ctas,
@@ -33,61 +30,34 @@ export function ChampagneCTAGroup({
   gap = "0.75rem",
   showDebug = false,
   label,
-  defaultPreset = "ghost",
+  defaultVariant = "ghost",
 }: ChampagneCTAGroupProps) {
-  const resolved = normalizeCTAs(ctas, defaultPreset);
+  const resolved = resolveCTAList(ctas ?? [], defaultVariant);
   if (resolved.length === 0) return null;
 
   return (
-    <div
-      style={{
-        display: "grid",
-        gap: "0.4rem",
-        padding: "0.2rem",
-      }}
-    >
+    <div className="grid gap-2">
       {label && (
-        <div style={{
-          textTransform: "uppercase",
-          letterSpacing: "0.08em",
-          fontSize: "0.78rem",
-          color: "var(--text-medium, rgba(255,255,255,0.7))",
-        }}>
+        <div className="text-[0.78rem] uppercase tracking-[0.08em] text-[var(--text-medium)]">
           {label}
         </div>
       )}
       <div
-        style={{
-          display: "flex",
-          flexDirection: direction,
-          gap,
-          flexWrap: direction === "row" ? "wrap" : undefined,
-          alignItems: align === "center" ? "center" : align === "end" ? "flex-end" : "flex-start",
-        }}
+        className={`flex ${directionClasses[direction]} ${alignClasses[align]} justify-start`}
+        style={{ gap }}
       >
         {resolved.map((cta) => (
           <ChampagneCTAButton key={cta.id} cta={cta} align={align} />
         ))}
       </div>
       {showDebug && (
-        <div
-          style={{
-            fontSize: "0.82rem",
-            color: "var(--text-medium, rgba(255,255,255,0.74))",
-            border: "1px dashed color-mix(in srgb, var(--champagne-keyline-gold, #f9e8c3) 45%, transparent)",
-            borderRadius: "var(--radius-sm)",
-            padding: "0.5rem 0.6rem",
-            background: "color-mix(in srgb, var(--bg-ink-soft, #0c0f16) 45%, transparent)",
-          }}
-        >
-          <div style={{ opacity: 0.85 }}>CTA slot debug ({resolved.length})</div>
-          <ul style={{ margin: "0.25rem 0 0", paddingLeft: "1.05rem", display: "grid", gap: "0.15rem" }}>
+        <div className="grid gap-1 rounded-md border border-dashed border-[color-mix(in_srgb,var(--champagne-keyline-gold)_45%,transparent)] bg-[color-mix(in_srgb,var(--bg-ink-soft)_35%,transparent)] p-2 text-[0.85rem] text-[var(--text-medium)]">
+          <div className="opacity-80">CTA slot debug ({resolved.length})</div>
+          <ul className="m-0 list-disc space-y-1 pl-4">
             {resolved.map((cta) => (
-              <Fragment key={`${cta.id}-${cta.href}`}>
-                <li>
-                  <strong>{cta.label}</strong> → {cta.href} ({cta.preset ?? "ghost"})
-                </li>
-              </Fragment>
+              <li key={`${cta.id}-${cta.href}`} className="leading-snug">
+                <strong>{cta.label}</strong> → {cta.href} ({cta.variant ?? "ghost"})
+              </li>
             ))}
           </ul>
         </div>

--- a/packages/champagne-cta/src/index.ts
+++ b/packages/champagne-cta/src/index.ts
@@ -5,7 +5,5 @@ export {
   registerCTA,
   resolveCTA,
   resolveCTAList,
-  type CTAStylePreset,
-  type ChampagneCTAConfig,
-  type CTAReference,
 } from "./CTARegistry";
+export type { ChampagneCTAConfig, ChampagneCTAInput, ChampagneCTAVariant } from "./types";

--- a/packages/champagne-cta/src/types.ts
+++ b/packages/champagne-cta/src/types.ts
@@ -1,12 +1,13 @@
-export type CTAStylePreset = "primary" | "secondary" | "luxury-gold" | "ghost" | (string & {});
+export type ChampagneCTAVariant = "primary" | "secondary" | "ghost";
 
 export interface ChampagneCTAConfig {
   id: string;
   label: string;
   href: string;
-  preset?: CTAStylePreset;
-  description?: string;
-  [key: string]: unknown;
+  variant?: ChampagneCTAVariant;
 }
 
-export type CTAReference = string | Partial<ChampagneCTAConfig>;
+export type ChampagneCTAInput =
+  | string
+  | ChampagneCTAConfig
+  | ({ preset?: string } & Partial<ChampagneCTAConfig>);

--- a/packages/champagne-sections/src/SectionRegistry.ts
+++ b/packages/champagne-sections/src/SectionRegistry.ts
@@ -28,7 +28,7 @@ export interface SectionRegistryEntry {
   attribution?: string;
   role?: string;
   strapline?: string;
-  ctas?: { label: string; href?: string; preset?: string }[];
+  ctas?: { id?: string; label?: string; href?: string; preset?: string; variant?: string }[];
   definition?: ChampagnePageSection | string;
 }
 
@@ -132,9 +132,11 @@ function normalizeDefinition(section: ChampagnePageSection | string, pageSlug: s
       }))
     : undefined;
   const ctas = Array.isArray((definition as Record<string, unknown>).ctas)
-    ? ((definition as Record<string, unknown>).ctas as Record<string, unknown>[]).map((cta) => ({
+    ? ((definition as Record<string, unknown>).ctas as Record<string, unknown>[]).map((cta, ctaIndex) => ({
+        id: (cta.id as string | undefined) ?? `${sectionId}-cta-${ctaIndex + 1}`,
         label: (cta.label as string | undefined) ?? (cta.title as string | undefined) ?? "Continue",
         href: (cta.href as string | undefined) ?? (cta.link as string | undefined),
+        variant: (cta.variant as string | undefined) ?? (cta.preset as string | undefined) ?? (cta.tone as string | undefined),
         preset: (cta.preset as string | undefined) ?? (cta.tone as string | undefined),
       }))
     : undefined;

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -4,6 +4,15 @@
     "module": "ESNext",
     "moduleResolution": "bundler",
     "jsx": "preserve",
+    "baseUrl": ".",
+    "paths": {
+      "@champagne/tokens": ["packages/champagne-tokens/src"],
+      "@champagne/guards": ["packages/champagne-guards/src"],
+      "@champagne/manifests": ["packages/champagne-manifests/src"],
+      "@champagne/hero": ["packages/champagne-hero/src"],
+      "@champagne/sections": ["packages/champagne-sections/src"],
+      "@champagne/cta": ["packages/champagne-cta/src"]
+    },
     "strict": true,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
## Summary
- create the @champagne/cta workspace with typed configs, CTA buttons/groups, and registry helpers
- route treatment CTA rendering through the CTA package, including manifest-driven closing CTAs and footer slots
- update TypeScript/Tailwind configs so @champagne/* imports (including the new CTA package) resolve and build correctly
- future CTA follow-ups: consider header/footer CTA placements, richer manifest CTA metadata, and consistent CTA usage on non-treatment pages

## Testing
- npm run lint
- CI=1 npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69365b27aaf483329675700e7c527b63)