### PR TITLE
Align non-treatment pages with Champagne manifests

### DIFF
--- a/apps/web/app/(champagne)/smile-gallery/page.tsx
+++ b/apps/web/app/(champagne)/smile-gallery/page.tsx
@@ -1,12 +1,5 @@
-import { ChampagneHeroFrame, getHeroBySlug } from "@champagne/hero";
-import { ChampagneSectionRenderer } from "@champagne/sections";
+import ChampagnePageBuilder from "../_builder/ChampagnePageBuilder";
 
 export default function Page() {
-  const hero = getHeroBySlug("/smile-gallery");
-  return (
-    <main className="space-y-8">
-      <ChampagneHeroFrame heroId={hero.id} headline={hero.label ?? "Smile gallery surface"} />
-      <ChampagneSectionRenderer pageSlug="/smile-gallery" />
-    </main>
-  );
+  return <ChampagnePageBuilder slug="/smile-gallery" />;
 }

--- a/apps/web/app/blog/page.tsx
+++ b/apps/web/app/blog/page.tsx
@@ -1,10 +1,5 @@
+import ChampagnePageBuilder from "../(champagne)/_builder/ChampagnePageBuilder";
+
 export default function BlogPage() {
-  return (
-    <div className="mx-auto flex max-w-4xl flex-col gap-4">
-      <h1 className="text-3xl font-semibold text-neutral-50">Blog</h1>
-      <p className="text-neutral-300">
-        This page will soon be upgraded to the full Champagne experience. Content is placeholder only.
-      </p>
-    </div>
-  );
+  return <ChampagnePageBuilder slug="/blog" />;
 }

--- a/apps/web/app/contact/page.tsx
+++ b/apps/web/app/contact/page.tsx
@@ -1,16 +1,5 @@
+import ChampagnePageBuilder from "../(champagne)/_builder/ChampagnePageBuilder";
+
 export default function ContactPage() {
-  return (
-    <div className="mx-auto flex max-w-4xl flex-col gap-4">
-      <h1 className="text-3xl font-semibold text-neutral-50">Contact the practice</h1>
-      <p className="text-neutral-300">
-        We&apos;re setting up the official contact channels for the new site. Soon you&apos;ll be able to submit enquiries,
-        request appointments, and reach the team directly through the Champagne Ecosystem tools.
-      </p>
-      <ul className="list-disc space-y-2 pl-6 text-neutral-300">
-        <li>Dedicated phone and email links for rapid replies</li>
-        <li>Secure messaging for patient questions</li>
-        <li>Directions and parking information for your visit</li>
-      </ul>
-    </div>
-  );
+  return <ChampagnePageBuilder slug="/contact" />;
 }

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,57 +1,5 @@
-import Link from "next/link";
-
-const quickLinks = [
-  {
-    title: "Treatments",
-    description: "Explore the full range of restorative and cosmetic care we offer.",
-    href: "/treatments",
-  },
-  {
-    title: "Patient stories",
-    description: "Hear how we support patients on their journey (coming soon).",
-    href: "#",
-  },
-  {
-    title: "Patient portal",
-    description: "Manage appointments, forms, and communication in one place.",
-    href: "/patient-portal",
-  },
-];
+import ChampagnePageBuilder from "./(champagne)/_builder/ChampagnePageBuilder";
 
 export default function Page() {
-  return (
-    <div className="mx-auto flex max-w-5xl flex-col gap-12">
-      <section className="space-y-4">
-        <p className="text-sm uppercase tracking-[0.2em] text-neutral-400">St Mary&apos;s House Dental</p>
-        <h1 className="text-4xl font-semibold tracking-tight text-neutral-50 sm:text-5xl">
-          High-quality dental care in a calm, modern setting.
-        </h1>
-        <p className="max-w-2xl text-lg text-neutral-300">
-          This neutral shell previews the future Champagne Ecosystem site for St Mary&apos;s House Dental.
-          Everything here is placeholder content while we prepare the full experience.
-        </p>
-      </section>
-
-      <section className="space-y-6">
-        <h2 className="text-2xl font-semibold text-neutral-50">Quick links</h2>
-        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-          {quickLinks.map((link) => (
-            <Link
-              key={link.title}
-              href={link.href}
-              className="group rounded-lg border border-neutral-800 bg-neutral-900/40 p-5 transition hover:border-neutral-700 hover:bg-neutral-900"
-            >
-              <div className="flex items-center justify-between gap-3">
-                <div>
-                  <p className="text-lg font-semibold text-neutral-50">{link.title}</p>
-                  <p className="text-sm text-neutral-300">{link.description}</p>
-                </div>
-                <span className="text-neutral-500 transition group-hover:text-neutral-200">→</span>
-              </div>
-            </Link>
-          ))}
-        </div>
-      </section>
-    </div>
-  );
+  return <ChampagnePageBuilder slug="/" />;
 }

