### PR TITLE
Scaffold Champagne OS docs structure (empty)

### DIFF
--- a/docs/champagne-os/3d/champagne-3d-assets.json
+++ b/docs/champagne-os/3d/champagne-3d-assets.json
@@ -1,0 +1,5 @@
+{
+  "status": "placeholder",
+  "description": "This config will be populated with real Champagne data later.",
+  "items": []
+}

--- a/docs/champagne-os/3d/champagne-3d-lighting-presets.json
+++ b/docs/champagne-os/3d/champagne-3d-lighting-presets.json
@@ -1,0 +1,5 @@
+{
+  "status": "placeholder",
+  "description": "This config will be populated with real Champagne data later.",
+  "items": []
+}

--- a/docs/champagne-os/3d/champagne-3d-roadmap.md
+++ b/docs/champagne-os/3d/champagne-3d-roadmap.md
@@ -1,0 +1,3 @@
+# Placeholder: Champagne 3D Roadmap
+
+This file will be populated with the Champagne 3D roadmap in a later phase.

--- a/docs/champagne-os/3d/champagne-3d-viewer-modes.json
+++ b/docs/champagne-os/3d/champagne-3d-viewer-modes.json
@@ -1,0 +1,5 @@
+{
+  "status": "placeholder",
+  "description": "This config will be populated with real Champagne data later.",
+  "items": []
+}

--- a/docs/champagne-os/ai/champagne-ai-narrative-chapters.json
+++ b/docs/champagne-os/ai/champagne-ai-narrative-chapters.json
@@ -1,0 +1,5 @@
+{
+  "status": "placeholder",
+  "description": "This config will be populated with real Champagne data later.",
+  "items": []
+}

--- a/docs/champagne-os/ai/champagne-ai-persona-matrix.md
+++ b/docs/champagne-os/ai/champagne-ai-persona-matrix.md
@@ -1,0 +1,3 @@
+# Placeholder: Champagne AI Persona Matrix
+
+This file will be populated with the AI persona matrix in a later phase.

--- a/docs/champagne-os/ai/champagne-ai-personas.json
+++ b/docs/champagne-os/ai/champagne-ai-personas.json
@@ -1,0 +1,5 @@
+{
+  "status": "placeholder",
+  "description": "This config will be populated with real Champagne data later.",
+  "items": []
+}

--- a/docs/champagne-os/ai/champagne-ai-tone-modes.json
+++ b/docs/champagne-os/ai/champagne-ai-tone-modes.json
@@ -1,0 +1,5 @@
+{
+  "status": "placeholder",
+  "description": "This config will be populated with real Champagne data later.",
+  "items": []
+}

--- a/docs/champagne-os/ai/champagne-ai-treatment-mapping.json
+++ b/docs/champagne-os/ai/champagne-ai-treatment-mapping.json
@@ -1,0 +1,5 @@
+{
+  "status": "placeholder",
+  "description": "This config will be populated with real Champagne data later.",
+  "items": []
+}

--- a/docs/champagne-os/emotion/champagne-emotional-hooks-notes.md
+++ b/docs/champagne-os/emotion/champagne-emotional-hooks-notes.md
@@ -1,0 +1,3 @@
+# Placeholder: Champagne Emotional Hooks Notes
+
+This file will be populated with emotional hooks notes in a later phase.

--- a/docs/champagne-os/emotion/champagne-emotional-lighting-canon.md
+++ b/docs/champagne-os/emotion/champagne-emotional-lighting-canon.md
@@ -1,0 +1,3 @@
+# Placeholder: Champagne Emotional Lighting Canon
+
+This file will be populated with the emotional lighting canon content in a later phase.

--- a/docs/champagne-os/emotion/champagne-emotional-lighting-presets.json
+++ b/docs/champagne-os/emotion/champagne-emotional-lighting-presets.json
@@ -1,0 +1,5 @@
+{
+  "status": "placeholder",
+  "description": "This config will be populated with real Champagne data later.",
+  "items": []
+}

--- a/docs/champagne-os/emotion/champagne-treatment-emotion-map.json
+++ b/docs/champagne-os/emotion/champagne-treatment-emotion-map.json
@@ -1,0 +1,5 @@
+{
+  "status": "placeholder",
+  "description": "This config will be populated with real Champagne data later.",
+  "items": []
+}

--- a/docs/champagne-os/fx/champagne-fx-canon.md
+++ b/docs/champagne-os/fx/champagne-fx-canon.md
@@ -1,0 +1,3 @@
+# Placeholder: Champagne FX Canon
+
+This file will be populated with the full Champagne FX canon content in a later phase.

--- a/docs/champagne-os/fx/champagne-fx-presets.json
+++ b/docs/champagne-os/fx/champagne-fx-presets.json
@@ -1,0 +1,5 @@
+{
+  "status": "placeholder",
+  "description": "This config will be populated with real Champagne data later.",
+  "items": []
+}

--- a/docs/champagne-os/fx/champagne-fx-routing-notes.md
+++ b/docs/champagne-os/fx/champagne-fx-routing-notes.md
@@ -1,0 +1,3 @@
+# Placeholder: Champagne FX Routing Notes
+
+This file will be populated with routing notes for Champagne FX in a later phase.

