### PR TITLE
Add rich manifest-driven home layout

### DIFF
--- a/packages/champagne-manifests/data/champagne_machine_manifest_full.json
+++ b/packages/champagne-manifests/data/champagne_machine_manifest_full.json
@@ -14,30 +14,90 @@
         {
           "id": "home_intro_positioning",
           "type": "copy-block",
-          "title": "Calm, modern care with Champagne surfaces",
-          "copy": "A neutral welcome while the full Champagne experience is prepared. Every section here is a placeholder scaffold for the future home layout.",
+          "title": "A calm welcome into Champagne care",
+          "copy": "Soft-light hero, steady rhythm, and a concise primer on how Champagne care works. This home stack guides visitors to key journeys without heavy motion.",
           "label": "Welcome"
         },
         {
-          "id": "home_care_highlights",
+          "id": "home_treatment_hub",
           "type": "feature-list",
-          "title": "Key care highlights",
+          "title": "Priority treatments at a glance",
           "items": [
-            "Comfort-led visits and clear explanations",
-            "Modern diagnostics with balanced aesthetics",
-            "Transparent next steps for every patient"
+            "Composite bonding, veneers, and full smile refinement",
+            "Clear aligners with mapped movement and check-ins",
+            "Implant dentistry, whitening, and restorative care"
           ],
-          "label": "Highlights"
+          "label": "Treatment hub"
         },
         {
-          "id": "home_get_started_band",
-          "type": "cta",
-          "title": "Ways to get started",
-          "ctas": [
-            { "label": "Explore treatments", "href": "/treatments", "preset": "primary" },
-            { "label": "Plan a visit", "href": "/contact", "preset": "secondary" }
+          "id": "home_care_pathway",
+          "type": "steps",
+          "title": "How care flows with Champagne",
+          "items": [
+            "Share goals and capture scans for a precise baseline",
+            "Preview options with visual planning and simple language",
+            "Start treatment with clear timelines and follow-ups"
           ],
-          "label": "Get started"
+          "label": "Care pathway"
+        },
+        {
+          "id": "home_finance_options",
+          "type": "feature-list",
+          "title": "Finance and access options",
+          "items": [
+            "Transparent estimates before any commitment",
+            "Installments or staged plans to fit your pace",
+            "Guidance on benefits, receipts, and aftercare"
+          ],
+          "label": "Finance"
+        },
+        {
+          "id": "home_technology_showcase",
+          "type": "media",
+          "label": "Tech & tools",
+          "title": "Technology that keeps planning clear",
+          "copy": "Diagnostics, digital planning, and visual previews stay visible on the Champagne canvas so you can see each step before it begins."
+        },
+        {
+          "id": "home_patient_stories",
+          "type": "patient_stories_rail",
+          "label": "Patient stories",
+          "title": "Journeys through Champagne care",
+          "stories": [
+            { "summary": "Mapped a bonding plan that stayed gentle on enamel.", "name": "Case A" },
+            { "summary": "Followed a clear aligner cadence with visual checkpoints.", "name": "Case B" },
+            { "summary": "Combined whitening and contouring with calm visits.", "name": "Case C" }
+          ]
+        },
+        {
+          "id": "home_faq",
+          "type": "treatment_faq_block",
+          "label": "FAQ",
+          "title": "Questions about the practice",
+          "faqs": [
+            {
+              "question": "What happens at the first visit?",
+              "answer": "We listen to goals, capture scans or photos if helpful, and outline options with straightforward next steps."
+            },
+            {
+              "question": "Do you show previews before treatment?",
+              "answer": "Whenever possible we use visual planning so you can see movement, shaping, or shade shifts before committing."
+            },
+            {
+              "question": "How do payments work?",
+              "answer": "We share estimates early, support staged payments, and provide receipts or documentation you may need."
+            }
+          ]
+        },
+        {
+          "id": "home_closing_cta",
+          "type": "treatment_closing_cta",
+          "title": "Plan your visit",
+          "strapline": "Book a calm consultation or explore treatment pathways.",
+          "ctas": [
+            { "label": "Book a consultation", "href": "/contact", "preset": "primary" },
+            { "label": "Explore treatments", "href": "/treatments", "preset": "secondary" }
+          ]
         }
       ],
       "surface": "champagne/surface/home"

--- a/packages/champagne-manifests/data/manifest.styles.champagne.json
+++ b/packages/champagne-manifests/data/manifest.styles.champagne.json
@@ -157,6 +157,34 @@
       "type": "cta",
       "surface": "champagne/surface/base"
     },
