### PR TITLE
Wire sacred hero variants and hero lab preview

### DIFF
--- a/apps/web/app/champagne/hero-lab/page.tsx
+++ b/apps/web/app/champagne/hero-lab/page.tsx
@@ -1,0 +1,156 @@
+import { HeroRenderer } from "../../components/hero/HeroRenderer";
+import type { HeroMode, HeroTimeOfDay } from "@champagne/hero";
+
+const TREATMENT_SLUGS: { label: string; slug: string }[] = [
+  { label: "Teeth whitening", slug: "teeth-whitening" },
+  { label: "Dental implants", slug: "dental-implants" },
+  { label: "Spark aligners", slug: "spark-aligners" },
+  { label: "Porcelain veneers", slug: "porcelain-veneers" },
+  { label: "Digital technology", slug: "dental-technology" },
+];
+
+function normalizeBoolean(value: string | string[] | undefined, defaultValue: boolean): boolean {
+  if (Array.isArray(value)) return value.includes("true") ? true : value.includes("false") ? false : defaultValue;
+  if (typeof value === "string") return value === "true";
+  return defaultValue;
+}
+
+function normalizeMode(value: string | string[] | undefined): HeroMode {
+  return value === "treatment" ? "treatment" : "home";
+}
+
+function normalizeTimeOfDay(value: string | string[] | undefined): HeroTimeOfDay | undefined {
+  if (value === "day" || value === "evening" || value === "night") return value;
+  return undefined;
+}
+
+export default async function HeroLabPage({
+  searchParams,
+}: {
+  searchParams?: Promise<Record<string, string | string[] | undefined>>;
+}) {
+  const resolvedParams = (await searchParams) ?? {};
+  const mode = normalizeMode(resolvedParams.mode);
+  const timeOfDay = normalizeTimeOfDay(resolvedParams.timeOfDay);
+  const treatmentSlug = typeof resolvedParams.treatmentSlug === "string" ? resolvedParams.treatmentSlug : undefined;
+  const prm = normalizeBoolean(resolvedParams.prm, false);
+  const particles = normalizeBoolean(resolvedParams.particles, true);
+  const filmGrain = normalizeBoolean(resolvedParams.filmGrain, true);
+  const theme = resolvedParams.theme === "light" ? "light" : "dark";
+
+  return (
+    <div
+      style={{
+        display: "grid",
+        gap: "1.5rem",
+        padding: "clamp(1.5rem, 4vw, 2.5rem)",
+        background: "var(--bg-ink)",
+        color: "var(--text-high)",
+      }}
+      data-theme={theme}
+    >
+      <header style={{ display: "grid", gap: "0.35rem" }}>
+        <p style={{ letterSpacing: "0.12em", textTransform: "uppercase", color: "var(--text-medium)" }}>Internal preview</p>
+        <h1 style={{ fontSize: "clamp(1.6rem, 2.4vw, 2.2rem)", fontWeight: 700 }}>Hero Lab</h1>
+        <p style={{ color: "var(--text-medium)", maxWidth: "760px", lineHeight: 1.5 }}>
+          Inspect sacred hero variants, motion safety, and manifests. Use this surface to sanity check treatment slugs before
+          shipping.
+        </p>
+      </header>
+
+      <form
+        style={{
+          display: "grid",
+          gap: "1rem",
+          padding: "1rem",
+          borderRadius: "var(--radius-lg)",
+          border: "1px solid var(--champagne-keyline-gold)",
+          background: "var(--surface-ink-soft)",
+        }}
+      >
+        <div style={{ display: "grid", gap: "0.35rem", gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))" }}>
+          <label style={{ display: "grid", gap: "0.35rem" }}>
+            <span style={{ color: "var(--text-medium)", fontSize: "0.95rem" }}>Mode</span>
+            <select name="mode" defaultValue={mode} style={{ padding: "0.75rem", borderRadius: "var(--radius-md)" }}>
+              <option value="home">Home</option>
+              <option value="treatment">Treatment</option>
+            </select>
+          </label>
+
+          <label style={{ display: "grid", gap: "0.35rem" }}>
+            <span style={{ color: "var(--text-medium)", fontSize: "0.95rem" }}>Treatment slug</span>
+            <select
+              name="treatmentSlug"
+              defaultValue={treatmentSlug ?? ""}
+              disabled={mode !== "treatment"}
+              style={{ padding: "0.75rem", borderRadius: "var(--radius-md)" }}
+            >
+              <option value="">(none)</option>
+              {TREATMENT_SLUGS.map((entry) => (
+                <option key={entry.slug} value={entry.slug}>
+                  {entry.label}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <label style={{ display: "grid", gap: "0.35rem" }}>
+            <span style={{ color: "var(--text-medium)", fontSize: "0.95rem" }}>Time of day</span>
+            <select name="timeOfDay" defaultValue={timeOfDay ?? ""} style={{ padding: "0.75rem", borderRadius: "var(--radius-md)" }}>
+              <option value="">Auto</option>
+              <option value="day">Day</option>
+              <option value="evening">Evening</option>
+              <option value="night">Night</option>
+            </select>
+          </label>
+
+          <label style={{ display: "grid", gap: "0.35rem" }}>
+            <span style={{ color: "var(--text-medium)", fontSize: "0.95rem" }}>Theme</span>
+            <select name="theme" defaultValue={theme} style={{ padding: "0.75rem", borderRadius: "var(--radius-md)" }}>
+              <option value="dark">Dark</option>
+              <option value="light">Light</option>
+            </select>
+          </label>
+        </div>
+
+        <div style={{ display: "flex", gap: "1rem", flexWrap: "wrap" }}>
+          <label style={{ display: "flex", gap: "0.5rem", alignItems: "center" }}>
+            <input type="hidden" name="prm" value="false" />
+            <input type="checkbox" name="prm" value="true" defaultChecked={prm} />
+            <span>Simulate reduced motion</span>
+          </label>
+          <label style={{ display: "flex", gap: "0.5rem", alignItems: "center" }}>
+            <input type="hidden" name="particles" value="false" />
+            <input type="checkbox" name="particles" value="true" defaultChecked={particles} />
+            <span>Particles</span>
+          </label>
+          <label style={{ display: "flex", gap: "0.5rem", alignItems: "center" }}>
+            <input type="hidden" name="filmGrain" value="false" />
+            <input type="checkbox" name="filmGrain" value="true" defaultChecked={filmGrain} />
+            <span>Film grain</span>
+          </label>
+        </div>
+
+        <div style={{ display: "flex", gap: "0.75rem", alignItems: "center" }}>
+          <button type="submit" style={{ padding: "0.75rem 1.1rem", borderRadius: "var(--radius-md)" }}>
+            Refresh preview
+          </button>
+          <span style={{ color: "var(--text-medium)", fontSize: "0.95rem" }}>
+            Params update via query string for easy sharing.
+          </span>
+        </div>
+      </form>
+
+      <div style={{ borderRadius: "var(--radius-lg)", overflow: "hidden", border: "1px solid var(--champagne-keyline-gold)" }}>
+        <HeroRenderer
+          mode={mode}
+          treatmentSlug={mode === "treatment" ? treatmentSlug : undefined}
+          prm={prm}
+          timeOfDay={timeOfDay}
+          particles={particles}
+          filmGrain={filmGrain}
+        />
+      </div>
+    </div>
+  );
+}

--- a/packages/champagne-hero/src/hero-engine/HeroConfig.ts
+++ b/packages/champagne-hero/src/hero-engine/HeroConfig.ts
@@ -16,6 +16,36 @@ export interface HeroContentConfig {
   secondaryCta?: HeroCTAConfig;
 }
 
+export type HeroMode = "home" | "treatment";
+
+export type HeroEnergyMode = "calm" | "balanced" | "dynamic";
+
+export interface HeroFilmGrainSettings {
+  enabled?: boolean;
+  opacity?: number;
+}
+
+export interface HeroParticleBehavior {
+  density?: number;
+  speed?: number;
+  curve?: "calm" | "sway" | "dynamic";
+}
+
+export interface HeroMotionTuning {
+  parallaxDepth?: number;
+  shimmerIntensity?: number;
+  particleDrift?: number;
+  energyMode?: HeroEnergyMode;
+  particles?: HeroParticleBehavior;
+}
+
+export interface HeroLayoutConfig {
+  contentAlign?: "start" | "center";
+  maxWidth?: number;
+  verticalOffset?: string;
+  padding?: string;
+}
+
 export interface HeroSurfaceTokenConfig {
   waveMask?: {
     desktop?: string;
@@ -25,6 +55,7 @@ export interface HeroSurfaceTokenConfig {
     desktop?: string;
     mobile?: string;
   };
+  gradient?: string;
   overlays?: {
     dots?: string;
     field?: string;
@@ -47,6 +78,7 @@ export interface HeroSurfaceConfig {
     desktop?: string;
     mobile?: string;
   };
+  gradient?: string;
   overlays?: {
     dots?: string;
     field?: string;
@@ -69,6 +101,7 @@ export interface ResolvedHeroSurfaceConfig {
     desktop?: HeroAssetEntry;
     mobile?: HeroAssetEntry;
   };
+  gradient?: string;
   overlays?: {
     dots?: HeroAssetEntry;
     field?: HeroAssetEntry;
@@ -87,6 +120,9 @@ export interface HeroBaseConfig {
   tone?: string;
   content: HeroContentConfig;
   defaultSurfaces: HeroSurfaceTokenConfig;
+  layout?: HeroLayoutConfig;
+  motion?: HeroMotionTuning;
+  filmGrain?: HeroFilmGrainSettings;
 }
 
 export interface HeroVariantConfig {
@@ -95,8 +131,12 @@ export interface HeroVariantConfig {
   tone?: string;
   treatmentSlug?: string;
   timeOfDay?: HeroTimeOfDay;
+  energyMode?: HeroEnergyMode;
   content?: Partial<HeroContentConfig>;
   surfaces?: HeroSurfaceTokenConfig;
+  layout?: HeroLayoutConfig;
+  motion?: HeroMotionTuning;
+  filmGrain?: HeroFilmGrainSettings;
 }
 
 export interface HeroRuntimeConfig {
@@ -104,9 +144,14 @@ export interface HeroRuntimeConfig {
   tone?: string;
   content: HeroContentConfig;
   surfaces: ResolvedHeroSurfaceConfig;
+  layout: HeroLayoutConfig;
+  motion: HeroMotionTuning;
+  filmGrain: HeroFilmGrainSettings;
+  energyMode?: HeroEnergyMode;
   variant?: HeroVariantConfig;
   flags: {
     prm: boolean;
+    mode: HeroMode;
     timeOfDay?: HeroTimeOfDay;
     treatmentSlug?: string;
   };

--- a/packages/champagne-hero/src/hero-engine/HeroManifestAdapter.ts
+++ b/packages/champagne-hero/src/hero-engine/HeroManifestAdapter.ts
@@ -5,6 +5,9 @@ import weatherManifest from "../../../champagne-manifests/data/hero/sacred_hero_
 import type {
   HeroBaseConfig,
   HeroContentConfig,
+  HeroFilmGrainSettings,
+  HeroLayoutConfig,
+  HeroMotionTuning,
   HeroSurfaceTokenConfig,
   HeroTimeOfDay,
   HeroVariantConfig,
@@ -18,6 +21,8 @@ interface SacredHeroBaseManifest {
   defaults?: {
     tone?: string;
     surfaces?: HeroSurfaceTokenConfig;
+    layout?: HeroLayoutConfig;
+    filmGrain?: HeroFilmGrainSettings;
   };
 }
 
@@ -25,7 +30,12 @@ interface SacredHeroVariantsManifest {
   variants?: HeroVariantConfig[];
 }
 
-type SacredHeroWeatherManifest = Partial<Record<HeroTimeOfDay, { tone?: string; surfaces?: HeroSurfaceTokenConfig }>>;
+type SacredHeroWeatherManifest = Partial<
+  Record<
+    HeroTimeOfDay,
+    { tone?: string; surfaces?: HeroSurfaceTokenConfig; layout?: HeroLayoutConfig; motion?: HeroMotionTuning; filmGrain?: HeroFilmGrainSettings }
+  >
+>;
 
 export interface SacredHeroManifests {
   base: HeroBaseConfig;
@@ -47,6 +57,8 @@ function normalizeBaseManifest(manifest: SacredHeroBaseManifest): HeroBaseConfig
     tone: manifest.defaults?.tone,
     content,
     defaultSurfaces: defaults,
+    layout: manifest.defaults?.layout,
+    filmGrain: manifest.defaults?.filmGrain,
   };
 }
 
@@ -60,8 +72,12 @@ function normalizeVariants(manifest: SacredHeroVariantsManifest): HeroVariantCon
       tone: (variant as HeroVariantConfig).tone,
       treatmentSlug: (variant as HeroVariantConfig).treatmentSlug,
       timeOfDay: (variant as HeroVariantConfig).timeOfDay,
+      energyMode: (variant as HeroVariantConfig).energyMode,
       content: (variant as HeroVariantConfig).content,
       surfaces: (variant as HeroVariantConfig).surfaces,
+      layout: (variant as HeroVariantConfig).layout,
+      motion: (variant as HeroVariantConfig).motion,
+      filmGrain: (variant as HeroVariantConfig).filmGrain,
     }));
 }
 

--- a/packages/champagne-hero/src/hero-engine/HeroRuntime.ts
+++ b/packages/champagne-hero/src/hero-engine/HeroRuntime.ts
@@ -1,5 +1,9 @@
 import type {
   HeroContentConfig,
+  HeroFilmGrainSettings,
+  HeroLayoutConfig,
+  HeroMode,
+  HeroMotionTuning,
   HeroRuntimeConfig,
   HeroSurfaceConfig,
   HeroSurfaceTokenConfig,
@@ -14,14 +18,49 @@ import {
 } from "./HeroSurfaceMap";
 
 interface RuntimeOptions {
+  mode?: HeroMode;
   treatmentSlug?: string;
   prm?: boolean;
   timeOfDay?: HeroTimeOfDay;
+  particles?: boolean;
+  filmGrain?: boolean;
+}
+
+const DEFAULT_LAYOUT: HeroLayoutConfig = {
+  contentAlign: "start",
+  maxWidth: 960,
+  verticalOffset: "0px",
+  padding: "clamp(2rem, 4vw, 3.5rem)",
+};
+
+const DEFAULT_FILM_GRAIN: Required<HeroFilmGrainSettings> = {
+  enabled: true,
+  opacity: 0.3,
+};
+
+const DEFAULT_MOTION: Required<HeroMotionTuning> = {
+  parallaxDepth: 18,
+  shimmerIntensity: 1,
+  particleDrift: 1,
+  energyMode: "balanced",
+  particles: {
+    density: 1,
+    speed: 1,
+    curve: "sway",
+  },
+};
+
+function resolvePrmFlag(options: RuntimeOptions): boolean {
+  if (typeof options.prm === "boolean") return options.prm;
+  if (typeof window !== "undefined" && typeof window.matchMedia === "function") {
+    return window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+  }
+  return false;
 }
 
 function pickVariant(variants: HeroVariantConfig[], options: RuntimeOptions): HeroVariantConfig | undefined {
   if (!variants.length) return undefined;
-  if (options.treatmentSlug) {
+  if ((options.mode ?? "home") === "treatment" && options.treatmentSlug) {
     const treatmentMatch = variants.find((variant) => variant.treatmentSlug === options.treatmentSlug);
     if (treatmentMatch) return treatmentMatch;
   }
@@ -43,6 +82,88 @@ function mergeContent(base: HeroContentConfig, variant?: Partial<HeroContentConf
   };
 }
 
+function mergeLayout(
+  base?: HeroLayoutConfig,
+  weather?: HeroLayoutConfig,
+  variant?: HeroLayoutConfig,
+): HeroLayoutConfig {
+  return {
+    ...DEFAULT_LAYOUT,
+    ...base,
+    ...weather,
+    ...variant,
+  };
+}
+
+function mergeMotion(
+  base?: HeroMotionTuning,
+  weather?: HeroMotionTuning,
+  variant?: HeroMotionTuning,
+  options?: RuntimeOptions,
+): HeroMotionTuning {
+  const merged: HeroMotionTuning = {
+    ...DEFAULT_MOTION,
+    ...base,
+    ...weather,
+    ...variant,
+    energyMode: variant?.energyMode ?? weather?.energyMode ?? base?.energyMode ?? DEFAULT_MOTION.energyMode,
+    particles: {
+      ...DEFAULT_MOTION.particles,
+      ...base?.particles,
+      ...weather?.particles,
+      ...variant?.particles,
+    },
+  };
+
+  if (options?.particles === false) {
+    merged.particles = {
+      ...merged.particles,
+      density: 0,
+      speed: 0,
+    };
+  }
+
+  const prm = resolvePrmFlag(options ?? {});
+  if (prm) {
+    merged.parallaxDepth = 0;
+    merged.shimmerIntensity = (merged.shimmerIntensity ?? 1) * 0.35;
+    merged.particleDrift = (merged.particleDrift ?? 1) * 0.4;
+    merged.particles = merged.particles
+      ? {
+          ...merged.particles,
+          density: (merged.particles.density ?? 1) * 0.35,
+          speed: (merged.particles.speed ?? 1) * 0.5,
+        }
+      : merged.particles;
+  }
+
+  return merged;
+}
+
+function mergeFilmGrain(
+  base?: HeroFilmGrainSettings,
+  weather?: HeroFilmGrainSettings,
+  variant?: HeroFilmGrainSettings,
+  options?: RuntimeOptions,
+): HeroFilmGrainSettings {
+  const merged: HeroFilmGrainSettings = {
+    ...DEFAULT_FILM_GRAIN,
+    ...base,
+    ...weather,
+    ...variant,
+  };
+
+  if (options?.filmGrain === false) {
+    merged.enabled = false;
+  }
+
+  if (resolvePrmFlag(options ?? {})) {
+    merged.opacity = (merged.opacity ?? DEFAULT_FILM_GRAIN.opacity) * 0.6;
+  }
+
+  return merged;
+}
+
 function mergeSurfaceConfig(
   base: HeroSurfaceTokenConfig,
   weather?: HeroSurfaceTokenConfig,
@@ -62,8 +183,19 @@ function applyPrm(surface: HeroSurfaceConfig, prm?: boolean): HeroSurfaceConfig 
 
 export async function getHeroRuntime(options: RuntimeOptions = {}): Promise<HeroRuntimeConfig> {
   const manifests = loadSacredHeroManifests();
-  const selectedVariant = pickVariant(manifests.variants, options);
+  const mode: HeroMode = options.mode ?? "home";
+  const prmFlag = resolvePrmFlag(options);
+  const variantCandidate = pickVariant(manifests.variants, options);
   const weatherConfig = options.timeOfDay ? manifests.weather[options.timeOfDay] : undefined;
+  const shouldFallbackToBase =
+    mode === "treatment" && Boolean(options.treatmentSlug) && variantCandidate?.treatmentSlug !== options.treatmentSlug;
+  const selectedVariant = shouldFallbackToBase ? undefined : variantCandidate;
+
+  if (shouldFallbackToBase && process.env.NODE_ENV !== "production") {
+    console.warn(
+      `[hero] No sacred variant found for treatment slug "${options.treatmentSlug}". Falling back to home hero visuals.`,
+    );
+  }
 
   const mergedSurfaceTokens = mergeSurfaceConfig(
     manifests.base.defaultSurfaces,
@@ -72,18 +204,27 @@ export async function getHeroRuntime(options: RuntimeOptions = {}): Promise<Hero
   );
 
   const assetIds = mapSurfaceTokensToAssets(mergedSurfaceTokens, manifests.surfaces);
-  const resolvedSurfaces = resolveHeroSurfaceAssets(applyPrm(assetIds, options.prm));
+  const resolvedSurfaces = resolveHeroSurfaceAssets(applyPrm(assetIds, prmFlag));
   const tone = selectedVariant?.tone ?? weatherConfig?.tone ?? manifests.base.tone;
   const content = mergeContent(manifests.base.content, selectedVariant?.content);
+  const layout = mergeLayout(manifests.base.layout, weatherConfig?.layout, selectedVariant?.layout);
+  const motion = mergeMotion(manifests.base.motion, weatherConfig?.motion, selectedVariant?.motion, options);
+  const filmGrain = mergeFilmGrain(manifests.base.filmGrain, weatherConfig?.filmGrain, selectedVariant?.filmGrain, options);
+  const energyMode = selectedVariant?.energyMode ?? motion.energyMode;
 
   return {
     id: manifests.base.id,
     tone,
     content,
     surfaces: resolvedSurfaces,
+    layout,
+    motion,
+    filmGrain,
+    energyMode,
     variant: selectedVariant,
     flags: {
-      prm: Boolean(options.prm),
+      prm: prmFlag,
+      mode,
       timeOfDay: options.timeOfDay,
       treatmentSlug: options.treatmentSlug,
     },

--- a/packages/champagne-hero/src/hero-engine/HeroSurfaceMap.ts
+++ b/packages/champagne-hero/src/hero-engine/HeroSurfaceMap.ts
@@ -8,6 +8,7 @@ import type {
 export interface HeroSurfaceDefinitionMap {
   waveMasks?: Record<string, string>;
   waveBackgrounds?: Record<string, { desktop?: string; mobile?: string }>;
+  gradients?: Record<string, string>;
   overlays?: Record<string, string>;
   particles?: Record<string, string>;
   grain?: Record<string, string>;
@@ -46,6 +47,7 @@ export function buildSurfaceDefinitionMap(manifest: unknown): HeroSurfaceDefinit
         {},
       );
     })(),
+    gradients: normalizeRecord((manifest as Record<string, unknown>).gradients),
     overlays: normalizeRecord((manifest as Record<string, unknown>).overlays),
     particles: normalizeRecord((manifest as Record<string, unknown>).particles),
     grain: normalizeRecord((manifest as Record<string, unknown>).grain),
@@ -117,6 +119,7 @@ export function mapSurfaceTokensToAssets(
           ?? fallbackBackground?.desktop,
       };
     })(),
+    gradient: surfaceTokens.gradient ? resolveToken(surfaceTokens.gradient, surfaceMap.gradients ?? {}) : undefined,
     overlays: {
       dots: resolveToken(surfaceTokens.overlays?.dots, surfaceMap.overlays ?? {}),
       field: resolveToken(surfaceTokens.overlays?.field, surfaceMap.overlays ?? {}),
@@ -145,6 +148,7 @@ export function resolveHeroSurfaceAssets(surfaceConfig: HeroSurfaceConfig): Reso
       desktop: resolveHeroAsset(surfaceConfig.background?.desktop),
       mobile: resolveHeroAsset(surfaceConfig.background?.mobile ?? surfaceConfig.background?.desktop),
     },
+    gradient: surfaceConfig.gradient,
     overlays: {
       dots: resolveHeroAsset(surfaceConfig.overlays?.dots),
       field: resolveHeroAsset(surfaceConfig.overlays?.field),
@@ -172,6 +176,7 @@ export function ensureSurfacePaths(surfaceConfig: HeroSurfaceConfig): HeroSurfac
       desktop: ensureHeroAssetPath(surfaceConfig.background?.desktop),
       mobile: ensureHeroAssetPath(surfaceConfig.background?.mobile ?? surfaceConfig.background?.desktop),
     },
+    gradient: surfaceConfig.gradient,
     overlays: {
       dots: ensureHeroAssetPath(surfaceConfig.overlays?.dots),
       field: ensureHeroAssetPath(surfaceConfig.overlays?.field),

--- a/packages/champagne-hero/src/index.ts
+++ b/packages/champagne-hero/src/index.ts
@@ -12,6 +12,7 @@ export {
   type HeroRuntimeConfig,
   type HeroSurfaceConfig,
   type HeroSurfaceTokenConfig,
+  type HeroMode,
   type HeroTimeOfDay,
 } from "./hero-engine";
 

--- a/packages/champagne-manifests/data/hero/sacred_hero_base.json
+++ b/packages/champagne-manifests/data/hero/sacred_hero_base.json
@@ -10,6 +10,7 @@
   "defaults": {
     "tone": "night",
     "surfaces": {
+      "gradient": "sacred",
       "waveMask": { "desktop": "primary", "mobile": "mobile" },
       "background": { "desktop": "primary", "mobile": "primary" },
       "overlays": { "dots": "dots", "field": "field" },
@@ -17,6 +18,20 @@
       "grain": { "desktop": "desktop", "mobile": "mobile" },
       "motion": ["wave", "glass"],
       "video": "heroVideo"
-    }
+    },
+    "layout": {
+      "contentAlign": "start",
+      "maxWidth": 960,
+      "verticalOffset": "0px",
+      "padding": "clamp(2rem, 4vw, 3.5rem)"
+    },
+    "motion": {
+      "parallaxDepth": 18,
+      "shimmerIntensity": 1,
+      "particleDrift": 1,
+      "energyMode": "balanced",
+      "particles": { "density": 1, "speed": 1, "curve": "sway" }
+    },
+    "filmGrain": { "enabled": true, "opacity": 0.32 }
   }
 }

--- a/packages/champagne-manifests/data/hero/sacred_hero_surfaces.json
+++ b/packages/champagne-manifests/data/hero/sacred_hero_surfaces.json
@@ -8,6 +8,9 @@
   "waveBackgrounds": {
     "primary": { "desktop": "sacred.wave.background.desktop", "mobile": "sacred.wave.background.mobile" }
   },
+  "gradients": {
+    "sacred": "var(--smh-gradient)"
+  },
   "overlays": {
     "dots": "sacred.wave.overlay.dots",
     "field": "sacred.wave.overlay.field"

--- a/packages/champagne-manifests/data/hero/sacred_hero_variants.json
+++ b/packages/champagne-manifests/data/hero/sacred_hero_variants.json
@@ -22,6 +22,111 @@
         "headline": "Daylight smile confidence.",
         "subheadline": "Bright, precise dentistry with a calm studio feel."
       }
+    },
+    {
+      "id": "hero_whitening",
+      "label": "Treatment: whitening",
+      "treatmentSlug": "teeth-whitening",
+      "energyMode": "dynamic",
+      "content": {
+        "eyebrow": "Teeth whitening",
+        "headline": "A brighter smile, tuned to your enamel.",
+        "subheadline": "Gentle in-studio whitening plans supported by digital shade matching and calming studio light.",
+        "cta": { "label": "Plan whitening", "href": "/treatments/teeth-whitening" },
+        "secondaryCta": { "label": "Compare options", "href": "/treatments" }
+      },
+      "surfaces": {
+        "particles": "magenta",
+        "motion": ["glass"]
+      },
+      "motion": {
+        "energyMode": "dynamic",
+        "particles": { "density": 1.05, "speed": 1.1, "curve": "dynamic" }
+      }
+    },
+    {
+      "id": "hero_implants",
+      "label": "Treatment: implants",
+      "treatmentSlug": "dental-implants",
+      "energyMode": "calm",
+      "content": {
+        "eyebrow": "Dental implants",
+        "headline": "Precision-guided implant planning.",
+        "subheadline": "Surgical guides, restorative artistry, and considerate follow-up for stable, confident smiles.",
+        "cta": { "label": "Book implant consult", "href": "/treatments/dental-implants" },
+        "secondaryCta": { "label": "See pricing", "href": "/contact" }
+      },
+      "surfaces": {
+        "particles": "gold",
+        "motion": ["wave"]
+      },
+      "motion": {
+        "energyMode": "calm",
+        "particles": { "density": 0.7, "speed": 0.8, "curve": "calm" }
+      }
+    },
+    {
+      "id": "hero_aligners",
+      "label": "Treatment: aligners",
+      "treatmentSlug": "spark-aligners",
+      "energyMode": "balanced",
+      "content": {
+        "eyebrow": "Spark aligners",
+        "headline": "Discreet aligner plans with precise tracking.",
+        "subheadline": "Crystal-clear aligners with digital check-ins, ensuring smooth progress with minimal clinic time.",
+        "cta": { "label": "Start aligner assessment", "href": "/treatments/spark-aligners" },
+        "secondaryCta": { "label": "How aligners work", "href": "/treatments" }
+      },
+      "surfaces": {
+        "particles": "teal",
+        "motion": ["glass"]
+      },
+      "motion": {
+        "energyMode": "balanced",
+        "particles": { "density": 0.95, "speed": 0.95, "curve": "sway" }
+      }
+    },
+    {
+      "id": "hero_veneers",
+      "label": "Treatment: veneers",
+      "treatmentSlug": "porcelain-veneers",
+      "energyMode": "balanced",
+      "content": {
+        "eyebrow": "Porcelain veneers",
+        "headline": "Layered ceramics with natural light play.",
+        "subheadline": "Mockups, wax-ups, and handcrafted ceramics designed to move with studio lighting and daily life.",
+        "cta": { "label": "Design my smile", "href": "/treatments/porcelain-veneers" },
+        "secondaryCta": { "label": "Preview cases", "href": "/smile-gallery" }
+      },
+      "surfaces": {
+        "particles": "gold",
+        "motion": ["glass", "wave"]
+      },
+      "motion": {
+        "energyMode": "balanced",
+        "particles": { "density": 0.9, "speed": 0.85, "curve": "sway" }
+      }
+    },
+    {
+      "id": "hero_technology",
+      "label": "Treatment: technology",
+      "treatmentSlug": "dental-technology",
+      "energyMode": "dynamic",
+      "content": {
+        "eyebrow": "Digital technology",
+        "headline": "Calm technology powering every visit.",
+        "subheadline": "Intraoral scanning, guided planning, and immersive visuals to keep every treatment transparent.",
+        "cta": { "label": "Explore our tech", "href": "/treatments/dental-technology" },
+        "secondaryCta": { "label": "See the studio", "href": "/about" }
+      },
+      "surfaces": {
+        "particles": "magenta",
+        "motion": ["glass", "dust"]
+      },
+      "motion": {
+        "energyMode": "dynamic",
+        "particles": { "density": 1.2, "speed": 1.15, "curve": "dynamic" }
+      }
     }
   ]
 }


### PR DESCRIPTION
## Summary
- route hero runtime through sacred manifest-driven layout, motion, film grain, and particle settings, including treatment variants by slug
- expose updated HeroRenderer options and add an internal hero lab preview surface with toggles for mode, slugs, motion, and theme
- extend sacred hero manifests with gradient tokens, film grain defaults, and new treatment copy variants without altering assets

## Testing
- npm run lint --workspaces=false
- npm run build --workspace @champagne/hero
- npm run build --workspace web

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69371f497d7c8332903e764ea0bfdd56)