--- a/docs/champagne-os/fx/champagne-motion-profiles.json
+++ b/docs/champagne-os/fx/champagne-motion-profiles.json
@@ -1,0 +1,5 @@
+{
+  "status": "placeholder",
+  "description": "This config will be populated with real Champagne data later.",
+  "items": []
+}

--- a/docs/champagne-os/security/champagne-ai-gateway-config.json
+++ b/docs/champagne-os/security/champagne-ai-gateway-config.json
@@ -1,0 +1,5 @@
+{
+  "status": "placeholder",
+  "description": "This config will be populated with real Champagne data later.",
+  "items": []
+}

--- a/docs/champagne-os/security/champagne-ai-gateway-policy.md
+++ b/docs/champagne-os/security/champagne-ai-gateway-policy.md
@@ -1,0 +1,3 @@
+# Placeholder: Champagne AI Gateway Policy
+
+This file will be populated with the Champagne AI gateway policy in a later phase.

--- a/docs/champagne-os/security/champagne-data-classes.json
+++ b/docs/champagne-os/security/champagne-data-classes.json
@@ -1,0 +1,5 @@
+{
+  "status": "placeholder",
+  "description": "This config will be populated with real Champagne data later.",
+  "items": []
+}

--- a/docs/champagne-os/security/champagne-retention-and-access.json
+++ b/docs/champagne-os/security/champagne-retention-and-access.json
@@ -1,0 +1,5 @@
+{
+  "status": "placeholder",
+  "description": "This config will be populated with real Champagne data later.",
+  "items": []
+}

--- a/docs/champagne-os/security/champagne-security-architecture.md
+++ b/docs/champagne-os/security/champagne-security-architecture.md
@@ -1,0 +1,3 @@
+# Placeholder: Champagne Security Architecture
+
+This file will be populated with the Champagne security architecture in a later phase.

--- a/docs/champagne-os/security/champagne-security-todo.md
+++ b/docs/champagne-os/security/champagne-security-todo.md
@@ -1,0 +1,3 @@
+# Placeholder: Champagne Security TODO
+
+This file will be populated with Champagne security TODO items in a later phase.

--- a/docs/champagne-os/tenants/champagne-bundles.json
+++ b/docs/champagne-os/tenants/champagne-bundles.json
@@ -1,0 +1,5 @@
+{
+  "status": "placeholder",
+  "description": "This config will be populated with real Champagne data later.",
+  "items": []
+}

--- a/docs/champagne-os/tenants/champagne-saas-onboarding-notes.md
+++ b/docs/champagne-os/tenants/champagne-saas-onboarding-notes.md
@@ -1,0 +1,3 @@
+# Placeholder: Champagne SaaS Onboarding Notes
+
+This file will be populated with SaaS onboarding notes in a later phase.

--- a/docs/champagne-os/tenants/champagne-tenant-manifests-notes.md
+++ b/docs/champagne-os/tenants/champagne-tenant-manifests-notes.md
@@ -1,0 +1,3 @@
+# Placeholder: Champagne Tenant Manifests Notes
+
+This file will be populated with tenant manifest notes in a later phase.

--- a/docs/champagne-os/tenants/champagne-tenants.json
+++ b/docs/champagne-os/tenants/champagne-tenants.json
@@ -1,0 +1,5 @@
+{
+  "status": "placeholder",
+  "description": "This config will be populated with real Champagne data later.",
+  "items": []
+}

--- a/docs/champagne-os/ux/champagne-component-contracts.json
+++ b/docs/champagne-os/ux/champagne-component-contracts.json
@@ -1,0 +1,5 @@
+{
+  "status": "placeholder",
+  "description": "This config will be populated with real Champagne data later.",
+  "items": []
+}

--- a/docs/champagne-os/ux/champagne-ux-journeys.json
+++ b/docs/champagne-os/ux/champagne-ux-journeys.json
@@ -1,0 +1,5 @@
+{
+  "status": "placeholder",
+  "description": "This config will be populated with real Champagne data later.",
+  "items": []
+}

--- a/docs/champagne-os/ux/champagne-ux-journeys.md
+++ b/docs/champagne-os/ux/champagne-ux-journeys.md
@@ -1,0 +1,3 @@
+# Placeholder: Champagne UX Journeys
+
+This file will be populated with Champagne UX journeys in a later phase.

--- a/docs/champagne-os/ux/champagne-ux-microinteractions.md
+++ b/docs/champagne-os/ux/champagne-ux-microinteractions.md
@@ -1,0 +1,3 @@
+# Placeholder: Champagne UX Microinteractions
+
+This file will be populated with Champagne UX microinteractions in a later phase.


### PR DESCRIPTION
## Summary
- Created the Champagne OS documentation directory tree under `docs/champagne-os`, including canon, fx, 3d, emotion, ai, ux, security, and tenants scopes.
- Added placeholder Markdown and JSON scaffolding files for FX, 3D, emotional lighting, AI personas and tone, UX journeys, security, and tenant materials to be filled in later.
- Confirmed that no existing files were modified; only new documentation placeholders were added.

## Testing
- Not run (documentation-only change).


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6936a4fc40b883329c857cb200053a32)