### PR TITLE
Add manifest-driven navigation and stub blog route

### DIFF
--- a/apps/web/app/_components/Header.tsx
+++ b/apps/web/app/_components/Header.tsx
@@ -1,14 +1,9 @@
+import { getMainNavItems } from "@champagne/manifests";
 import Link from "next/link";
 
-const navLinks = [
-  { href: "/", label: "Home" },
-  { href: "/treatments", label: "Treatments" },
-  { href: "/team", label: "Team" },
-  { href: "/contact", label: "Contact" },
-  { href: "/patient-portal", label: "Patient Portal" },
-];
-
 export function Header() {
+  const navItems = getMainNavItems();
+
   return (
     <header className="border-b border-neutral-800 bg-neutral-900/50">
       <div className="mx-auto flex max-w-5xl items-center justify-between px-6 py-4">
@@ -16,13 +11,13 @@ export function Header() {
           St Mary&apos;s House Dental
         </Link>
         <nav className="flex items-center gap-4 text-sm text-neutral-200">
-          {navLinks.map((link) => (
+          {navItems.map((item) => (
             <Link
-              key={link.href}
-              href={link.href}
+              key={item.href}
+              href={item.href}
               className="rounded px-2 py-1 transition hover:bg-neutral-800 hover:text-neutral-50"
             >
-              {link.label}
+              {item.label}
             </Link>
           ))}
         </nav>

--- a/apps/web/app/blog/page.tsx
+++ b/apps/web/app/blog/page.tsx
@@ -1,0 +1,10 @@
+export default function BlogPage() {
+  return (
+    <div className="mx-auto flex max-w-4xl flex-col gap-4">
+      <h1 className="text-3xl font-semibold text-neutral-50">Blog</h1>
+      <p className="text-neutral-300">
+        This page will soon be upgraded to the full Champagne experience. Content is placeholder only.
+      </p>
+    </div>
+  );
+}

--- a/packages/champagne-manifests/data/manifest.nav.main.json
+++ b/packages/champagne-manifests/data/manifest.nav.main.json
@@ -1,0 +1,11 @@
+{
+  "items": [
+    { "id": "home", "label": "Home", "href": "/", "priority": 1 },
+    { "id": "treatments", "label": "Treatments", "href": "/treatments", "priority": 2 },
+    { "id": "team", "label": "Team", "href": "/team", "priority": 3 },
+    { "id": "smile-gallery", "label": "Smile gallery", "href": "/smile-gallery", "priority": 4 },
+    { "id": "blog", "label": "Blog", "href": "/blog", "priority": 5, "status": "stub" },
+    { "id": "contact", "label": "Contact", "href": "/contact", "priority": 6 },
+    { "id": "patient-portal", "label": "Patient portal", "href": "/patient-portal", "priority": 7 }
+  ]
+}

--- a/packages/champagne-manifests/reports/page-canon-map.md
+++ b/packages/champagne-manifests/reports/page-canon-map.md
@@ -1,0 +1,12 @@
+# Page Canon Map (Non-Treatment)
+
+| Slug | Title | Hero preset? | Section stack? | Route status |
+| --- | --- | --- | --- | --- |
+| / | Home | Yes | Yes | Present via `/page.tsx` |
+| /smile-gallery | Smile Gallery | Yes | Yes | Present via `(champagne)/smile-gallery` |
+| /about | About | Yes | Yes | Present via `(champagne)/about` |
+| /contact | Contact | Yes | Yes | Present via `/contact/page.tsx` |
+| /legal/privacy | Privacy Policy | Yes | Yes | Present via `(champagne)/legal/privacy` |
+
+## Notes
+- No additional non-treatment manifest entries are currently missing routes. TODO list remains empty.

--- a/packages/champagne-manifests/src/core.ts
+++ b/packages/champagne-manifests/src/core.ts
@@ -1,4 +1,5 @@
 import machineManifestData from "../data/champagne_machine_manifest_full.json";
+import navManifestData from "../data/manifest.nav.main.json";
 import publicBrandManifest from "../data/manifest.public.brand.json";
 import stylesManifest from "../data/manifest.styles.champagne.json";
 import manusImportManifest from "../data/manus_import_unified_manifest_20251104.json";
@@ -63,8 +64,28 @@ export interface ChampagneStylesManifest {
   [key: string]: unknown;
 }
 
+export interface NavItem {
+  id: string;
+  label: string;
+  href: string;
+  priority?: number;
+  status?: "live" | "stub";
+}
+
+export interface ChampagneNavigationManifest {
+  items?: NavItem[];
+  [key: string]: unknown;
+}
+
 const champagneMachineManifest: ChampagneMachineManifest = machineManifestData;
 const champagneStylesManifest: ChampagneStylesManifest = stylesManifest;
+const champagneNavigationManifest: ChampagneNavigationManifest = {
+  ...navManifestData,
+  items: (navManifestData.items ?? []).map((item) => ({
+    ...item,
+    status: item.status === "stub" ? "stub" : item.status === "live" ? "live" : undefined,
+  })),
+};
 
 const registry: ChampagneManifestRegistry = {
   core: champagneMachineManifest,
@@ -99,6 +120,16 @@ const pageCollections = [
   champagneMachineManifest.pages ?? {},
   champagneMachineManifest.treatments ?? {},
 ];
+
+export function getMainNavItems(): NavItem[] {
+  const items = champagneNavigationManifest.items ?? [];
+  return [...items].sort((a, b) => {
+    const priorityA = a.priority ?? Number.MAX_SAFE_INTEGER;
+    const priorityB = b.priority ?? Number.MAX_SAFE_INTEGER;
+    if (priorityA !== priorityB) return priorityA - priorityB;
+    return a.label.localeCompare(b.label);
+  });
+}
 
 export function getPageManifestBySlug(slug: string): ChampagnePageManifest | undefined {
   for (const collection of pageCollections) {

--- a/packages/champagne-manifests/src/index.ts
+++ b/packages/champagne-manifests/src/index.ts
@@ -7,6 +7,7 @@ export {
   getPageManifestBySlug,
   getHeroPresetForPage,
   getSectionStackForPage,
+  getMainNavItems,
   type ChampagneCTA,
   type ChampagnePageCTAConfig,
   type ChampagneMachineManifest,
@@ -15,6 +16,7 @@ export {
   type ChampagnePageManifest,
   type ChampagnePageSection,
   type ChampagneStylesManifest,
+  type NavItem,
 } from "./core";
 
 export {


### PR DESCRIPTION
## Summary
- add a main navigation manifest plus helper exports from @champagne/manifests
- wire the app header to read nav items from the manifest and add a placeholder blog page
- document current non-treatment page canon in a new report file

## Testing
- npm run lint
- CI=1 npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693660254c708332b62be63b936c37cd)