### PR TITLE
Wire sacred hero runtime implementation

### DIFF
--- a/apps/web/app/components/hero/HeroRenderer.tsx
+++ b/apps/web/app/components/hero/HeroRenderer.tsx
@@ -1,10 +1,262 @@
-import type { FC } from "react";
+import type { CSSProperties } from "react";
+import { BaseChampagneSurface, getHeroRuntime, type HeroTimeOfDay } from "@champagne/hero";
 
 export interface HeroRendererProps {
-  config: any;
+  treatmentSlug?: string;
+  prm?: boolean;
+  timeOfDay?: HeroTimeOfDay;
 }
 
-export const HeroRenderer: FC<HeroRendererProps> = () => {
-  // TODO: connect to hero runtime engine once available.
-  return null;
-};
+function HeroFallback() {
+  return (
+    <BaseChampagneSurface
+      variant="inkGlass"
+      style={{
+        background: "var(--smh-gradient)",
+        minHeight: "48vh",
+        display: "grid",
+        alignItems: "center",
+        padding: "clamp(2rem, 5vw, 3.5rem)",
+      }}
+    >
+      <div style={{ display: "grid", gap: "0.75rem", maxWidth: "960px" }}>
+        <span style={{ letterSpacing: "0.12em", textTransform: "uppercase", color: "var(--text-medium)" }}>
+          Champagne Dentistry
+        </span>
+        <h1 style={{ fontSize: "clamp(2rem, 3.6vw, 3rem)", lineHeight: 1.1 }}>
+          A calm, cinematic hero is loading.
+        </h1>
+        <p style={{ color: "var(--text-medium)", maxWidth: "720px", lineHeight: 1.6 }}>
+          Sacred hero assets are unavailable. Showing a safe gradient surface until the manifest is ready.
+        </p>
+      </div>
+    </BaseChampagneSurface>
+  );
+}
+
+export async function HeroRenderer({ treatmentSlug, prm, timeOfDay }: HeroRendererProps) {
+  let runtime: Awaited<ReturnType<typeof getHeroRuntime>> | null = null;
+
+  try {
+    runtime = await getHeroRuntime({ treatmentSlug, prm, timeOfDay });
+  } catch (error) {
+    if (process.env.NODE_ENV !== "production") {
+      console.error("Hero runtime failed", error);
+    }
+  }
+
+  if (!runtime) return <HeroFallback />;
+
+  const { content, surfaces } = runtime;
+  const surfaceVars: CSSProperties = {
+    ["--hero-bg-desktop" as string]: surfaces.background?.desktop?.path
+      ? `var(--smh-gradient), url(${surfaces.background.desktop.path})`
+      : "var(--smh-gradient)",
+    ["--hero-bg-mobile" as string]: surfaces.background?.mobile?.path
+      ? `var(--smh-gradient), url(${surfaces.background.mobile.path})`
+      : undefined,
+    ["--hero-wave-mask-desktop" as string]: surfaces.waveMask?.desktop?.path
+      ? `url(${surfaces.waveMask.desktop.path})`
+      : undefined,
+    ["--hero-wave-mask-mobile" as string]: surfaces.waveMask?.mobile?.path
+      ? `url(${surfaces.waveMask.mobile.path})`
+      : undefined,
+    ["--hero-overlay-dots" as string]: surfaces.overlays?.dots?.path
+      ? `url(${surfaces.overlays.dots.path})`
+      : undefined,
+    ["--hero-overlay-field" as string]: surfaces.overlays?.field?.path
+      ? `url(${surfaces.overlays.field.path})`
+      : undefined,
+    ["--hero-particles" as string]: surfaces.particles?.path
+      ? `url(${surfaces.particles.path})`
+      : undefined,
+    ["--hero-grain-desktop" as string]: surfaces.grain?.desktop?.path
+      ? `url(${surfaces.grain.desktop.path})`
+      : undefined,
+    ["--hero-grain-mobile" as string]: surfaces.grain?.mobile?.path
+      ? `url(${surfaces.grain.mobile.path})`
+      : undefined,
+  };
+
+  const motionEntries = surfaces.motion ?? [];
+  const videoEntry = surfaces.video;
+
+  return (
+    <BaseChampagneSurface
+      variant="inkGlass"
+      style={{
+        minHeight: "60vh",
+        display: "grid",
+        alignItems: "center",
+        overflow: "hidden",
+        ...surfaceVars,
+      }}
+      className="hero-renderer"
+    >
+      <style
+        dangerouslySetInnerHTML={{
+          __html: `
+            .hero-renderer {
+              position: relative;
+              background-image: var(--hero-bg-desktop, var(--smh-gradient));
+              background-size: cover;
+              background-position: center;
+              color: var(--text-high);
+            }
+            .hero-renderer .hero-layer {
+              position: absolute;
+              inset: 0;
+              z-index: 0;
+            }
+            .hero-renderer .hero-layer.wave {
+              mask-image: var(--hero-wave-mask-desktop);
+              -webkit-mask-image: var(--hero-wave-mask-desktop);
+              mask-size: cover;
+              -webkit-mask-size: cover;
+              background: currentColor;
+              opacity: 0.82;
+              pointer-events: none;
+            }
+            .hero-renderer .hero-layer.overlay {
+              mix-blend-mode: screen;
+              opacity: 0.65;
+              background-repeat: no-repeat;
+              background-size: cover;
+              pointer-events: none;
+            }
+            .hero-renderer .hero-layer.overlay.field {
+              background-image: var(--hero-overlay-field);
+            }
+            .hero-renderer .hero-layer.overlay.dots {
+              background-image: var(--hero-overlay-dots);
+            }
+            .hero-renderer .hero-layer.particles {
+              background-image: var(--hero-particles), var(--hero-grain-desktop);
+              background-repeat: no-repeat, repeat;
+              background-size: cover, cover;
+              mix-blend-mode: soft-light;
+              opacity: 0.35;
+              pointer-events: none;
+            }
+            .hero-renderer .hero-layer.motion {
+              object-fit: cover;
+              width: 100%;
+              height: 100%;
+              mix-blend-mode: screen;
+              opacity: 0.85;
+              pointer-events: none;
+            }
+            .hero-renderer .hero-content {
+              position: relative;
+              z-index: 2;
+              display: grid;
+              gap: 1rem;
+              max-width: 960px;
+              padding: clamp(2rem, 4vw, 3.5rem);
+            }
+            @media (max-width: 640px) {
+              .hero-renderer {
+                background-image: var(--hero-bg-mobile, var(--hero-bg-desktop));
+              }
+              .hero-renderer .hero-layer.wave {
+                mask-image: var(--hero-wave-mask-mobile, var(--hero-wave-mask-desktop));
+                -webkit-mask-image: var(--hero-wave-mask-mobile, var(--hero-wave-mask-desktop));
+              }
+              .hero-renderer .hero-layer.particles {
+                background-image: var(--hero-particles), var(--hero-grain-mobile, var(--hero-grain-desktop));
+              }
+            }
+            @media (prefers-reduced-motion: reduce) {
+              .hero-renderer .hero-layer.motion { display: none; }
+              .hero-renderer .hero-layer.particles { opacity: 0.12; }
+            }
+          `,
+        }}
+      />
+
+      <div aria-hidden className="hero-layer wave" />
+      {surfaces.overlays?.field?.path && <div aria-hidden className="hero-layer overlay field" />}
+      {surfaces.overlays?.dots?.path && <div aria-hidden className="hero-layer overlay dots" />}
+      {(surfaces.particles?.path || surfaces.grain?.desktop?.path) && <div aria-hidden className="hero-layer particles" />}
+
+      {videoEntry?.path && (
+        <video
+          className="hero-layer motion"
+          autoPlay
+          playsInline
+          loop
+          muted
+          preload="metadata"
+          poster={surfaces.background?.desktop?.path}
+        >
+          <source src={videoEntry.path} />
+        </video>
+      )}
+
+      {motionEntries.map((entry) => (
+        <video
+          key={entry.id}
+          className="hero-layer motion"
+          autoPlay
+          playsInline
+          loop
+          muted
+          preload="metadata"
+        >
+          <source src={entry.path} />
+        </video>
+      ))}
+
+      <div className="hero-content">
+        {content.eyebrow && (
+          <span style={{ letterSpacing: "0.12em", textTransform: "uppercase", color: "var(--text-medium)" }}>
+            {content.eyebrow}
+          </span>
+        )}
+        {content.headline && (
+          <h1 style={{ fontSize: "clamp(2.2rem, 3.2vw, 3rem)", lineHeight: 1.05 }}>
+            {content.headline}
+          </h1>
+        )}
+        {content.subheadline && (
+          <p style={{ color: "var(--text-medium)", fontSize: "1.08rem", lineHeight: 1.6, maxWidth: "820px" }}>
+            {content.subheadline}
+          </p>
+        )}
+        <div style={{ display: "flex", gap: "0.75rem", flexWrap: "wrap" }}>
+          {content.cta && (
+            <a
+              href={content.cta.href}
+              style={{
+                padding: "0.9rem 1.6rem",
+                borderRadius: "var(--radius-md)",
+                background: "var(--surface-gold-soft, rgba(255, 215, 137, 0.16))",
+                color: "var(--text-high)",
+                border: "1px solid var(--champagne-keyline-gold, rgba(255, 215, 137, 0.45))",
+                textDecoration: "none",
+                boxShadow: "0 12px 32px rgba(0,0,0,0.3)",
+              }}
+            >
+              {content.cta.label}
+            </a>
+          )}
+          {content.secondaryCta && (
+            <a
+              href={content.secondaryCta.href}
+              style={{
+                padding: "0.9rem 1.2rem",
+                borderRadius: "var(--radius-md)",
+                background: "var(--surface-ink-soft, rgba(6,7,12,0.35))",
+                color: "var(--text-high)",
+                border: "1px solid var(--champagne-keyline-gold, rgba(255, 215, 137, 0.3))",
+                textDecoration: "none",
+              }}
+            >
+              {content.secondaryCta.label}
+            </a>
+          )}
+        </div>
+      </div>
+    </BaseChampagneSurface>
+  );
+}

