### PR TITLE
Render sacred hero on home route behind feature flag

### DIFF
--- a/apps/web/app/featureFlags.ts
+++ b/apps/web/app/featureFlags.ts
@@ -1,0 +1,9 @@
+export function isBrandHeroEnabled() {
+  const flag = process.env.NEXT_PUBLIC_FEATURE_BRAND_HERO;
+
+  if (flag === undefined) {
+    return process.env.NODE_ENV !== "production";
+  }
+
+  return flag === "true" || flag === "1";
+}

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,5 +1,14 @@
 import ChampagnePageBuilder from "./(champagne)/_builder/ChampagnePageBuilder";
+import { HeroRenderer } from "./components/hero/HeroRenderer";
+import { isBrandHeroEnabled } from "./featureFlags";
 
 export default function Page() {
-  return <ChampagnePageBuilder slug="/" />;
+  const isHeroEnabled = isBrandHeroEnabled();
+
+  return (
+    <>
+      {isHeroEnabled && <HeroRenderer />}
+      <ChampagnePageBuilder slug="/" />
+    </>
+  );
 }


### PR DESCRIPTION
## Summary
- Mount HeroRenderer on the main home route (apps/web/app/page.tsx) above the existing hub builder.
- Add a feature flag helper that reads NEXT_PUBLIC_FEATURE_BRAND_HERO and defaults to enabled outside production when undefined.

## Testing
- npm run lint --workspaces=false
- npm run build --workspace @champagne/hero
- npm run build --workspace web

## Additional Details
- Home route file modified: apps/web/app/page.tsx
- HeroRenderer import path: ./components/hero/HeroRenderer
- Feature flag: NEXT_PUBLIC_FEATURE_BRAND_HERO; defaults to true when unset in non-production environments.
- No asset paths or binary files were changed.


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693725bb5c8483328618520731a9b61f)