--- a/apps/web/app/patient-portal/page.tsx
+++ b/apps/web/app/patient-portal/page.tsx
@@ -1,16 +1,5 @@
+import ChampagnePageBuilder from "../(champagne)/_builder/ChampagnePageBuilder";
+
 export default function PatientPortalPage() {
-  return (
-    <div className="mx-auto flex max-w-4xl flex-col gap-4">
-      <h1 className="text-3xl font-semibold text-neutral-50">Patient portal</h1>
-      <p className="text-neutral-300">
-        The patient portal will become your hub for appointments, treatment plans, and forms. This placeholder page
-        previews how St Mary&apos;s House Dental will connect through the Champagne Ecosystem.
-      </p>
-      <ul className="list-disc space-y-2 pl-6 text-neutral-300">
-        <li>Online booking and reminders</li>
-        <li>Secure document sharing and consent forms</li>
-        <li>Updates on treatment progress</li>
-      </ul>
-    </div>
-  );
+  return <ChampagnePageBuilder slug="/patient-portal" />;
 }

--- a/apps/web/app/team/page.tsx
+++ b/apps/web/app/team/page.tsx
@@ -1,16 +1,5 @@
+import ChampagnePageBuilder from "../(champagne)/_builder/ChampagnePageBuilder";
+
 export default function TeamPage() {
-  return (
-    <div className="mx-auto flex max-w-4xl flex-col gap-4">
-      <h1 className="text-3xl font-semibold text-neutral-50">Meet the team</h1>
-      <p className="text-neutral-300">
-        Our clinical team profile pages are coming soon. Expect introductions to the dentists, hygienists, and support
-        staff who care for every patient at St Mary&apos;s House Dental.
-      </p>
-      <ul className="list-disc space-y-2 pl-6 text-neutral-300">
-        <li>Backgrounds and qualifications for each clinician</li>
-        <li>Photos and short bios to help patients feel welcome</li>
-        <li>Contact options for booking or follow-up questions</li>
-      </ul>
-    </div>
-  );
+  return <ChampagnePageBuilder slug="/team" />;
 }

--- a/packages/champagne-manifests/data/champagne_machine_manifest_full.json
+++ b/packages/champagne-manifests/data/champagne_machine_manifest_full.json
@@ -9,27 +9,35 @@
       "label": "Home",
       "path": "/",
       "category": "hub",
