### PR TITLE
Add treatment hero variants and preview route

### DIFF
--- a/apps/web/app/champagne/hero-engine-preview/DevPanel.tsx
+++ b/apps/web/app/champagne/hero-engine-preview/DevPanel.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import { useCallback } from "react";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+
+const variantOptions = [
+  { label: "Sacred hero (current)", value: "" },
+  { label: "Veneers", value: "veneers_calm_precision" },
+  { label: "Implants", value: "implants_tech_precision" },
+  { label: "Whitening", value: "whitening_bright_pop" },
+  { label: "Ortho", value: "ortho_progression" },
+];
+
+interface DevPanelProps {
+  variantId?: string;
+  prm?: boolean;
+}
+
+export function DevPanel({ variantId, prm }: DevPanelProps) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  const updateParam = useCallback(
+    (key: string, value?: string | null) => {
+      const params = new URLSearchParams(searchParams?.toString());
+      if (value) {
+        params.set(key, value);
+      } else {
+        params.delete(key);
+      }
+      const query = params.toString();
+      const next = query ? `${pathname}?${query}` : pathname;
+      router.replace(next, { scroll: false });
+    },
+    [pathname, router, searchParams],
+  );
+
+  return (
+    <div
+      style={{
+        position: "absolute",
+        top: "1.25rem",
+        right: "1.25rem",
+        display: "grid",
+        gap: "0.75rem",
+        padding: "1rem",
+        borderRadius: "var(--radius-lg)",
+        background: "var(--surface-ink-soft, rgba(6,7,12,0.65))",
+        border: "1px solid var(--champagne-keyline-gold, rgba(255, 215, 137, 0.4))",
+        boxShadow: "0 14px 40px rgba(0,0,0,0.35)",
+        minWidth: "240px",
+        color: "var(--text-high)",
+        zIndex: 4,
+      }}
+    >
+      <div style={{ display: "grid", gap: "0.5rem" }}>
+        <label style={{ fontWeight: 600 }}>Variant</label>
+        <select
+          value={variantId ?? ""}
+          onChange={(event) => updateParam("variant", event.target.value || null)}
+          style={{
+            padding: "0.65rem 0.75rem",
+            borderRadius: "var(--radius-md)",
+            background: "var(--surface-ink-soft, rgba(6,7,12,0.85))",
+            color: "var(--text-high)",
+            border: "1px solid var(--champagne-keyline-gold, rgba(255, 215, 137, 0.35))",
+          }}
+        >
+          {variantOptions.map((variant) => (
+            <option key={variant.value || "base"} value={variant.value}>
+              {variant.label}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <label style={{ display: "flex", gap: "0.6rem", alignItems: "center" }}>
+        <input
+          type="checkbox"
+          checked={Boolean(prm)}
+          onChange={(event) => updateParam("prm", event.target.checked ? "1" : null)}
+        />
+        <span>Reduced motion (simulated)</span>
+      </label>
+    </div>
+  );
+}

--- a/apps/web/app/champagne/hero-engine-preview/page.tsx
+++ b/apps/web/app/champagne/hero-engine-preview/page.tsx
@@ -1,0 +1,26 @@
+import { HeroRenderer } from "../../components/hero/HeroRenderer";
+import { DevPanel } from "./DevPanel";
+
+type PreviewSearchParams = Promise<Record<string, string | string[] | undefined> | undefined> | undefined;
+
+export default async function Page({ searchParams }: { searchParams?: PreviewSearchParams }) {
+  const resolvedSearchParams = await searchParams;
+  const variantParam = resolvedSearchParams?.variant;
+  const variantId = Array.isArray(variantParam) ? variantParam[0] : variantParam;
+  const prmParam = resolvedSearchParams?.prm;
+  const prm = Array.isArray(prmParam) ? prmParam[0] === "1" : prmParam === "1";
+
+  return (
+    <main
+      style={{
+        position: "relative",
+        minHeight: "100vh",
+        background: "var(--surface-ink-soft)",
+        color: "var(--text-high)",
+      }}
+    >
+      <DevPanel variantId={variantId} prm={prm} />
+      <HeroRenderer variantId={variantId || undefined} prm={prm} />
+    </main>
+  );
+}

--- a/apps/web/app/components/hero/HeroRenderer.tsx
+++ b/apps/web/app/components/hero/HeroRenderer.tsx
@@ -1,7 +1,14 @@
 import type { CSSProperties } from "react";
-import { BaseChampagneSurface, getHeroRuntime, type HeroTimeOfDay } from "@champagne/hero";
+import {
+  BaseChampagneSurface,
+  getHeroRuntime,
+  type HeroRuntimeOptions,
+  type HeroTimeOfDay,
+} from "@champagne/hero";
 
 export interface HeroRendererProps {
+  heroId?: HeroRuntimeOptions["heroId"];
+  variantId?: HeroRuntimeOptions["variantId"];
   treatmentSlug?: string;
   prm?: boolean;
   timeOfDay?: HeroTimeOfDay;
@@ -34,11 +41,11 @@ function HeroFallback() {
   );
 }
 
-export async function HeroRenderer({ treatmentSlug, prm, timeOfDay }: HeroRendererProps) {
+export async function HeroRenderer({ heroId, variantId, treatmentSlug, prm, timeOfDay }: HeroRendererProps) {
   let runtime: Awaited<ReturnType<typeof getHeroRuntime>> | null = null;
 
   try {
-    runtime = await getHeroRuntime({ treatmentSlug, prm, timeOfDay });
+    runtime = await getHeroRuntime({ heroId, variantId, treatmentSlug, prm, timeOfDay });
   } catch (error) {
     if (process.env.NODE_ENV !== "production") {
       console.error("Hero runtime failed", error);

--- a/packages/champagne-hero/src/hero-engine/HeroConfig.ts
+++ b/packages/champagne-hero/src/hero-engine/HeroConfig.ts
@@ -107,6 +107,8 @@ export interface HeroRuntimeConfig {
   variant?: HeroVariantConfig;
   flags: {
     prm: boolean;
+    heroId?: string;
+    variantId?: string;
     timeOfDay?: HeroTimeOfDay;
     treatmentSlug?: string;
   };

--- a/packages/champagne-hero/src/index.ts
+++ b/packages/champagne-hero/src/index.ts
@@ -9,9 +9,11 @@ export {
 } from "./HeroRegistry";
 export {
   getHeroRuntime,
+  getTreatmentHeroConfig,
   type HeroRuntimeConfig,
   type HeroSurfaceConfig,
   type HeroSurfaceTokenConfig,
+  type HeroRuntimeOptions,
   type HeroTimeOfDay,
 } from "./hero-engine";
 

--- a/packages/champagne-manifests/data/hero/sacred_hero_variants.json
+++ b/packages/champagne-manifests/data/hero/sacred_hero_variants.json
@@ -1,8 +1,8 @@
 {
   "variants": [
     {
-      "id": "default",
-      "label": "Sacred night base",
+      "id": "base_sacred_hero",
+      "label": "Sacred hero base",
       "tone": "night",
       "surfaces": {
         "particles": "base",
@@ -10,17 +10,43 @@
       }
     },
     {
-      "id": "day",
-      "label": "Daylight shimmer",
-      "timeOfDay": "day",
-      "tone": "day",
+      "id": "veneers_calm_precision",
+      "label": "Veneers calm precision",
+      "treatmentSlug": "veneers",
+      "tone": "evening",
       "surfaces": {
         "particles": "teal",
         "motion": ["glass"]
-      },
-      "content": {
-        "headline": "Daylight smile confidence.",
-        "subheadline": "Bright, precise dentistry with a calm studio feel."
+      }
+    },
+    {
+      "id": "implants_tech_precision",
+      "label": "Implants technical precision",
+      "treatmentSlug": "dental-implants",
+      "tone": "night",
+      "surfaces": {
+        "particles": "gold",
+        "motion": ["glass", "drift"]
+      }
+    },
+    {
+      "id": "whitening_bright_pop",
+      "label": "Whitening bright pop",
+      "treatmentSlug": "teeth-whitening",
+      "tone": "day",
+      "surfaces": {
+        "particles": "magenta",
+        "motion": ["glass"]
+      }
+    },
+    {
+      "id": "ortho_progression",
+      "label": "Ortho progression",
+      "treatmentSlug": "spark-clear-aligners",
+      "tone": "night",
+      "surfaces": {
+        "particles": "base",
+        "motion": ["wave"]
       }
     }
   ]


### PR DESCRIPTION
## Summary
- add sacred hero treatment variants in manifests (base_sacred_hero, veneers_calm_precision, implants_tech_precision, whitening_bright_pop, ortho_progression)
- map treatment slugs to variant lookups and extend hero runtime with heroId/variantId support
- create internal /champagne/hero-engine-preview route with a dev panel to toggle variants and simulated reduced motion

## Treatment mapping
- veneers → veneers_calm_precision
- dental-implants → implants_tech_precision
- teeth-whitening → whitening_bright_pop
- spark-clear-aligners → ortho_progression

## Preview route
- /champagne/hero-engine-preview

## TODO
- polish variant-specific copy and visual tuning in a later Manus pass

## Testing
- npm run lint --workspaces=false
- npm run build --workspace @champagne/hero
- npm run build --workspace web

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69371bb2ee388332b5eee246a2e19b87)