--- a/packages/champagne-hero/src/HeroAssetRegistry.ts
+++ b/packages/champagne-hero/src/HeroAssetRegistry.ts
@@ -1,6 +1,126 @@
-export const HERO_ASSET_PATHS = {
-  masks: "/public/assets/champagne/waves/",
-  particles: "/public/assets/champagne/particles/",
-  motion: "/public/assets/champagne/motion/",
-  textures: "/public/assets/champagne/textures/",
+export type HeroAssetType = "image" | "video";
+
+export interface HeroAssetEntry {
+  id: string;
+  type: HeroAssetType;
+  path: string;
+  description?: string;
+}
+
+const HERO_ASSET_BASE = "/assets/champagne" as const;
+
+export const HERO_ASSET_REGISTRY: Record<string, HeroAssetEntry> = {
+  // Wave masks & backgrounds
+  "sacred.wave.mask.desktop": {
+    id: "sacred.wave.mask.desktop",
+    type: "image",
+    path: `${HERO_ASSET_BASE}/waves/wave-mask-desktop.webp`,
+    description: "Primary Sacred hero wave mask for desktop",
+  },
+  "sacred.wave.mask.mobile": {
+    id: "sacred.wave.mask.mobile",
+    type: "image",
+    path: `${HERO_ASSET_BASE}/waves/wave-mask-mobile.webp`,
+    description: "Primary Sacred hero wave mask for mobile",
+  },
+  "sacred.wave.mask.header": {
+    id: "sacred.wave.mask.header",
+    type: "image",
+    path: `${HERO_ASSET_BASE}/waves/header-wave-mask.svg`,
+  },
+  "sacred.wave.mask.smh": {
+    id: "sacred.wave.mask.smh",
+    type: "image",
+    path: `${HERO_ASSET_BASE}/waves/smh-wave-mask.svg`,
+  },
+  "sacred.wave.background.desktop": {
+    id: "sacred.wave.background.desktop",
+    type: "image",
+    path: `${HERO_ASSET_BASE}/waves/waves-bg-1920.webp`,
+  },
+  "sacred.wave.background.mobile": {
+    id: "sacred.wave.background.mobile",
+    type: "image",
+    path: `${HERO_ASSET_BASE}/waves/waves-bg-768.webp`,
+  },
+  "sacred.wave.overlay.dots": {
+    id: "sacred.wave.overlay.dots",
+    type: "image",
+    path: `${HERO_ASSET_BASE}/waves/wave-dots.svg`,
+  },
+  "sacred.wave.overlay.field": {
+    id: "sacred.wave.overlay.field",
+    type: "image",
+    path: `${HERO_ASSET_BASE}/waves/wave-field.svg`,
+  },
+
+  // Particles
+  "sacred.particles.home": {
+    id: "sacred.particles.home",
+    type: "image",
+    path: `${HERO_ASSET_BASE}/particles/home-hero-particles.webp`,
+  },
+  "sacred.particles.gold": {
+    id: "sacred.particles.gold",
+    type: "image",
+    path: `${HERO_ASSET_BASE}/particles/particles-gold .webp`,
+  },
+  "sacred.particles.magenta": {
+    id: "sacred.particles.magenta",
+    type: "image",
+    path: `${HERO_ASSET_BASE}/particles/particles-magenta .webp`,
+  },
+  "sacred.particles.teal": {
+    id: "sacred.particles.teal",
+    type: "image",
+    path: `${HERO_ASSET_BASE}/particles/particles-teal .webp`,
+  },
+
+  // Grain
+  "sacred.grain.desktop": {
+    id: "sacred.grain.desktop",
+    type: "image",
+    path: `${HERO_ASSET_BASE}/film-grain/film-grain-desktop .webp`,
+  },
+  "sacred.grain.mobile": {
+    id: "sacred.grain.mobile",
+    type: "image",
+    path: `${HERO_ASSET_BASE}/film-grain/film-grain-mobile .webp`,
+  },
+
+  // Motion
+  "sacred.motion.waveCaustics": {
+    id: "sacred.motion.waveCaustics",
+    type: "video",
+    path: `${HERO_ASSET_BASE}/motion/wave-caustics.webm`,
+  },
+  "sacred.motion.glassShimmer": {
+    id: "sacred.motion.glassShimmer",
+    type: "video",
+    path: `${HERO_ASSET_BASE}/motion/glass-shimmer.webm`,
+  },
+  "sacred.motion.goldDust": {
+    id: "sacred.motion.goldDust",
+    type: "video",
+    path: `${HERO_ASSET_BASE}/motion/gold-dust-drift.webm`,
+  },
+  "sacred.motion.particleDrift": {
+    id: "sacred.motion.particleDrift",
+    type: "video",
+    path: `${HERO_ASSET_BASE}/motion/particles-drift.webm`,
+  },
+  "sacred.motion.heroVideo": {
+    id: "sacred.motion.heroVideo",
+    type: "video",
+    path: `${HERO_ASSET_BASE}/motion/dental-hero-4k.mp4`,
+  },
 } as const;
+
+export function resolveHeroAsset(id?: string): HeroAssetEntry | undefined {
+  if (!id) return undefined;
+  return HERO_ASSET_REGISTRY[id];
+}
+
+export function ensureHeroAssetPath(id?: string): string | undefined {
+  return resolveHeroAsset(id)?.path;
+}

--- a/packages/champagne-hero/src/hero-engine/HeroConfig.ts
+++ b/packages/champagne-hero/src/hero-engine/HeroConfig.ts
@@ -1,9 +1,113 @@
-export interface HeroConfig {
-  /**
-   * TODO: define hero configuration contract for runtime rendering.
-   */
-  sceneId?: string;
-  variantId?: string;
-  surfaceToken?: string;
-  [key: string]: unknown;
+import type { HeroAssetEntry } from "../HeroAssetRegistry";
+
+export type HeroTimeOfDay = "day" | "evening" | "night";
+
+export interface HeroCTAConfig {
+  label: string;
+  href: string;
+}
+
+export interface HeroContentConfig {
+  eyebrow?: string;
+  headline?: string;
+  subheadline?: string;
+  strapline?: string;
+  cta?: HeroCTAConfig;
+  secondaryCta?: HeroCTAConfig;
+}
+
+export interface HeroSurfaceTokenConfig {
+  waveMask?: {
+    desktop?: string;
+    mobile?: string;
+  };
+  background?: {
+    desktop?: string;
+    mobile?: string;
+  };
+  overlays?: {
+    dots?: string;
+    field?: string;
+  };
+  particles?: string;
+  grain?: {
+    desktop?: string;
+    mobile?: string;
+  };
+  motion?: string[];
+  video?: string;
+}
+
+export interface HeroSurfaceConfig {
+  waveMask?: {
+    desktop?: string;
+    mobile?: string;
+  };
+  background?: {
+    desktop?: string;
+    mobile?: string;
+  };
+  overlays?: {
+    dots?: string;
+    field?: string;
+  };
+  particles?: string;
+  grain?: {
+    desktop?: string;
+    mobile?: string;
+  };
+  motion?: string[];
+  video?: string;
+}
+
+export interface ResolvedHeroSurfaceConfig {
+  waveMask?: {
+    desktop?: HeroAssetEntry;
+    mobile?: HeroAssetEntry;
+  };
+  background?: {
+    desktop?: HeroAssetEntry;
+    mobile?: HeroAssetEntry;
+  };
+  overlays?: {
+    dots?: HeroAssetEntry;
+    field?: HeroAssetEntry;
+  };
+  particles?: HeroAssetEntry;
+  grain?: {
+    desktop?: HeroAssetEntry;
+    mobile?: HeroAssetEntry;
+  };
+  motion?: HeroAssetEntry[];
+  video?: HeroAssetEntry;
+}
+
+export interface HeroBaseConfig {
+  id: string;
+  tone?: string;
+  content: HeroContentConfig;
+  defaultSurfaces: HeroSurfaceTokenConfig;
+}
+
+export interface HeroVariantConfig {
+  id: string;
+  label?: string;
+  tone?: string;
+  treatmentSlug?: string;
+  timeOfDay?: HeroTimeOfDay;
+  content?: Partial<HeroContentConfig>;
+  surfaces?: HeroSurfaceTokenConfig;
+}
+
+export interface HeroRuntimeConfig {
+  id: string;
+  tone?: string;
+  content: HeroContentConfig;
+  surfaces: ResolvedHeroSurfaceConfig;
+  variant?: HeroVariantConfig;
+  flags: {
+    prm: boolean;
+    timeOfDay?: HeroTimeOfDay;
+    treatmentSlug?: string;
+  };
 }

--- a/packages/champagne-hero/src/hero-engine/HeroManifestAdapter.ts
+++ b/packages/champagne-hero/src/hero-engine/HeroManifestAdapter.ts
@@ -1,8 +1,80 @@
-import { HeroConfig } from "./HeroConfig";
+import baseManifest from "../../../champagne-manifests/data/hero/sacred_hero_base.json" assert { type: "json" };
+import surfacesManifest from "../../../champagne-manifests/data/hero/sacred_hero_surfaces.json" assert { type: "json" };
+import variantsManifest from "../../../champagne-manifests/data/hero/sacred_hero_variants.json" assert { type: "json" };
+import weatherManifest from "../../../champagne-manifests/data/hero/sacred_hero_weather.json" assert { type: "json" };
+import type {
+  HeroBaseConfig,
+  HeroContentConfig,
+  HeroSurfaceTokenConfig,
+  HeroTimeOfDay,
+  HeroVariantConfig,
+} from "./HeroConfig";
+import type { HeroSurfaceDefinitionMap } from "./HeroSurfaceMap";
+import { buildSurfaceDefinitionMap } from "./HeroSurfaceMap";
 
-export interface HeroManifestAdapter {
-  /**
-   * TODO: read hero data from manifests and canon definitions.
-   */
-  readManifest: (experienceId: string) => Promise<HeroConfig | undefined>;
+interface SacredHeroBaseManifest {
+  id?: string;
+  content?: HeroContentConfig;
+  defaults?: {
+    tone?: string;
+    surfaces?: HeroSurfaceTokenConfig;
+  };
+}
+
+interface SacredHeroVariantsManifest {
+  variants?: HeroVariantConfig[];
+}
+
+type SacredHeroWeatherManifest = Partial<Record<HeroTimeOfDay, { tone?: string; surfaces?: HeroSurfaceTokenConfig }>>;
+
+export interface SacredHeroManifests {
+  base: HeroBaseConfig;
+  surfaces: HeroSurfaceDefinitionMap;
+  variants: HeroVariantConfig[];
+  weather: SacredHeroWeatherManifest;
+}
+
+function assertString(value: unknown): value is string {
+  return typeof value === "string" && value.length > 0;
+}
+
+function normalizeBaseManifest(manifest: SacredHeroBaseManifest): HeroBaseConfig {
+  const id = assertString(manifest.id) ? manifest.id : "sacred-home-hero";
+  const content: HeroContentConfig = manifest.content ?? {};
+  const defaults: HeroSurfaceTokenConfig = manifest.defaults?.surfaces ?? {};
+  return {
+    id,
+    tone: manifest.defaults?.tone,
+    content,
+    defaultSurfaces: defaults,
+  };
+}
+
+function normalizeVariants(manifest: SacredHeroVariantsManifest): HeroVariantConfig[] {
+  if (!Array.isArray(manifest.variants)) return [];
+  return manifest.variants
+    .filter((variant) => variant && typeof variant === "object")
+    .map((variant) => ({
+      id: assertString((variant as HeroVariantConfig).id) ? (variant as HeroVariantConfig).id : "default",
+      label: (variant as HeroVariantConfig).label,
+      tone: (variant as HeroVariantConfig).tone,
+      treatmentSlug: (variant as HeroVariantConfig).treatmentSlug,
+      timeOfDay: (variant as HeroVariantConfig).timeOfDay,
+      content: (variant as HeroVariantConfig).content,
+      surfaces: (variant as HeroVariantConfig).surfaces,
+    }));
+}
+
+export function loadSacredHeroManifests(): SacredHeroManifests {
+  const base = normalizeBaseManifest(baseManifest as SacredHeroBaseManifest);
+  const surfaceMap = buildSurfaceDefinitionMap(surfacesManifest);
+  const variants = normalizeVariants(variantsManifest as SacredHeroVariantsManifest);
+  const weather = (weatherManifest as SacredHeroWeatherManifest) ?? {};
+
+  return {
+    base,
+    surfaces: surfaceMap,
+    variants,
+    weather,
+  };
 }

--- a/packages/champagne-hero/src/hero-engine/HeroRuntime.ts
+++ b/packages/champagne-hero/src/hero-engine/HeroRuntime.ts
@@ -1,8 +1,91 @@
-import { HeroConfig } from "./HeroConfig";
+import type {
+  HeroContentConfig,
+  HeroRuntimeConfig,
+  HeroSurfaceConfig,
+  HeroSurfaceTokenConfig,
+  HeroTimeOfDay,
+  HeroVariantConfig,
+} from "./HeroConfig";
+import { loadSacredHeroManifests } from "./HeroManifestAdapter";
+import {
+  combineSurfaceTokens,
+  mapSurfaceTokensToAssets,
+  resolveHeroSurfaceAssets,
+} from "./HeroSurfaceMap";
 
-export interface HeroRuntime {
-  /**
-   * TODO: expose runtime hooks for hero rendering integration.
-   */
-  getConfig: (experienceId: string) => Promise<HeroConfig | undefined>;
+interface RuntimeOptions {
+  treatmentSlug?: string;
+  prm?: boolean;
+  timeOfDay?: HeroTimeOfDay;
+}
+
+function pickVariant(variants: HeroVariantConfig[], options: RuntimeOptions): HeroVariantConfig | undefined {
+  if (!variants.length) return undefined;
+  if (options.treatmentSlug) {
+    const treatmentMatch = variants.find((variant) => variant.treatmentSlug === options.treatmentSlug);
+    if (treatmentMatch) return treatmentMatch;
+  }
+
+  if (options.timeOfDay) {
+    const timeMatch = variants.find((variant) => variant.timeOfDay === options.timeOfDay);
+    if (timeMatch) return timeMatch;
+  }
+
+  return variants.find((variant) => variant.id === "default") ?? variants[0];
+}
+
+function mergeContent(base: HeroContentConfig, variant?: Partial<HeroContentConfig>): HeroContentConfig {
+  return {
+    ...base,
+    ...variant,
+    cta: variant?.cta ?? base.cta,
+    secondaryCta: variant?.secondaryCta ?? base.secondaryCta,
+  };
+}
+
+function mergeSurfaceConfig(
+  base: HeroSurfaceTokenConfig,
+  weather?: HeroSurfaceTokenConfig,
+  variant?: HeroSurfaceTokenConfig,
+): HeroSurfaceTokenConfig {
+  return combineSurfaceTokens(base, weather, variant);
+}
+
+function applyPrm(surface: HeroSurfaceConfig, prm?: boolean): HeroSurfaceConfig {
+  if (!prm) return surface;
+  return {
+    ...surface,
+    motion: [],
+    video: undefined,
+  };
+}
+
+export async function getHeroRuntime(options: RuntimeOptions = {}): Promise<HeroRuntimeConfig> {
+  const manifests = loadSacredHeroManifests();
+  const selectedVariant = pickVariant(manifests.variants, options);
+  const weatherConfig = options.timeOfDay ? manifests.weather[options.timeOfDay] : undefined;
+
+  const mergedSurfaceTokens = mergeSurfaceConfig(
+    manifests.base.defaultSurfaces,
+    weatherConfig?.surfaces,
+    selectedVariant?.surfaces,
+  );
+
+  const assetIds = mapSurfaceTokensToAssets(mergedSurfaceTokens, manifests.surfaces);
+  const resolvedSurfaces = resolveHeroSurfaceAssets(applyPrm(assetIds, options.prm));
+  const tone = selectedVariant?.tone ?? weatherConfig?.tone ?? manifests.base.tone;
+  const content = mergeContent(manifests.base.content, selectedVariant?.content);
+
+  return {
+    id: manifests.base.id,
+    tone,
+    content,
+    surfaces: resolvedSurfaces,
+    variant: selectedVariant,
+    flags: {
+      prm: Boolean(options.prm),
+      timeOfDay: options.timeOfDay,
+      treatmentSlug: options.treatmentSlug,
+    },
+  };
 }

--- a/packages/champagne-hero/src/hero-engine/HeroSurfaceMap.ts
+++ b/packages/champagne-hero/src/hero-engine/HeroSurfaceMap.ts
@@ -1,14 +1,187 @@
-export interface HeroSurfaceMapEntry {
-  /**
-   * TODO: map canon surface tokens to hero surfaces.
-   */
-  token: string;
-  surface: string;
+import { ensureHeroAssetPath, resolveHeroAsset } from "../HeroAssetRegistry";
+import type {
+  HeroSurfaceConfig,
+  HeroSurfaceTokenConfig,
+  ResolvedHeroSurfaceConfig,
+} from "./HeroConfig";
+
+export interface HeroSurfaceDefinitionMap {
+  waveMasks?: Record<string, string>;
+  waveBackgrounds?: Record<string, { desktop?: string; mobile?: string }>;
+  overlays?: Record<string, string>;
+  particles?: Record<string, string>;
+  grain?: Record<string, string>;
+  motion?: Record<string, string>;
+  video?: Record<string, string>;
 }
 
-export interface HeroSurfaceMap {
-  /**
-   * TODO: define mapping registry between canon surfaces and hero runtime surfaces.
-   */
-  [token: string]: HeroSurfaceMapEntry | undefined;
+function normalizeRecord(entry: unknown): Record<string, string> {
+  if (!entry || typeof entry !== "object") return {};
+  return Object.entries(entry as Record<string, unknown>)
+    .filter(([, value]) => typeof value === "string")
+    .reduce<Record<string, string>>((acc, [key, value]) => {
+      acc[key] = value as string;
+      return acc;
+    }, {});
+}
+
+export function buildSurfaceDefinitionMap(manifest: unknown): HeroSurfaceDefinitionMap {
+  if (!manifest || typeof manifest !== "object") return {};
+  return {
+    waveMasks: normalizeRecord((manifest as Record<string, unknown>).waveMasks),
+    waveBackgrounds: (() => {
+      const entry = (manifest as Record<string, unknown>).waveBackgrounds;
+      if (!entry || typeof entry !== "object") return {};
+      return Object.entries(entry as Record<string, unknown>).reduce<Record<string, { desktop?: string; mobile?: string }>>(
+        (acc, [key, value]) => {
+          if (!value || typeof value !== "object") return acc;
+          const desktop = (value as Record<string, unknown>).desktop;
+          const mobile = (value as Record<string, unknown>).mobile;
+          acc[key] = {
+            desktop: typeof desktop === "string" ? desktop : undefined,
+            mobile: typeof mobile === "string" ? mobile : undefined,
+          };
+          return acc;
+        },
+        {},
+      );
+    })(),
+    overlays: normalizeRecord((manifest as Record<string, unknown>).overlays),
+    particles: normalizeRecord((manifest as Record<string, unknown>).particles),
+    grain: normalizeRecord((manifest as Record<string, unknown>).grain),
+    motion: normalizeRecord((manifest as Record<string, unknown>).motion),
+    video: normalizeRecord((manifest as Record<string, unknown>).video),
+  };
+}
+
+function resolveToken(token: string | undefined, map: Record<string, string>): string | undefined {
+  if (!token) return undefined;
+  return map[token] ?? token;
+}
+
+function mergeSurfaceTokens(
+  target: HeroSurfaceTokenConfig,
+  source?: HeroSurfaceTokenConfig,
+): HeroSurfaceTokenConfig {
+  if (!source) return target;
+  return {
+    waveMask: {
+      ...target.waveMask,
+      ...source.waveMask,
+    },
+    background: {
+      ...target.background,
+      ...source.background,
+    },
+    overlays: {
+      ...target.overlays,
+      ...source.overlays,
+    },
+    particles: source.particles ?? target.particles,
+    grain: {
+      ...target.grain,
+      ...source.grain,
+    },
+    motion: source.motion ?? target.motion,
+    video: source.video ?? target.video,
+  };
+}
+
+export function combineSurfaceTokens(
+  ...configs: (HeroSurfaceTokenConfig | undefined)[]
+): HeroSurfaceTokenConfig {
+  return configs.reduce<HeroSurfaceTokenConfig>((acc, entry) => mergeSurfaceTokens(acc, entry), {});
+}
+
+export function mapSurfaceTokensToAssets(
+  surfaceTokens: HeroSurfaceTokenConfig,
+  surfaceMap: HeroSurfaceDefinitionMap,
+): HeroSurfaceConfig {
+  return {
+    waveMask: {
+      desktop: resolveToken(surfaceTokens.waveMask?.desktop, surfaceMap.waveMasks ?? {}),
+      mobile: resolveToken(surfaceTokens.waveMask?.mobile ?? surfaceTokens.waveMask?.desktop, surfaceMap.waveMasks ?? {}),
+    },
+    background: (() => {
+      const backgroundToken = surfaceTokens.background?.desktop ?? surfaceTokens.background?.mobile;
+      const backgroundDefinition = backgroundToken ? surfaceMap.waveBackgrounds?.[backgroundToken] : undefined;
+      const fallbackBackground = surfaceMap.waveBackgrounds?.primary;
+      return {
+        desktop: backgroundDefinition?.desktop
+          ?? surfaceMap.waveBackgrounds?.[surfaceTokens.background?.desktop ?? ""]?.desktop
+          ?? fallbackBackground?.desktop,
+        mobile: backgroundDefinition?.mobile
+          ?? surfaceMap.waveBackgrounds?.[surfaceTokens.background?.mobile ?? ""]?.mobile
+          ?? backgroundDefinition?.desktop
+          ?? fallbackBackground?.mobile
+          ?? fallbackBackground?.desktop,
+      };
+    })(),
+    overlays: {
+      dots: resolveToken(surfaceTokens.overlays?.dots, surfaceMap.overlays ?? {}),
+      field: resolveToken(surfaceTokens.overlays?.field, surfaceMap.overlays ?? {}),
+    },
+    particles: resolveToken(surfaceTokens.particles, surfaceMap.particles ?? {}),
+    grain: {
+      desktop: surfaceTokens.grain?.desktop
+        ? surfaceMap.grain?.[surfaceTokens.grain.desktop] ?? surfaceTokens.grain.desktop
+        : surfaceMap.grain?.desktop,
+      mobile: surfaceTokens.grain?.mobile
+        ? surfaceMap.grain?.[surfaceTokens.grain.mobile] ?? surfaceTokens.grain.mobile
+        : surfaceMap.grain?.mobile ?? surfaceMap.grain?.desktop,
+    },
+    motion: surfaceTokens.motion?.map((entry) => resolveToken(entry, surfaceMap.motion ?? {})).filter(Boolean) as string[] | undefined,
+    video: resolveToken(surfaceTokens.video, surfaceMap.video ?? {}),
+  };
+}
+
+export function resolveHeroSurfaceAssets(surfaceConfig: HeroSurfaceConfig): ResolvedHeroSurfaceConfig {
+  return {
+    waveMask: {
+      desktop: resolveHeroAsset(surfaceConfig.waveMask?.desktop),
+      mobile: resolveHeroAsset(surfaceConfig.waveMask?.mobile ?? surfaceConfig.waveMask?.desktop),
+    },
+    background: {
+      desktop: resolveHeroAsset(surfaceConfig.background?.desktop),
+      mobile: resolveHeroAsset(surfaceConfig.background?.mobile ?? surfaceConfig.background?.desktop),
+    },
+    overlays: {
+      dots: resolveHeroAsset(surfaceConfig.overlays?.dots),
+      field: resolveHeroAsset(surfaceConfig.overlays?.field),
+    },
+    particles: resolveHeroAsset(surfaceConfig.particles),
+    grain: {
+      desktop: resolveHeroAsset(surfaceConfig.grain?.desktop),
+      mobile: resolveHeroAsset(surfaceConfig.grain?.mobile ?? surfaceConfig.grain?.desktop),
+    },
+    motion: (surfaceConfig.motion ?? [])
+      .map((entry) => resolveHeroAsset(entry))
+      .filter(Boolean) as ResolvedHeroSurfaceConfig["motion"],
+    video: resolveHeroAsset(surfaceConfig.video),
+  };
+}
+
+export function ensureSurfacePaths(surfaceConfig: HeroSurfaceConfig): HeroSurfaceConfig {
+  return {
+    ...surfaceConfig,
+    waveMask: {
+      desktop: ensureHeroAssetPath(surfaceConfig.waveMask?.desktop),
+      mobile: ensureHeroAssetPath(surfaceConfig.waveMask?.mobile ?? surfaceConfig.waveMask?.desktop),
+    },
+    background: {
+      desktop: ensureHeroAssetPath(surfaceConfig.background?.desktop),
+      mobile: ensureHeroAssetPath(surfaceConfig.background?.mobile ?? surfaceConfig.background?.desktop),
+    },
+    overlays: {
+      dots: ensureHeroAssetPath(surfaceConfig.overlays?.dots),
+      field: ensureHeroAssetPath(surfaceConfig.overlays?.field),
+    },
+    particles: ensureHeroAssetPath(surfaceConfig.particles),
+    grain: {
+      desktop: ensureHeroAssetPath(surfaceConfig.grain?.desktop),
+      mobile: ensureHeroAssetPath(surfaceConfig.grain?.mobile ?? surfaceConfig.grain?.desktop),
+    },
+    motion: surfaceConfig.motion?.map((entry) => ensureHeroAssetPath(entry)).filter(Boolean) as string[] | undefined,
+    video: ensureHeroAssetPath(surfaceConfig.video),
+  };
 }

--- a/packages/champagne-hero/src/index.ts
+++ b/packages/champagne-hero/src/index.ts
@@ -7,6 +7,13 @@ export {
   resolveHeroVariant,
   type HeroRegistryEntry,
 } from "./HeroRegistry";
+export {
+  getHeroRuntime,
+  type HeroRuntimeConfig,
+  type HeroSurfaceConfig,
+  type HeroSurfaceTokenConfig,
+  type HeroTimeOfDay,
+} from "./hero-engine";
 
 export const placeholder = {
   package: "@champagne/hero",

--- a/packages/champagne-manifests/data/hero/sacred_hero_base.json
+++ b/packages/champagne-manifests/data/hero/sacred_hero_base.json
@@ -1,3 +1,22 @@
 {
-  "//": "TODO: add sacred hero base manifest"
+  "id": "sacred-home-hero",
+  "content": {
+    "eyebrow": "Champagne Dentistry",
+    "headline": "Advanced cosmetic dentistry crafted with calm precision.",
+    "subheadline": "Digital workflows, gentle clinicians, and beautifully layered studio light for confident smiles.",
+    "cta": { "label": "Book a consultation", "href": "/book" },
+    "secondaryCta": { "label": "Explore treatments", "href": "/treatments" }
+  },
+  "defaults": {
+    "tone": "night",
+    "surfaces": {
+      "waveMask": { "desktop": "primary", "mobile": "mobile" },
+      "background": { "desktop": "primary", "mobile": "primary" },
+      "overlays": { "dots": "dots", "field": "field" },
+      "particles": "base",
+      "grain": { "desktop": "desktop", "mobile": "mobile" },
+      "motion": ["wave", "glass"],
+      "video": "heroVideo"
+    }
+  }
 }

--- a/packages/champagne-manifests/data/hero/sacred_hero_surfaces.json
+++ b/packages/champagne-manifests/data/hero/sacred_hero_surfaces.json
@@ -1,3 +1,34 @@
 {
-  "//": "TODO: add sacred hero surfaces"
+  "waveMasks": {
+    "primary": "sacred.wave.mask.desktop",
+    "mobile": "sacred.wave.mask.mobile",
+    "header": "sacred.wave.mask.header",
+    "smh": "sacred.wave.mask.smh"
+  },
+  "waveBackgrounds": {
+    "primary": { "desktop": "sacred.wave.background.desktop", "mobile": "sacred.wave.background.mobile" }
+  },
+  "overlays": {
+    "dots": "sacred.wave.overlay.dots",
+    "field": "sacred.wave.overlay.field"
+  },
+  "particles": {
+    "base": "sacred.particles.home",
+    "gold": "sacred.particles.gold",
+    "magenta": "sacred.particles.magenta",
+    "teal": "sacred.particles.teal"
+  },
+  "grain": {
+    "desktop": "sacred.grain.desktop",
+    "mobile": "sacred.grain.mobile"
+  },
+  "motion": {
+    "wave": "sacred.motion.waveCaustics",
+    "glass": "sacred.motion.glassShimmer",
+    "dust": "sacred.motion.goldDust",
+    "drift": "sacred.motion.particleDrift"
+  },
+  "video": {
+    "heroVideo": "sacred.motion.heroVideo"
+  }
 }

--- a/packages/champagne-manifests/data/hero/sacred_hero_variants.json
+++ b/packages/champagne-manifests/data/hero/sacred_hero_variants.json
@@ -1,3 +1,27 @@
 {
-  "//": "TODO: add sacred hero variants"
+  "variants": [
+    {
+      "id": "default",
+      "label": "Sacred night base",
+      "tone": "night",
+      "surfaces": {
+        "particles": "base",
+        "motion": ["wave", "glass"]
+      }
+    },
+    {
+      "id": "day",
+      "label": "Daylight shimmer",
+      "timeOfDay": "day",
+      "tone": "day",
+      "surfaces": {
+        "particles": "teal",
+        "motion": ["glass"]
+      },
+      "content": {
+        "headline": "Daylight smile confidence.",
+        "subheadline": "Bright, precise dentistry with a calm studio feel."
+      }
+    }
+  ]
 }

--- a/packages/champagne-manifests/data/hero/sacred_hero_weather.json
+++ b/packages/champagne-manifests/data/hero/sacred_hero_weather.json
@@ -1,3 +1,23 @@
 {
-  "//": "TODO: add sacred hero weather"
+  "day": {
+    "tone": "day",
+    "surfaces": {
+      "particles": "teal",
+      "motion": ["glass"]
+    }
+  },
+  "evening": {
+    "tone": "evening",
+    "surfaces": {
+      "particles": "gold",
+      "motion": ["dust"]
+    }
+  },
+  "night": {
+    "tone": "night",
+    "surfaces": {
+      "particles": "base",
+      "motion": ["wave"]
+    }
+  }
 }

--- a/packages/champagne-tokens/styles/champagne/surface.css
+++ b/packages/champagne-tokens/styles/champagne/surface.css
@@ -1,13 +1,13 @@
 :root {
   /* Canonical surface assets (paths stable; binaries uploaded separately) */
-  --grain-desktop: url("/assets/champagne/film-grain-desktop.webp");
-  --grain-mobile:  url("/assets/champagne/film-grain-mobile.webp");
-  --particles:     url("/assets/champagne/home-hero-particles.webp");
-  --wave-mask:     url("/assets/champagne/wave-mask-desktop.webp");
+  --grain-desktop: url("/assets/champagne/film-grain/film-grain-desktop .webp");
+  --grain-mobile:  url("/assets/champagne/film-grain/film-grain-mobile .webp");
+  --particles:     url("/assets/champagne/particles/home-hero-particles.webp");
+  --wave-mask:     url("/assets/champagne/waves/wave-mask-desktop.webp");
 }
 
 @media (max-width: 640px) {
-  :root { --wave-mask: url("/assets/champagne/wave-mask-mobile.webp"); }
+  :root { --wave-mask: url("/assets/champagne/waves/wave-mask-mobile.webp"); }
 }
 
 /* Layer order: gradient → wave mask → particles → grain → glass → content */


### PR DESCRIPTION
## Summary
- populate sacred hero manifests and registry entries with brand-safe asset paths and surface tokens
- implement hero engine adapters/runtime to merge base, variants, weather, and PRM-safe surface resolution
- render sacred hero via HeroRenderer with runtime-configured layers and corrected surface token paths

## Testing
- npm run lint --workspaces=false
- npm run build --workspace @champagne/hero
- npm run build --workspace web


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693714a26c9c8332b97163126be4860b)