-      "hero": "sacred_home_hero_v1",
+      "hero": "home_neutral_hero_v1",
       "sections": [
         {
-          "id": "intro_story_walk",
-          "type": "story"
+          "id": "home_intro_positioning",
+          "type": "copy-block",
+          "title": "Calm, modern care with Champagne surfaces",
+          "copy": "A neutral welcome while the full Champagne experience is prepared. Every section here is a placeholder scaffold for the future home layout.",
+          "label": "Welcome"
         },
         {
-          "id": "treatment_highlights",
-          "type": "grid"
+          "id": "home_care_highlights",
+          "type": "feature-list",
+          "title": "Key care highlights",
+          "items": [
+            "Comfort-led visits and clear explanations",
+            "Modern diagnostics with balanced aesthetics",
+            "Transparent next steps for every patient"
+          ],
+          "label": "Highlights"
         },
         {
-          "id": "ai_smile_atelier",
-          "type": "lab"
-        },
-        {
-          "id": "reviews_radiance",
-          "type": "social-proof"
-        },
-        {
-          "id": "cta_gold_bar",
-          "type": "cta"
+          "id": "home_get_started_band",
+          "type": "cta",
+          "title": "Ways to get started",
+          "ctas": [
+            { "label": "Explore treatments", "href": "/treatments", "preset": "primary" },
+            { "label": "Plan a visit", "href": "/contact", "preset": "secondary" }
+          ],
+          "label": "Get started"
         }
       ],
       "surface": "champagne/surface/home"
@@ -195,22 +203,36 @@
     },
     "smile_gallery": {
       "id": "smile_gallery",
-      "label": "Smile Gallery",
+      "label": "Smile gallery",
       "path": "/smile-gallery",
       "category": "editorial",
-      "hero": "gallery_showcase_hero",
+      "hero": "smile_gallery_placeholder_hero",
       "sections": [
         {
-          "id": "gallery_grid",
-          "type": "gallery"
+          "id": "smile_gallery_intro_copy",
+          "type": "copy-block",
+          "title": "Smile transformations, simplified",
+          "copy": "This gallery will showcase restorative and cosmetic journeys once assets are ready. For now, it outlines the structure for future case stories.",
+          "label": "Overview"
         },
         {
-          "id": "testimonial_slider",
-          "type": "slider"
+          "id": "smile_gallery_cases_overview",
+          "type": "copy-block",
+          "title": "Cases overview",
+          "copy": "Each case will pair concise context with before-and-after frames. Categories below preview how the gallery will be organized.",
+          "label": "Cases"
         },
         {
-          "id": "cta_gold_bar",
-          "type": "cta"
+          "id": "smile_gallery_case_categories",
+          "type": "feature-list",
+          "title": "Case categories",
+          "items": [
+            "Everyday smile refresh",
+            "Full smile rehabilitation",
+            "Implant-supported transformations",
+            "Aligner-guided straightening"
+          ],
+          "label": "Categories"
         }
       ],
       "surface": "champagne/surface/editorial"
@@ -241,24 +263,78 @@
       ],
       "surface": "champagne/surface/hub"
     },
+    "team": {
+      "id": "team",
+      "label": "Team",
+      "path": "/team",
+      "category": "hub",
+      "hero": "team_preview_hero_v1",
+      "sections": [
+        {
+          "id": "team_intro_copy",
+          "type": "copy-block",
+          "title": "Meet the clinical team",
+          "copy": "Profiles and credentials will sit here soon. This placeholder keeps space for a welcoming introduction and future team spotlights.",
+          "label": "Team"
+        },
+        {
+          "id": "team_grid_placeholder",
+          "type": "feature-grid",
+          "title": "Team members",
+          "items": [
+            "Clinical leads — bios in progress",
+            "Hygiene and therapy — caring guides",
+            "Support staff — coordinating each visit"
+          ],
+          "label": "Team grid"
+        },
+        {
+          "id": "team_connection_cta",
+          "type": "cta",
+          "title": "Connect with the team",
+          "ctas": [
+            { "label": "Plan a visit", "href": "/contact", "preset": "primary" },
+            { "label": "Patient portal", "href": "/patient-portal", "preset": "secondary" }
+          ],
+          "label": "Connection"
+        }
+      ],
+      "surface": "champagne/surface/hub"
+    },
     "contact": {
       "id": "contact",
       "label": "Contact",
       "path": "/contact",
       "category": "utility",
-      "hero": "contact_friendly_hero",
+      "hero": "contact_calm_hero_v1",
       "sections": [
         {
-          "id": "contact_details",
-          "type": "contact"
+          "id": "contact_intro_copy",
+          "type": "copy-block",
+          "title": "How to reach us",
+          "copy": "We are setting up the refreshed contact channels. Use these placeholders as a guide until the live communication tools are connected.",
+          "label": "Contact"
         },
         {
-          "id": "map_embed",
-          "type": "map"
+          "id": "contact_details_simple",
+          "type": "feature-list",
+          "title": "Practice details",
+          "items": [
+            "Direct phone and email links will be published here",
+            "Location, parking, and access notes stay front and center",
+            "Secure messaging will route through the portal"
+          ],
+          "label": "Details"
         },
         {
-          "id": "cta_gold_bar",
-          "type": "cta"
+          "id": "contact_followup_cta",
+          "type": "cta",
+          "title": "Plan a visit",
+          "ctas": [
+            { "label": "Request a call back", "href": "/patient-portal", "preset": "primary" },
+            { "label": "Message the team", "href": "/contact", "preset": "secondary" }
+          ],
+          "label": "Next steps"
         }
       ],
       "surface": "champagne/surface/utility"
@@ -280,6 +356,72 @@
         }
       ],
       "surface": "champagne/surface/legal"