+    "home_treatment_hub": {
+      "type": "feature-list",
+      "surface": "champagne/surface/home"
+    },
+    "home_care_pathway": {
+      "type": "steps",
+      "surface": "champagne/surface/home"
+    },
+    "home_finance_options": {
+      "type": "feature-list",
+      "surface": "champagne/surface/home"
+    },
+    "home_technology_showcase": {
+      "type": "media",
+      "surface": "champagne/surface/home"
+    },
+    "home_patient_stories": {
+      "type": "patient_stories_rail",
+      "surface": "champagne/surface/home"
+    },
+    "home_faq": {
+      "type": "treatment_faq_block",
+      "surface": "champagne/surface/base"
+    },
+    "home_closing_cta": {
+      "type": "treatment_closing_cta",
+      "surface": "champagne/surface/base"
+    },
     "cta_gold_bar": {
       "type": "cta",
       "surface": "champagne/surface/base"

--- a/packages/champagne-manifests/data/manus_import_unified_manifest_20251104.json
+++ b/packages/champagne-manifests/data/manus_import_unified_manifest_20251104.json
@@ -7,9 +7,94 @@
       "slug": "/",
       "hero": "home_neutral_hero_v1",
       "sections": [
-        "home_intro_positioning",
-        "home_care_highlights",
-        "home_get_started_band"
+        {
+          "id": "home_intro_positioning",
+          "type": "copy-block",
+          "title": "A calm welcome into Champagne care",
+          "copy": "Soft-light hero, steady rhythm, and a concise primer on how Champagne care works. This home stack guides visitors to key journeys without heavy motion.",
+          "label": "Welcome"
+        },
+        {
+          "id": "home_treatment_hub",
+          "type": "feature-list",
+          "title": "Priority treatments at a glance",
+          "items": [
+            "Composite bonding, veneers, and full smile refinement",
+            "Clear aligners with mapped movement and check-ins",
+            "Implant dentistry, whitening, and restorative care"
+          ],
+          "label": "Treatment hub"
+        },
+        {
+          "id": "home_care_pathway",
+          "type": "steps",
+          "title": "How care flows with Champagne",
+          "items": [
+            "Share goals and capture scans for a precise baseline",
+            "Preview options with visual planning and simple language",
+            "Start treatment with clear timelines and follow-ups"
+          ],
+          "label": "Care pathway"
+        },
+        {
+          "id": "home_finance_options",
+          "type": "feature-list",
+          "title": "Finance and access options",
+          "items": [
+            "Transparent estimates before any commitment",
+            "Installments or staged plans to fit your pace",
+            "Guidance on benefits, receipts, and aftercare"
+          ],
+          "label": "Finance"
+        },
+        {
+          "id": "home_technology_showcase",
+          "type": "media",
+          "label": "Tech & tools",
+          "title": "Technology that keeps planning clear",
+          "copy": "Diagnostics, digital planning, and visual previews stay visible on the Champagne canvas so you can see each step before it begins."
+        },
+        {
+          "id": "home_patient_stories",
+          "type": "patient_stories_rail",
+          "label": "Patient stories",
+          "title": "Journeys through Champagne care",
+          "stories": [
+            { "summary": "Mapped a bonding plan that stayed gentle on enamel.", "name": "Case A" },
+            { "summary": "Followed a clear aligner cadence with visual checkpoints.", "name": "Case B" },
+            { "summary": "Combined whitening and contouring with calm visits.", "name": "Case C" }
+          ]
+        },
+        {
+          "id": "home_faq",
+          "type": "treatment_faq_block",
+          "label": "FAQ",
+          "title": "Questions about the practice",
+          "faqs": [
+            {
+              "question": "What happens at the first visit?",
+              "answer": "We listen to goals, capture scans or photos if helpful, and outline options with straightforward next steps."
+            },
+            {
+              "question": "Do you show previews before treatment?",
+              "answer": "Whenever possible we use visual planning so you can see movement, shaping, or shade shifts before committing."
+            },
+            {
+              "question": "How do payments work?",
+              "answer": "We share estimates early, support staged payments, and provide receipts or documentation you may need."
+            }
+          ]
+        },
+        {
+          "id": "home_closing_cta",
+          "type": "treatment_closing_cta",
+          "title": "Plan your visit",
+          "strapline": "Book a calm consultation or explore treatment pathways.",
+          "ctas": [
+            { "label": "Book a consultation", "href": "/contact", "preset": "primary" },
+            { "label": "Explore treatments", "href": "/treatments", "preset": "secondary" }
+          ]
+        }
       ],
       "category": "hub"
     },