+    },
+    "blog": {
+      "id": "blog",
+      "label": "Blog",
+      "path": "/blog",
+      "category": "editorial",
+      "hero": "blog_intro_hero_v1",
+      "sections": [
+        {
+          "id": "blog_intro_copy",
+          "type": "copy-block",
+          "title": "Practice insights",
+          "copy": "Stories and updates will publish here once the content calendar is live. This space holds the layout for future articles.",
+          "label": "Insights"
+        },
+        {
+          "id": "blog_placeholder_features",
+          "type": "feature-list",
+          "title": "Latest insights (coming soon)",
+          "items": [
+            "Clinical updates and technology notes",
+            "Preventive tips from the team",
+            "Practice news and patient experience stories"
+          ],
+          "label": "Coming soon"
+        }
+      ],
+      "surface": "champagne/surface/editorial"
+    },
+    "patient_portal": {
+      "id": "patient_portal",
+      "label": "Patient portal",
+      "path": "/patient-portal",
+      "category": "utility",
+      "hero": "patient_portal_placeholder_hero",
+      "sections": [
+        {
+          "id": "patient_portal_intro_copy",
+          "type": "copy-block",
+          "title": "Secure access for patients",
+          "copy": "The portal will bring together appointments, forms, and updates. Until it is live, this placeholder outlines the planned experience.",
+          "label": "Portal"
+        },
+        {
+          "id": "patient_portal_features",
+          "type": "feature-list",
+          "title": "What to expect",
+          "items": [
+            "Encrypted access to appointments and records",
+            "Secure document sharing and forms",
+            "Progress updates and follow-up reminders"
+          ],
+          "label": "Features"
+        },
+        {
+          "id": "patient_portal_cta_band",
+          "type": "cta",
+          "title": "Check back soon",
+          "ctas": [
+            { "label": "Portal status", "href": "/patient-portal", "preset": "primary" },
+            { "label": "Contact the team", "href": "/contact", "preset": "secondary" }
+          ],
+          "label": "CTA"
+        }
+      ],
+      "surface": "champagne/surface/utility"
     },
     "implants_single_tooth": {
       "id": "implants_single_tooth",

--- a/packages/champagne-manifests/data/manifest.styles.champagne.json
+++ b/packages/champagne-manifests/data/manifest.styles.champagne.json
@@ -8,6 +8,11 @@
       "motion": "calm",
       "cta": "book_home_eval"
     },
+    "home_neutral_hero_v1": {
+      "palette": "champagne",
+      "motion": "calm",
+      "cta": "explore-site"
+    },
     "implants_variant_hero_v3": {
       "palette": "platinum",
       "motion": "precision",
@@ -28,20 +33,45 @@
       "motion": "steady",
       "cta": "view_gallery"
     },