--- a/packages/champagne-manifests/reports/non-treatment-layout-usage.md
+++ b/packages/champagne-manifests/reports/non-treatment-layout-usage.md
@@ -6,8 +6,18 @@ Summary of canon-aligned non-treatment pages now running through the Champagne m
 
 ### Home (`/`)
 - Hero preset: `home_neutral_hero_v1`
-- Sections: `home_intro_positioning` → `home_care_highlights` → `home_get_started_band`
-- Notes: kept deliberately minimal; sacred hero and richer storytelling will arrive in a later phase.
+- Sections: `home_intro_positioning` → `home_treatment_hub` → `home_care_pathway` → `home_finance_options` → `home_technology_showcase` → `home_patient_stories` → `home_faq` → `home_closing_cta`
+- Notes: rich neutral layout for hub journeys; copy remains placeholder-safe while preserving calm pacing.
+
+#### Home – Rich Layout Plan
+1. `home_intro_positioning` → `Section_TextBlock` — calm welcome, manifesto tone.
+2. `home_treatment_hub` → `Section_FeatureList` — hub for priority treatments.
+3. `home_care_pathway` → `Section_FeatureList` (steps) — simple flow of visits.
+4. `home_finance_options` → `Section_FeatureList` — transparent finance points.
+5. `home_technology_showcase` → `Section_MediaBlock` — tech and planning preview placeholder.
+6. `home_patient_stories` → `Section_PatientStoriesRail` — rail of anonymised journeys.
+7. `home_faq` → `Section_FAQ` — practice questions, neutral answers.
+8. `home_closing_cta` → `Section_TreatmentClosingCTA` — book or explore CTA pair.
 
 ### Team (`/team`)
 - Hero preset: `team_preview_hero_v1`

--- a/packages/champagne-manifests/reports/page-canon-map.md
+++ b/packages/champagne-manifests/reports/page-canon-map.md
@@ -2,7 +2,7 @@
 
 | Slug | Title | Hero preset? | Section stack? | Route status |
 | --- | --- | --- | --- | --- |
-| / | Home | `home_neutral_hero_v1` | `home_intro_positioning`, `home_care_highlights`, `home_get_started_band` | Manifest-driven via `/page.tsx` |
+| / | Home | `home_neutral_hero_v1` | `home_intro_positioning`, `home_treatment_hub`, `home_care_pathway`, `home_finance_options`, `home_technology_showcase`, `home_patient_stories`, `home_faq`, `home_closing_cta` | Manifest-driven via `/page.tsx` |
 | /team | Team | `team_preview_hero_v1` | `team_intro_copy`, `team_grid_placeholder`, `team_connection_cta` | Manifest-driven via `/team/page.tsx` |
 | /contact | Contact | `contact_calm_hero_v1` | `contact_intro_copy`, `contact_details_simple`, `contact_followup_cta` | Manifest-driven via `/contact/page.tsx` |
 | /smile-gallery | Smile gallery | `smile_gallery_placeholder_hero` | `smile_gallery_intro_copy`, `smile_gallery_cases_overview`, `smile_gallery_case_categories` | Manifest-driven via `(champagne)/smile-gallery` |
@@ -13,4 +13,4 @@
 
 ## Notes
 - All non-treatment nav destinations now map to manifest entries, style presets, and live routes.
-- Home remains intentionally minimal while the sacred hero evolves; other pages use neutral placeholder copy only.
+- Home now follows the richer Champagne stack (hub → pathway → finance → tech → stories → FAQ → closing CTA) while keeping neutral placeholder copy.

--- a/packages/champagne-manifests/reports/treatment-layout-usage.md
+++ b/packages/champagne-manifests/reports/treatment-layout-usage.md
@@ -28,6 +28,8 @@ This note traces how treatment slugs now flow through the builder into the hero 
 - Many treatment sections only ship IDs/types today; the adapter supplies neutral, accessible placeholder copy to keep layouts complete until full text arrives.
 - Hero presets from the styles manifest currently provide palette/motion metadata. If a hero-specific title/subtitle is ever authored there, `ChampagneHeroFrame` will display it automatically.
 
+The richer Home stack now mirrors the priority treatment structure (overview, pathway, tools/tech, stories, FAQ, closing CTA) to keep journeys consistent between hub and treatment routes.
+
 ## Composite bonding — rich layout stack
 
 - Overview rich (eyebrow, headline, key bullets)


### PR DESCRIPTION
## Summary
- expand the home page manifest to a richer section stack covering treatment hub, care pathway, finance, tech, stories, FAQ, and closing CTA
- add style mappings for the new home sections and synchronize the unified Manus import
- refresh manifest reports to document the home layout plan and parity with treatment flows

## Testing
- npm run lint
- CI=1 npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693668cab6d4833298343a4b5a9174ad)