+    "smile_gallery_placeholder_hero": {
+      "palette": "glass",
+      "motion": "calm",
+      "cta": "view-gallery"
+    },
     "about_story_hero_v1": {
       "palette": "champagne",
       "motion": "calm",
       "cta": "meet_team"
+    },
+    "team_preview_hero_v1": {
+      "palette": "champagne",
+      "motion": "steady",
+      "cta": "meet-team"
     },
     "contact_friendly_hero": {
       "palette": "fresh",
       "motion": "float",
       "cta": "contact_us"
     },
+    "contact_calm_hero_v1": {
+      "palette": "platinum",
+      "motion": "calm",
+      "cta": "plan-visit"
+    },
     "legal_simple_banner": {
       "palette": "linen",
       "motion": "static",
       "cta": "scroll"
+    },
+    "blog_intro_hero_v1": {
+      "palette": "champagne",
+      "motion": "steady",
+      "cta": "read-more"
+    },
+    "patient_portal_placeholder_hero": {
+      "palette": "glass",
+      "motion": "calm",
+      "cta": "portal-status"
     },
     "treatment_neutral_hero_v1": {
       "palette": "champagne",
@@ -115,21 +145,17 @@
     }
   },
   "sections": {
-    "intro_story_walk": {
-      "type": "story",
+    "home_intro_positioning": {
+      "type": "copy-block",
       "surface": "champagne/surface/home"
     },
-    "treatment_highlights": {
-      "type": "grid",
+    "home_care_highlights": {
+      "type": "feature-list",
       "surface": "champagne/surface/home"
     },
-    "ai_smile_atelier": {
-      "type": "lab",
-      "surface": "champagne/surface/home"
-    },
-    "reviews_radiance": {
-      "type": "social-proof",
-      "surface": "champagne/surface/home"
+    "home_get_started_band": {
+      "type": "cta",
+      "surface": "champagne/surface/base"
     },
     "cta_gold_bar": {
       "type": "cta",
@@ -175,12 +201,16 @@
       "type": "faq",
       "surface": "champagne/surface/treatment"
     },
-    "gallery_grid": {
-      "type": "gallery",
+    "smile_gallery_intro_copy": {
+      "type": "copy-block",
       "surface": "champagne/surface/editorial"
     },
-    "testimonial_slider": {
-      "type": "slider",
+    "smile_gallery_cases_overview": {
+      "type": "copy-block",
+      "surface": "champagne/surface/editorial"
+    },
+    "smile_gallery_case_categories": {
+      "type": "feature-list",
       "surface": "champagne/surface/editorial"
     },
     "about_story": {
@@ -195,12 +225,28 @@
       "type": "feature-grid",
       "surface": "champagne/surface/hub"
     },
-    "contact_details": {
-      "type": "contact",
+    "team_intro_copy": {
+      "type": "copy-block",
+      "surface": "champagne/surface/hub"
+    },
+    "team_grid_placeholder": {
+      "type": "feature-grid",
+      "surface": "champagne/surface/hub"
+    },
+    "team_connection_cta": {
+      "type": "cta",
+      "surface": "champagne/surface/hub"
+    },
+    "contact_intro_copy": {
+      "type": "copy-block",
       "surface": "champagne/surface/utility"
     },
-    "map_embed": {
-      "type": "map",
+    "contact_details_simple": {
+      "type": "feature-list",
+      "surface": "champagne/surface/utility"
+    },
+    "contact_followup_cta": {
+      "type": "cta",
       "surface": "champagne/surface/utility"
     },
     "legal_intro": {
@@ -210,6 +256,26 @@
     "legal_terms": {
       "type": "accordion",
       "surface": "champagne/surface/legal"
+    },
+    "blog_intro_copy": {
+      "type": "copy-block",
+      "surface": "champagne/surface/editorial"
+    },
+    "blog_placeholder_features": {
+      "type": "feature-list",
+      "surface": "champagne/surface/editorial"
+    },
+    "patient_portal_intro_copy": {
+      "type": "copy-block",
+      "surface": "champagne/surface/utility"
+    },
+    "patient_portal_features": {
+      "type": "feature-list",
+      "surface": "champagne/surface/utility"
+    },
+    "patient_portal_cta_band": {
+      "type": "cta",
+      "surface": "champagne/surface/utility"
     },
     "treatment_overview_copy": {
       "type": "copy-block",

--- a/packages/champagne-manifests/data/manus_import_unified_manifest_20251104.json
+++ b/packages/champagne-manifests/data/manus_import_unified_manifest_20251104.json
@@ -5,13 +5,11 @@
   "routes": [
     {
       "slug": "/",
-      "hero": "sacred_home_hero_v1",
+      "hero": "home_neutral_hero_v1",
       "sections": [
-        "intro_story_walk",
-        "treatment_highlights",
-        "ai_smile_atelier",
-        "reviews_radiance",
-        "cta_gold_bar"
+        "home_intro_positioning",
+        "home_care_highlights",
+        "home_get_started_band"
       ],
       "category": "hub"
     },
@@ -167,11 +165,11 @@
     },
     {
       "slug": "/smile-gallery",
-      "hero": "gallery_showcase_hero",
+      "hero": "smile_gallery_placeholder_hero",
       "sections": [
-        "gallery_grid",
-        "testimonial_slider",
-        "cta_gold_bar"
+        "smile_gallery_intro_copy",
+        "smile_gallery_cases_overview",
+        "smile_gallery_case_categories"
       ],
       "category": "editorial"
     },
@@ -188,11 +186,40 @@
     },
     {
       "slug": "/contact",
-      "hero": "contact_friendly_hero",
+      "hero": "contact_calm_hero_v1",
       "sections": [
-        "contact_details",
-        "map_embed",
-        "cta_gold_bar"
+        "contact_intro_copy",
+        "contact_details_simple",
+        "contact_followup_cta"
+      ],
+      "category": "utility"
+    },
+    {
+      "slug": "/team",
+      "hero": "team_preview_hero_v1",
+      "sections": [
+        "team_intro_copy",
+        "team_grid_placeholder",
+        "team_connection_cta"
+      ],
+      "category": "hub"
+    },
+    {
+      "slug": "/blog",
+      "hero": "blog_intro_hero_v1",
+      "sections": [
+        "blog_intro_copy",
+        "blog_placeholder_features"
+      ],
+      "category": "editorial"
+    },
+    {
+      "slug": "/patient-portal",
+      "hero": "patient_portal_placeholder_hero",
+      "sections": [
+        "patient_portal_intro_copy",
+        "patient_portal_features",
+        "patient_portal_cta_band"
       ],
       "category": "utility"
     },

--- a/packages/champagne-manifests/reports/non-treatment-layout-usage.md
+++ b/packages/champagne-manifests/reports/non-treatment-layout-usage.md
@@ -1,0 +1,35 @@
+# Non-treatment layout usage
+
+Summary of canon-aligned non-treatment pages now running through the Champagne manifests and surfaces.
+
+## Routes
+
+### Home (`/`)
+- Hero preset: `home_neutral_hero_v1`
+- Sections: `home_intro_positioning` → `home_care_highlights` → `home_get_started_band`
+- Notes: kept deliberately minimal; sacred hero and richer storytelling will arrive in a later phase.
+
+### Team (`/team`)
+- Hero preset: `team_preview_hero_v1`
+- Sections: `team_intro_copy` → `team_grid_placeholder` → `team_connection_cta`
+- Notes: placeholder team grid only; no clinician data wired yet.
+
+### Contact (`/contact`)
+- Hero preset: `contact_calm_hero_v1`
+- Sections: `contact_intro_copy` → `contact_details_simple` → `contact_followup_cta`
+- Notes: neutral contact details without live addresses or phone numbers.
+
+### Smile gallery (`/smile-gallery`)
+- Hero preset: `smile_gallery_placeholder_hero`
+- Sections: `smile_gallery_intro_copy` → `smile_gallery_cases_overview` → `smile_gallery_case_categories`
+- Notes: placeholder case categories; no images or PHI.
+
+### Blog (`/blog`)
+- Hero preset: `blog_intro_hero_v1`
+- Sections: `blog_intro_copy` → `blog_placeholder_features`
+- Notes: index-only shell; no post routing yet.
+
+### Patient portal (`/patient-portal`)
+- Hero preset: `patient_portal_placeholder_hero`
+- Sections: `patient_portal_intro_copy` → `patient_portal_features` → `patient_portal_cta_band`
+- Notes: high-level placeholder with security emphasis; no forms or authentication.

--- a/packages/champagne-manifests/reports/page-canon-map.md
+++ b/packages/champagne-manifests/reports/page-canon-map.md
@@ -2,11 +2,15 @@
 
 | Slug | Title | Hero preset? | Section stack? | Route status |
 | --- | --- | --- | --- | --- |
-| / | Home | Yes | Yes | Present via `/page.tsx` |
-| /smile-gallery | Smile Gallery | Yes | Yes | Present via `(champagne)/smile-gallery` |
-| /about | About | Yes | Yes | Present via `(champagne)/about` |
-| /contact | Contact | Yes | Yes | Present via `/contact/page.tsx` |
-| /legal/privacy | Privacy Policy | Yes | Yes | Present via `(champagne)/legal/privacy` |
+| / | Home | `home_neutral_hero_v1` | `home_intro_positioning`, `home_care_highlights`, `home_get_started_band` | Manifest-driven via `/page.tsx` |
+| /team | Team | `team_preview_hero_v1` | `team_intro_copy`, `team_grid_placeholder`, `team_connection_cta` | Manifest-driven via `/team/page.tsx` |
+| /contact | Contact | `contact_calm_hero_v1` | `contact_intro_copy`, `contact_details_simple`, `contact_followup_cta` | Manifest-driven via `/contact/page.tsx` |
+| /smile-gallery | Smile gallery | `smile_gallery_placeholder_hero` | `smile_gallery_intro_copy`, `smile_gallery_cases_overview`, `smile_gallery_case_categories` | Manifest-driven via `(champagne)/smile-gallery` |
+| /blog | Blog | `blog_intro_hero_v1` | `blog_intro_copy`, `blog_placeholder_features` | Manifest-driven via `/blog/page.tsx` |
+| /patient-portal | Patient portal | `patient_portal_placeholder_hero` | `patient_portal_intro_copy`, `patient_portal_features`, `patient_portal_cta_band` | Manifest-driven via `/patient-portal/page.tsx` |
+| /about | About | `about_story_hero_v1` | `about_story`, `team_profiles`, `technology_stack`, `cta_gold_bar` | Present via `(champagne)/about` |
+| /legal/privacy | Privacy Policy | `legal_simple_banner` | `legal_intro`, `legal_terms` | Present via `(champagne)/legal/privacy` |
 
 ## Notes
-- No additional non-treatment manifest entries are currently missing routes. TODO list remains empty.
+- All non-treatment nav destinations now map to manifest entries, style presets, and live routes.
+- Home remains intentionally minimal while the sacred hero evolves; other pages use neutral placeholder copy only.


### PR DESCRIPTION
## Summary
- add manifest hero presets and placeholder section stacks for home, team, contact, smile gallery, blog, and patient portal
- route non-treatment Next.js pages through the Champagne page builder for consistent surfaces and sections
- document manifest coverage for the updated non-treatment routes

## Testing
- npm run lint
- CI=1 npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69366480c85c8332a24b19828afbde69)