### PR TITLE
Rebuild sacred hero surfaces with preview

### DIFF
--- a/apps/web/app/champagne/hero-preview/controls.tsx
+++ b/apps/web/app/champagne/hero-preview/controls.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import { useMemo } from "react";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+
+interface ControlPanelProps {
+  theme: "light" | "dark";
+  particles: boolean;
+  filmGrain: boolean;
+  prm: boolean;
+}
+
+export function HeroPreviewControls({ theme, particles, filmGrain, prm }: ControlPanelProps) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  const params = useMemo(() => {
+    const next = new URLSearchParams(searchParams?.toString() ?? "");
+    return next;
+  }, [searchParams]);
+
+  const updateParam = (key: string, value: string | null) => {
+    const next = new URLSearchParams(params.toString());
+    if (value === null) {
+      next.delete(key);
+    } else {
+      next.set(key, value);
+    }
+    router.replace(`${pathname}?${next.toString()}`);
+  };
+
+  return (
+    <div
+      style={{
+        display: "grid",
+        gap: "0.75rem",
+        padding: "1rem",
+        borderRadius: "var(--radius-lg)",
+        border: "1px solid var(--champagne-keyline-gold)",
+        background: "var(--surface-ink-soft)",
+        color: "var(--text-high)",
+        minWidth: "260px",
+      }}
+    >
+      <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
+        <span style={{ color: "var(--text-medium)", fontSize: "0.95rem" }}>Theme</span>
+        <div style={{ display: "flex", gap: "0.35rem" }}>
+          <button
+            type="button"
+            onClick={() => updateParam("theme", "dark")}
+            style={{
+              padding: "0.45rem 0.75rem",
+              borderRadius: "var(--radius-md)",
+              border: theme === "dark" ? "1px solid var(--champagne-keyline-gold)" : "1px solid transparent",
+              background: theme === "dark" ? "var(--surface-ink-strong)" : "var(--surface-ink-soft)",
+              color: "var(--text-high)",
+            }}
+          >
+            Dark
+          </button>
+          <button
+            type="button"
+            onClick={() => updateParam("theme", "light")}
+            style={{
+              padding: "0.45rem 0.75rem",
+              borderRadius: "var(--radius-md)",
+              border: theme === "light" ? "1px solid var(--champagne-keyline-gold)" : "1px solid transparent",
+              background: theme === "light" ? "var(--surface-ink-strong)" : "var(--surface-ink-soft)",
+              color: "var(--text-high)",
+            }}
+          >
+            Light
+          </button>
+        </div>
+      </div>
+
+      <label style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: "0.5rem" }}>
+        <span style={{ color: "var(--text-medium)", fontSize: "0.95rem" }}>Particles</span>
+        <input
+          type="checkbox"
+          checked={particles}
+          onChange={(event) => updateParam("particles", event.target.checked ? "true" : "false")}
+        />
+      </label>
+
+      <label style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: "0.5rem" }}>
+        <span style={{ color: "var(--text-medium)", fontSize: "0.95rem" }}>Film grain</span>
+        <input
+          type="checkbox"
+          checked={filmGrain}
+          onChange={(event) => updateParam("filmGrain", event.target.checked ? "true" : "false")}
+        />
+      </label>
+
+      <label style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: "0.5rem" }}>
+        <span style={{ color: "var(--text-medium)", fontSize: "0.95rem" }}>Reduced motion</span>
+        <input
+          type="checkbox"
+          checked={prm}
+          onChange={(event) => updateParam("prm", event.target.checked ? "true" : "false")}
+        />
+      </label>
+    </div>
+  );
+}

--- a/apps/web/app/champagne/hero-preview/page.tsx
+++ b/apps/web/app/champagne/hero-preview/page.tsx
@@ -1,0 +1,60 @@
+import { HeroRenderer } from "../../components/hero/HeroRenderer";
+import type { HeroTimeOfDay } from "@champagne/hero";
+import { HeroPreviewControls } from "./controls";
+
+type SearchParams = Promise<Record<string, string | string[] | undefined>>;
+
+function normalizeBoolean(value: string | string[] | undefined, defaultValue: boolean): boolean {
+  if (Array.isArray(value)) return value.includes("true") ? true : value.includes("false") ? false : defaultValue;
+  if (typeof value === "string") return value === "true";
+  return defaultValue;
+}
+
+function mapThemeToTimeOfDay(theme: string | string[] | undefined): HeroTimeOfDay {
+  if (theme === "light") return "day";
+  return "night";
+}
+
+export default async function HeroPreviewPage({ searchParams }: { searchParams?: SearchParams }) {
+  const resolved = (await searchParams) ?? {};
+  const themeParam = typeof resolved.theme === "string" ? resolved.theme : "dark";
+  const timeOfDay = mapThemeToTimeOfDay(themeParam);
+  const particles = normalizeBoolean(resolved.particles, true);
+  const filmGrain = normalizeBoolean(resolved.filmGrain, true);
+  const prm = normalizeBoolean(resolved.prm, false);
+
+  return (
+    <div
+      style={{
+        display: "grid",
+        gap: "1.5rem",
+        padding: "clamp(1.5rem, 4vw, 2.5rem)",
+        background: "var(--bg-ink)",
+        color: "var(--text-high)",
+      }}
+    >
+      <header style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: "1rem" }}>
+        <div style={{ display: "grid", gap: "0.35rem" }}>
+          <p style={{ letterSpacing: "0.12em", textTransform: "uppercase", color: "var(--text-medium)" }}>
+            Sacred hero preview
+          </p>
+          <h1 style={{ fontSize: "clamp(1.8rem, 2.6vw, 2.3rem)", fontWeight: 700 }}>Surface parity sandbox</h1>
+          <p style={{ color: "var(--text-medium)", maxWidth: "740px", lineHeight: 1.5 }}>
+            Toggle key surface layers, motion safety, and light variants to validate the reconstructed Sacred hero before
+            shipping.
+          </p>
+        </div>
+        <HeroPreviewControls
+          theme={themeParam === "light" ? "light" : "dark"}
+          particles={particles}
+          filmGrain={filmGrain}
+          prm={prm}
+        />
+      </header>
+
+      <div style={{ borderRadius: "var(--radius-xl)", overflow: "hidden", position: "relative" }}>
+        <HeroRenderer timeOfDay={timeOfDay} particles={particles} filmGrain={filmGrain} prm={prm} />
+      </div>
+    </div>
+  );
+}

--- a/packages/champagne-hero/src/hero-engine/HeroConfig.ts
+++ b/packages/champagne-hero/src/hero-engine/HeroConfig.ts
@@ -2,6 +2,27 @@ import type { HeroAssetEntry } from "../HeroAssetRegistry";
 
 export type HeroTimeOfDay = "day" | "evening" | "night";
 
+export interface HeroSurfaceLayerDefinition {
+  asset?: string | HeroAssetEntry;
+  blendMode?: string;
+  opacity?: number;
+  prmSafe?: boolean;
+  className?: string;
+}
+
+export interface HeroSurfaceLayer extends HeroSurfaceLayerDefinition {
+  id?: string;
+  path?: string;
+}
+
+export interface HeroSurfaceLayerResolved extends HeroSurfaceLayerDefinition {
+  id?: string;
+  asset?: HeroAssetEntry;
+  path?: string;
+}
+
+export type HeroSurfaceLayerRef = string | HeroSurfaceLayerDefinition;
+
 export interface HeroCTAConfig {
   label: string;
   href: string;
@@ -48,71 +69,71 @@ export interface HeroLayoutConfig {
 
 export interface HeroSurfaceTokenConfig {
   waveMask?: {
-    desktop?: string;
-    mobile?: string;
+    desktop?: HeroSurfaceLayerRef;
+    mobile?: HeroSurfaceLayerRef;
   };
   background?: {
-    desktop?: string;
-    mobile?: string;
+    desktop?: HeroSurfaceLayerRef;
+    mobile?: HeroSurfaceLayerRef;
   };
   gradient?: string;
   overlays?: {
-    dots?: string;
-    field?: string;
+    dots?: HeroSurfaceLayerRef;
+    field?: HeroSurfaceLayerRef;
   };
-  particles?: string;
+  particles?: HeroSurfaceLayerRef;
   grain?: {
-    desktop?: string;
-    mobile?: string;
+    desktop?: HeroSurfaceLayerRef;
+    mobile?: HeroSurfaceLayerRef;
   };
-  motion?: string[];
-  video?: string;
+  motion?: HeroSurfaceLayerRef[];
+  video?: HeroSurfaceLayerRef;
 }
 
 export interface HeroSurfaceConfig {
   waveMask?: {
-    desktop?: string;
-    mobile?: string;
+    desktop?: HeroSurfaceLayer;
+    mobile?: HeroSurfaceLayer;
   };
   background?: {
-    desktop?: string;
-    mobile?: string;
+    desktop?: HeroSurfaceLayer;
+    mobile?: HeroSurfaceLayer;
   };
   gradient?: string;
   overlays?: {
-    dots?: string;
-    field?: string;
+    dots?: HeroSurfaceLayer;
+    field?: HeroSurfaceLayer;
   };
-  particles?: string;
+  particles?: HeroSurfaceLayer;
   grain?: {
-    desktop?: string;
-    mobile?: string;
+    desktop?: HeroSurfaceLayer;
+    mobile?: HeroSurfaceLayer;
   };
-  motion?: string[];
-  video?: string;
+  motion?: HeroSurfaceLayer[];
+  video?: HeroSurfaceLayer;
 }
 
 export interface ResolvedHeroSurfaceConfig {
   waveMask?: {
-    desktop?: HeroAssetEntry;
-    mobile?: HeroAssetEntry;
+    desktop?: HeroSurfaceLayerResolved;
+    mobile?: HeroSurfaceLayerResolved;
   };
   background?: {
-    desktop?: HeroAssetEntry;
-    mobile?: HeroAssetEntry;
+    desktop?: HeroSurfaceLayerResolved;
+    mobile?: HeroSurfaceLayerResolved;
   };
   gradient?: string;
   overlays?: {
-    dots?: HeroAssetEntry;
-    field?: HeroAssetEntry;
+    dots?: HeroSurfaceLayerResolved;
+    field?: HeroSurfaceLayerResolved;
   };
-  particles?: HeroAssetEntry;
+  particles?: HeroSurfaceLayerResolved;
   grain?: {
-    desktop?: HeroAssetEntry;
-    mobile?: HeroAssetEntry;
+    desktop?: HeroSurfaceLayerResolved;
+    mobile?: HeroSurfaceLayerResolved;
   };
-  motion?: HeroAssetEntry[];
-  video?: HeroAssetEntry;
+  motion?: HeroSurfaceLayerResolved[];
+  video?: HeroSurfaceLayerResolved;
 }
 
 export interface HeroBaseConfig {

--- a/packages/champagne-hero/src/hero-engine/HeroRuntime.ts
+++ b/packages/champagne-hero/src/hero-engine/HeroRuntime.ts
@@ -176,8 +176,8 @@ function applyPrm(surface: HeroSurfaceConfig, prm?: boolean): HeroSurfaceConfig 
   if (!prm) return surface;
   return {
     ...surface,
-    motion: [],
-    video: undefined,
+    motion: surface.motion?.filter((entry) => entry?.prmSafe),
+    video: surface.video?.prmSafe ? surface.video : undefined,
   };
 }
 

--- a/packages/champagne-hero/src/hero-engine/HeroSurfaceMap.ts
+++ b/packages/champagne-hero/src/hero-engine/HeroSurfaceMap.ts
@@ -1,22 +1,53 @@
 import { ensureHeroAssetPath, resolveHeroAsset } from "../HeroAssetRegistry";
 import type {
   HeroSurfaceConfig,
+  HeroSurfaceLayer,
+  HeroSurfaceLayerDefinition,
+  HeroSurfaceLayerRef,
+  HeroSurfaceLayerResolved,
   HeroSurfaceTokenConfig,
   ResolvedHeroSurfaceConfig,
 } from "./HeroConfig";
 
 export interface HeroSurfaceDefinitionMap {
-  waveMasks?: Record<string, string>;
-  waveBackgrounds?: Record<string, { desktop?: string; mobile?: string }>;
+  waveMasks?: Record<string, HeroSurfaceLayerDefinition>;
+  waveBackgrounds?: Record<string, { desktop?: HeroSurfaceLayerDefinition; mobile?: HeroSurfaceLayerDefinition }>;
   gradients?: Record<string, string>;
-  overlays?: Record<string, string>;
-  particles?: Record<string, string>;
-  grain?: Record<string, string>;
-  motion?: Record<string, string>;
-  video?: Record<string, string>;
+  overlays?: Record<string, HeroSurfaceLayerDefinition>;
+  particles?: Record<string, HeroSurfaceLayerDefinition>;
+  grain?: Record<string, HeroSurfaceLayerDefinition>;
+  motion?: Record<string, HeroSurfaceLayerDefinition>;
+  video?: Record<string, HeroSurfaceLayerDefinition>;
 }
 
-function normalizeRecord(entry: unknown): Record<string, string> {
+function normalizeLayer(entry: unknown): HeroSurfaceLayerDefinition | undefined {
+  if (!entry) return undefined;
+  if (typeof entry === "string") return { asset: entry };
+  if (typeof entry !== "object") return undefined;
+  const record = entry as Record<string, unknown>;
+  const asset = typeof record.asset === "string" ? record.asset : undefined;
+  const blendMode = typeof record.blendMode === "string" ? record.blendMode : undefined;
+  const className = typeof record.className === "string" ? record.className : undefined;
+  const opacity = typeof record.opacity === "number" ? record.opacity : undefined;
+  const prmSafe = typeof record.prmSafe === "boolean" ? record.prmSafe : undefined;
+
+  if (!asset && !blendMode && !className && opacity === undefined && prmSafe === undefined) return undefined;
+
+  return { asset, blendMode, className, opacity, prmSafe };
+}
+
+function normalizeRecord(entry: unknown): Record<string, HeroSurfaceLayerDefinition> {
+  if (!entry || typeof entry !== "object") return {};
+  return Object.entries(entry as Record<string, unknown>)
+    .map(([key, value]) => [key, normalizeLayer(value)] as const)
+    .filter(([, value]) => Boolean(value))
+    .reduce<Record<string, HeroSurfaceLayerDefinition>>((acc, [key, value]) => {
+      acc[key] = value as HeroSurfaceLayerDefinition;
+      return acc;
+    }, {});
+}
+
+function normalizeGradients(entry: unknown): Record<string, string> {
   if (!entry || typeof entry !== "object") return {};
   return Object.entries(entry as Record<string, unknown>)
     .filter(([, value]) => typeof value === "string")
@@ -33,21 +64,23 @@ export function buildSurfaceDefinitionMap(manifest: unknown): HeroSurfaceDefinit
     waveBackgrounds: (() => {
       const entry = (manifest as Record<string, unknown>).waveBackgrounds;
       if (!entry || typeof entry !== "object") return {};
-      return Object.entries(entry as Record<string, unknown>).reduce<Record<string, { desktop?: string; mobile?: string }>>(
+      return Object.entries(entry as Record<string, unknown>).reduce<
+        Record<string, { desktop?: HeroSurfaceLayerDefinition; mobile?: HeroSurfaceLayerDefinition }>
+      >(
         (acc, [key, value]) => {
           if (!value || typeof value !== "object") return acc;
           const desktop = (value as Record<string, unknown>).desktop;
           const mobile = (value as Record<string, unknown>).mobile;
           acc[key] = {
-            desktop: typeof desktop === "string" ? desktop : undefined,
-            mobile: typeof mobile === "string" ? mobile : undefined,
+            desktop: normalizeLayer(desktop),
+            mobile: normalizeLayer(mobile),
           };
           return acc;
         },
         {},
       );
     })(),
-    gradients: normalizeRecord((manifest as Record<string, unknown>).gradients),
+    gradients: normalizeGradients((manifest as Record<string, unknown>).gradients),
     overlays: normalizeRecord((manifest as Record<string, unknown>).overlays),
     particles: normalizeRecord((manifest as Record<string, unknown>).particles),
     grain: normalizeRecord((manifest as Record<string, unknown>).grain),
@@ -56,9 +89,38 @@ export function buildSurfaceDefinitionMap(manifest: unknown): HeroSurfaceDefinit
   };
 }
 
-function resolveToken(token: string | undefined, map: Record<string, string>): string | undefined {
-  if (!token) return undefined;
-  return map[token] ?? token;
+function resolveLayerRef(
+  ref: HeroSurfaceLayerRef | undefined,
+  map: Record<string, HeroSurfaceLayerDefinition>,
+): HeroSurfaceLayer | undefined {
+  if (!ref) return undefined;
+
+  if (typeof ref === "string") {
+    const mapped = map[ref];
+    if (mapped) {
+      const assetKey = typeof mapped.asset === "string" ? mapped.asset : ref;
+      return { ...mapped, id: assetKey };
+    }
+    return { id: ref, asset: ref };
+  }
+
+  const normalized = normalizeLayer(ref);
+  const assetKey = typeof normalized?.asset === "string" ? normalized.asset : undefined;
+  if (assetKey && map[assetKey]) {
+    return { ...map[assetKey], ...normalized, id: assetKey };
+  }
+
+  return normalized
+    ? { ...normalized, id: assetKey ?? (typeof normalized.asset === "string" ? normalized.asset : undefined) }
+    : undefined;
+}
+
+function definitionToLayer(definition?: HeroSurfaceLayerDefinition, token?: string): HeroSurfaceLayer | undefined {
+  if (!definition) return undefined;
+  return {
+    ...definition,
+    id: typeof definition.asset === "string" ? definition.asset : token,
+  };
 }
 
 function mergeSurfaceTokens(
@@ -101,92 +163,127 @@ export function mapSurfaceTokensToAssets(
 ): HeroSurfaceConfig {
   return {
     waveMask: {
-      desktop: resolveToken(surfaceTokens.waveMask?.desktop, surfaceMap.waveMasks ?? {}),
-      mobile: resolveToken(surfaceTokens.waveMask?.mobile ?? surfaceTokens.waveMask?.desktop, surfaceMap.waveMasks ?? {}),
+      desktop: resolveLayerRef(surfaceTokens.waveMask?.desktop, surfaceMap.waveMasks ?? {}),
+      mobile: resolveLayerRef(surfaceTokens.waveMask?.mobile ?? surfaceTokens.waveMask?.desktop, surfaceMap.waveMasks ?? {}),
     },
     background: (() => {
       const backgroundToken = surfaceTokens.background?.desktop ?? surfaceTokens.background?.mobile;
-      const backgroundDefinition = backgroundToken ? surfaceMap.waveBackgrounds?.[backgroundToken] : undefined;
+      const backgroundDefinition =
+        typeof backgroundToken === "string" ? surfaceMap.waveBackgrounds?.[backgroundToken] : undefined;
       const fallbackBackground = surfaceMap.waveBackgrounds?.primary;
+      const desktopRef = surfaceTokens.background?.desktop;
+      const mobileRef = surfaceTokens.background?.mobile;
       return {
-        desktop: backgroundDefinition?.desktop
-          ?? surfaceMap.waveBackgrounds?.[surfaceTokens.background?.desktop ?? ""]?.desktop
-          ?? fallbackBackground?.desktop,
-        mobile: backgroundDefinition?.mobile
-          ?? surfaceMap.waveBackgrounds?.[surfaceTokens.background?.mobile ?? ""]?.mobile
-          ?? backgroundDefinition?.desktop
-          ?? fallbackBackground?.mobile
-          ?? fallbackBackground?.desktop,
+        desktop:
+          definitionToLayer(backgroundDefinition?.desktop, backgroundToken as string)
+            ?? (typeof desktopRef === "string"
+              ? definitionToLayer(surfaceMap.waveBackgrounds?.[desktopRef]?.desktop, desktopRef)
+              : definitionToLayer(normalizeLayer(desktopRef)))
+            ?? (typeof mobileRef === "string"
+              ? definitionToLayer(surfaceMap.waveBackgrounds?.[mobileRef]?.desktop, mobileRef)
+              : undefined)
+            ?? definitionToLayer(fallbackBackground?.desktop),
+        mobile:
+          definitionToLayer(backgroundDefinition?.mobile, backgroundToken as string)
+            ?? (typeof mobileRef === "string"
+              ? definitionToLayer(surfaceMap.waveBackgrounds?.[mobileRef]?.mobile, mobileRef)
+              : definitionToLayer(normalizeLayer(mobileRef)))
+            ?? definitionToLayer(backgroundDefinition?.desktop, backgroundToken as string)
+            ?? definitionToLayer(fallbackBackground?.mobile)
+            ?? definitionToLayer(fallbackBackground?.desktop),
       };
     })(),
-    gradient: surfaceTokens.gradient ? resolveToken(surfaceTokens.gradient, surfaceMap.gradients ?? {}) : undefined,
+    gradient: surfaceTokens.gradient ? surfaceMap.gradients?.[surfaceTokens.gradient] ?? surfaceTokens.gradient : undefined,
     overlays: {
-      dots: resolveToken(surfaceTokens.overlays?.dots, surfaceMap.overlays ?? {}),
-      field: resolveToken(surfaceTokens.overlays?.field, surfaceMap.overlays ?? {}),
+      dots: resolveLayerRef(surfaceTokens.overlays?.dots, surfaceMap.overlays ?? {}),
+      field: resolveLayerRef(surfaceTokens.overlays?.field, surfaceMap.overlays ?? {}),
     },
-    particles: resolveToken(surfaceTokens.particles, surfaceMap.particles ?? {}),
+    particles: resolveLayerRef(surfaceTokens.particles, surfaceMap.particles ?? {}),
     grain: {
       desktop: surfaceTokens.grain?.desktop
-        ? surfaceMap.grain?.[surfaceTokens.grain.desktop] ?? surfaceTokens.grain.desktop
+        ? resolveLayerRef(surfaceTokens.grain.desktop, surfaceMap.grain ?? {})
         : surfaceMap.grain?.desktop,
       mobile: surfaceTokens.grain?.mobile
-        ? surfaceMap.grain?.[surfaceTokens.grain.mobile] ?? surfaceTokens.grain.mobile
+        ? resolveLayerRef(surfaceTokens.grain.mobile, surfaceMap.grain ?? {})
         : surfaceMap.grain?.mobile ?? surfaceMap.grain?.desktop,
     },
-    motion: surfaceTokens.motion?.map((entry) => resolveToken(entry, surfaceMap.motion ?? {})).filter(Boolean) as string[] | undefined,
-    video: resolveToken(surfaceTokens.video, surfaceMap.video ?? {}),
+    motion: surfaceTokens.motion
+      ?.map((entry) => resolveLayerRef(entry, surfaceMap.motion ?? {}))
+      .filter(Boolean) as HeroSurfaceLayer[] | undefined,
+    video: resolveLayerRef(surfaceTokens.video, surfaceMap.video ?? {}),
   };
+}
+
+function resolveLayer(layer?: HeroSurfaceLayer): HeroSurfaceLayerResolved | undefined {
+  if (!layer?.asset && !layer?.id) return layer as HeroSurfaceLayerResolved | undefined;
+  const assetRef = typeof layer.asset === "string" ? layer.asset : layer.id;
+  const assetEntry = typeof layer.asset === "object" && "path" in layer.asset ? layer.asset : resolveHeroAsset(assetRef);
+  const path = assetEntry?.path ?? (typeof layer.asset === "object" && "path" in layer.asset ? layer.asset.path : layer.path);
+  return assetEntry
+    ? ({
+        ...layer,
+        id: typeof layer.asset === "string" ? layer.asset : layer.id,
+        asset: assetEntry,
+        path,
+      } as HeroSurfaceLayerResolved)
+    : (layer as HeroSurfaceLayerResolved);
 }
 
 export function resolveHeroSurfaceAssets(surfaceConfig: HeroSurfaceConfig): ResolvedHeroSurfaceConfig {
   return {
     waveMask: {
-      desktop: resolveHeroAsset(surfaceConfig.waveMask?.desktop),
-      mobile: resolveHeroAsset(surfaceConfig.waveMask?.mobile ?? surfaceConfig.waveMask?.desktop),
+      desktop: resolveLayer(surfaceConfig.waveMask?.desktop),
+      mobile: resolveLayer(surfaceConfig.waveMask?.mobile ?? surfaceConfig.waveMask?.desktop),
     },
     background: {
-      desktop: resolveHeroAsset(surfaceConfig.background?.desktop),
-      mobile: resolveHeroAsset(surfaceConfig.background?.mobile ?? surfaceConfig.background?.desktop),
+      desktop: resolveLayer(surfaceConfig.background?.desktop),
+      mobile: resolveLayer(surfaceConfig.background?.mobile ?? surfaceConfig.background?.desktop),
     },
     gradient: surfaceConfig.gradient,
     overlays: {
-      dots: resolveHeroAsset(surfaceConfig.overlays?.dots),
-      field: resolveHeroAsset(surfaceConfig.overlays?.field),
+      dots: resolveLayer(surfaceConfig.overlays?.dots),
+      field: resolveLayer(surfaceConfig.overlays?.field),
     },
-    particles: resolveHeroAsset(surfaceConfig.particles),
+    particles: resolveLayer(surfaceConfig.particles),
     grain: {
-      desktop: resolveHeroAsset(surfaceConfig.grain?.desktop),
-      mobile: resolveHeroAsset(surfaceConfig.grain?.mobile ?? surfaceConfig.grain?.desktop),
+      desktop: resolveLayer(surfaceConfig.grain?.desktop),
+      mobile: resolveLayer(surfaceConfig.grain?.mobile ?? surfaceConfig.grain?.desktop),
     },
     motion: (surfaceConfig.motion ?? [])
-      .map((entry) => resolveHeroAsset(entry))
+      .map((entry) => resolveLayer(entry))
       .filter(Boolean) as ResolvedHeroSurfaceConfig["motion"],
-    video: resolveHeroAsset(surfaceConfig.video),
+    video: resolveLayer(surfaceConfig.video),
   };
+}
+
+function ensureLayerPath(layer?: HeroSurfaceLayer): HeroSurfaceLayer | undefined {
+  if (!layer) return undefined;
+  const path = ensureHeroAssetPath(typeof layer.asset === "string" ? layer.asset : layer.id);
+  return path ? { ...layer, path } : layer;
 }
 
 export function ensureSurfacePaths(surfaceConfig: HeroSurfaceConfig): HeroSurfaceConfig {
   return {
     ...surfaceConfig,
     waveMask: {
-      desktop: ensureHeroAssetPath(surfaceConfig.waveMask?.desktop),
-      mobile: ensureHeroAssetPath(surfaceConfig.waveMask?.mobile ?? surfaceConfig.waveMask?.desktop),
+      desktop: ensureLayerPath(surfaceConfig.waveMask?.desktop),
+      mobile: ensureLayerPath(surfaceConfig.waveMask?.mobile ?? surfaceConfig.waveMask?.desktop),
     },
     background: {
-      desktop: ensureHeroAssetPath(surfaceConfig.background?.desktop),
-      mobile: ensureHeroAssetPath(surfaceConfig.background?.mobile ?? surfaceConfig.background?.desktop),
+      desktop: ensureLayerPath(surfaceConfig.background?.desktop),
+      mobile: ensureLayerPath(surfaceConfig.background?.mobile ?? surfaceConfig.background?.desktop),
     },
     gradient: surfaceConfig.gradient,
     overlays: {
-      dots: ensureHeroAssetPath(surfaceConfig.overlays?.dots),
-      field: ensureHeroAssetPath(surfaceConfig.overlays?.field),
+      dots: ensureLayerPath(surfaceConfig.overlays?.dots),
+      field: ensureLayerPath(surfaceConfig.overlays?.field),
     },
-    particles: ensureHeroAssetPath(surfaceConfig.particles),
+    particles: ensureLayerPath(surfaceConfig.particles),
     grain: {
-      desktop: ensureHeroAssetPath(surfaceConfig.grain?.desktop),
-      mobile: ensureHeroAssetPath(surfaceConfig.grain?.mobile ?? surfaceConfig.grain?.desktop),
+      desktop: ensureLayerPath(surfaceConfig.grain?.desktop),
+      mobile: ensureLayerPath(surfaceConfig.grain?.mobile ?? surfaceConfig.grain?.desktop),
     },
-    motion: surfaceConfig.motion?.map((entry) => ensureHeroAssetPath(entry)).filter(Boolean) as string[] | undefined,
-    video: ensureHeroAssetPath(surfaceConfig.video),
+    motion: surfaceConfig.motion?.map((entry) => ensureLayerPath(entry)).filter(Boolean) as HeroSurfaceLayer[] | undefined,
+    video: ensureLayerPath(surfaceConfig.video),
   };
 }

--- a/packages/champagne-manifests/data/hero/sacred_hero_base.json
+++ b/packages/champagne-manifests/data/hero/sacred_hero_base.json
@@ -10,13 +10,13 @@
   "defaults": {
     "tone": "night",
     "surfaces": {
-      "gradient": "sacred",
-      "waveMask": { "desktop": "primary", "mobile": "mobile" },
-      "background": { "desktop": "primary", "mobile": "primary" },
-      "overlays": { "dots": "dots", "field": "field" },
-      "particles": "base",
-      "grain": { "desktop": "desktop", "mobile": "mobile" },
-      "motion": ["wave", "glass"],
+      "gradient": "base.gradientField",
+      "waveMask": { "desktop": "base.waveMask", "mobile": "base.waveMask.mobile" },
+      "background": { "desktop": "base.waveField", "mobile": "base.waveField" },
+      "overlays": { "dots": "base.dotsTexture", "field": "base.waveFieldLines" },
+      "particles": "fx.particlesPrimary",
+      "grain": { "desktop": "overlay.filmGrain", "mobile": "overlay.filmGrain.mobile" },
+      "motion": ["fx.caustics", "fx.glass", "fx.goldDust", "fx.particleDrift"],
       "video": "heroVideo"
     },
     "layout": {

--- a/packages/champagne-manifests/data/hero/sacred_hero_surfaces.json
+++ b/packages/champagne-manifests/data/hero/sacred_hero_surfaces.json
@@ -1,37 +1,40 @@
 {
   "waveMasks": {
-    "primary": "sacred.wave.mask.desktop",
-    "mobile": "sacred.wave.mask.mobile",
+    "base.waveMask": "sacred.wave.mask.desktop",
+    "base.waveMask.mobile": "sacred.wave.mask.mobile",
     "header": "sacred.wave.mask.header",
     "smh": "sacred.wave.mask.smh"
   },
   "waveBackgrounds": {
-    "primary": { "desktop": "sacred.wave.background.desktop", "mobile": "sacred.wave.background.mobile" }
+    "base.waveField": {
+      "desktop": "sacred.wave.background.desktop",
+      "mobile": "sacred.wave.background.mobile"
+    }
   },
   "gradients": {
-    "sacred": "var(--smh-gradient)"
+    "base.gradientField": "var(--smh-gradient)"
   },
   "overlays": {
-    "dots": "sacred.wave.overlay.dots",
-    "field": "sacred.wave.overlay.field"
+    "base.waveFieldLines": { "asset": "sacred.wave.overlay.field", "blendMode": "soft-light", "opacity": 0.85 },
+    "base.dotsTexture": { "asset": "sacred.wave.overlay.dots", "blendMode": "screen", "opacity": 0.58, "prmSafe": true }
   },
   "particles": {
-    "base": "sacred.particles.home",
-    "gold": "sacred.particles.gold",
-    "magenta": "sacred.particles.magenta",
-    "teal": "sacred.particles.teal"
+    "fx.particlesPrimary": { "asset": "sacred.particles.home", "blendMode": "screen", "opacity": 0.48 },
+    "fx.particlesGold": { "asset": "sacred.particles.gold", "blendMode": "screen", "opacity": 0.52 },
+    "fx.particlesMagenta": { "asset": "sacred.particles.magenta", "blendMode": "screen", "opacity": 0.46 },
+    "fx.particlesTeal": { "asset": "sacred.particles.teal", "blendMode": "screen", "opacity": 0.46 }
   },
   "grain": {
-    "desktop": "sacred.grain.desktop",
-    "mobile": "sacred.grain.mobile"
+    "overlay.filmGrain": { "asset": "sacred.grain.desktop", "blendMode": "soft-light", "opacity": 0.32, "prmSafe": true },
+    "overlay.filmGrain.mobile": { "asset": "sacred.grain.mobile", "blendMode": "soft-light", "opacity": 0.32, "prmSafe": true }
   },
   "motion": {
-    "wave": "sacred.motion.waveCaustics",
-    "glass": "sacred.motion.glassShimmer",
-    "dust": "sacred.motion.goldDust",
-    "drift": "sacred.motion.particleDrift"
+    "fx.caustics": { "asset": "sacred.motion.waveCaustics", "blendMode": "screen", "opacity": 0.9 },
+    "fx.glass": { "asset": "sacred.motion.glassShimmer", "blendMode": "screen", "opacity": 0.85 },
+    "fx.goldDust": { "asset": "sacred.motion.goldDust", "blendMode": "screen", "opacity": 0.7 },
+    "fx.particleDrift": { "asset": "sacred.motion.particleDrift", "blendMode": "screen", "opacity": 0.6 }
   },
   "video": {
-    "heroVideo": "sacred.motion.heroVideo"
+    "heroVideo": { "asset": "sacred.motion.heroVideo", "blendMode": "screen" }
   }
 }

--- a/packages/champagne-manifests/data/hero/sacred_hero_variants.json
+++ b/packages/champagne-manifests/data/hero/sacred_hero_variants.json
@@ -5,8 +5,8 @@
       "label": "Sacred night base",
       "tone": "night",
       "surfaces": {
-        "particles": "base",
-        "motion": ["wave", "glass"]
+        "particles": "fx.particlesPrimary",
+        "motion": ["fx.caustics", "fx.glass", "fx.goldDust"]
       }
     },
     {
@@ -15,8 +15,8 @@
       "timeOfDay": "day",
       "tone": "day",
       "surfaces": {
-        "particles": "teal",
-        "motion": ["glass"]
+        "particles": "fx.particlesTeal",
+        "motion": ["fx.glass"]
       },
       "content": {
         "headline": "Daylight smile confidence.",
@@ -36,8 +36,8 @@
         "secondaryCta": { "label": "Compare options", "href": "/treatments" }
       },
       "surfaces": {
-        "particles": "magenta",
-        "motion": ["glass"]
+        "particles": "fx.particlesMagenta",
+        "motion": ["fx.glass"]
       },
       "motion": {
         "energyMode": "dynamic",
@@ -57,8 +57,8 @@
         "secondaryCta": { "label": "See pricing", "href": "/contact" }
       },
       "surfaces": {
-        "particles": "gold",
-        "motion": ["wave"]
+        "particles": "fx.particlesGold",
+        "motion": ["fx.caustics"]
       },
       "motion": {
         "energyMode": "calm",
@@ -78,8 +78,8 @@
         "secondaryCta": { "label": "How aligners work", "href": "/treatments" }
       },
       "surfaces": {
-        "particles": "teal",
-        "motion": ["glass"]
+        "particles": "fx.particlesTeal",
+        "motion": ["fx.glass"]
       },
       "motion": {
         "energyMode": "balanced",
@@ -99,8 +99,8 @@
         "secondaryCta": { "label": "Preview cases", "href": "/smile-gallery" }
       },
       "surfaces": {
-        "particles": "gold",
-        "motion": ["glass", "wave"]
+        "particles": "fx.particlesGold",
+        "motion": ["fx.glass", "fx.caustics"]
       },
       "motion": {
         "energyMode": "balanced",
@@ -120,8 +120,8 @@
         "secondaryCta": { "label": "See the studio", "href": "/about" }
       },
       "surfaces": {
-        "particles": "magenta",
-        "motion": ["glass", "dust"]
+        "particles": "fx.particlesMagenta",
+        "motion": ["fx.glass", "fx.goldDust"]
       },
       "motion": {
         "energyMode": "dynamic",

--- a/packages/champagne-manifests/data/hero/sacred_hero_weather.json
+++ b/packages/champagne-manifests/data/hero/sacred_hero_weather.json
@@ -2,22 +2,22 @@
   "day": {
     "tone": "day",
     "surfaces": {
-      "particles": "teal",
-      "motion": ["glass"]
+      "particles": "fx.particlesTeal",
+      "motion": ["fx.glass"]
     }
   },
   "evening": {
     "tone": "evening",
     "surfaces": {
-      "particles": "gold",
-      "motion": ["dust"]
+      "particles": "fx.particlesGold",
+      "motion": ["fx.goldDust"]
     }
   },
   "night": {
     "tone": "night",
     "surfaces": {
-      "particles": "base",
-      "motion": ["wave"]
+      "particles": "fx.particlesPrimary",
+      "motion": ["fx.caustics"]
     }
   }
 }

--- a/packages/champagne-tokens/styles/champagne/surface.css
+++ b/packages/champagne-tokens/styles/champagne/surface.css
@@ -1,16 +1,36 @@
 :root {
-  /* Canonical surface assets (paths stable; binaries uploaded separately) */
-  --grain-desktop: url("/assets/champagne/film-grain/film-grain-desktop .webp");
-  --grain-mobile:  url("/assets/champagne/film-grain/film-grain-mobile .webp");
-  --particles:     url("/assets/champagne/particles/home-hero-particles.webp");
-  --wave-mask:     url("/assets/champagne/waves/wave-mask-desktop.webp");
+  --champagne-wave-mask-desktop: url("/assets/champagne/waves/wave-mask-desktop.webp");
+  --champagne-wave-mask-mobile: url("/assets/champagne/waves/wave-mask-mobile.webp");
+  --champagne-wave-bg-desktop: url("/assets/champagne/waves/waves-bg-1920.webp");
+  --champagne-wave-bg-mobile: url("/assets/champagne/waves/waves-bg-768.webp");
+  --champagne-overlay-dots: url("/assets/champagne/waves/wave-dots.svg");
+  --champagne-overlay-field: url("/assets/champagne/waves/wave-field.svg");
+  --champagne-particles-primary: url("/assets/champagne/particles/home-hero-particles.webp");
+  --champagne-grain-desktop: url("/assets/champagne/film-grain/film-grain-desktop .webp");
+  --champagne-grain-mobile: url("/assets/champagne/film-grain/film-grain-mobile .webp");
+}
+
+:root {
+  --hero-wave-background-desktop: var(--champagne-wave-bg-desktop);
+  --hero-wave-background-mobile: var(--champagne-wave-bg-mobile);
+  --hero-wave-mask-desktop: var(--champagne-wave-mask-desktop);
+  --hero-wave-mask-mobile: var(--champagne-wave-mask-mobile);
+  --hero-overlay-dots: var(--champagne-overlay-dots);
+  --hero-overlay-field: var(--champagne-overlay-field);
+  --hero-particles: var(--champagne-particles-primary);
+  --hero-grain-desktop: var(--champagne-grain-desktop);
+  --hero-grain-mobile: var(--champagne-grain-mobile);
+  --hero-film-grain-opacity: 0.32;
 }
 
 @media (max-width: 640px) {
-  :root { --wave-mask: url("/assets/champagne/waves/wave-mask-mobile.webp"); }
+  :root {
+    --hero-wave-mask-desktop: var(--champagne-wave-mask-mobile);
+    --hero-wave-background-desktop: var(--champagne-wave-bg-mobile);
+  }
 }
 
-/* Layer order: gradient → wave mask → particles → grain → glass → content */
+/* Layer order: gradient → wave field → overlays → particles → grain → content */
 .champagne-surface,
 .champagne-surface-lux {
   background-image: var(--smh-gradient);
@@ -19,22 +39,25 @@
 }
 
 .champagne-surface::before,
-.champagne-surface-lux::before { /* wave mask */
+.champagne-surface-lux::before {
   content: "";
-  position: absolute; inset: 0;
-  mask-image: var(--wave-mask);
-  -webkit-mask-image: var(--wave-mask);
-  mask-size: cover; -webkit-mask-size: cover;
+  position: absolute;
+  inset: 0;
+  mask-image: var(--hero-wave-mask-desktop);
+  -webkit-mask-image: var(--hero-wave-mask-desktop);
+  mask-size: cover;
+  -webkit-mask-size: cover;
   background: currentColor;
   opacity: 1;
   pointer-events: none;
 }
 
 .champagne-surface::after,
-.champagne-surface-lux::after { /* particles + grain */
+.champagne-surface-lux::after {
   content: "";
-  position: absolute; inset: 0;
-  background-image: var(--particles), var(--grain-desktop);
+  position: absolute;
+  inset: 0;
+  background-image: var(--hero-particles), var(--hero-grain-desktop);
   background-repeat: no-repeat, repeat;
   background-size: cover, cover;
   mix-blend-mode: soft-light;
@@ -45,6 +68,6 @@
 @media (max-width: 640px) {
   .champagne-surface::after,
   .champagne-surface-lux::after {
-    background-image: var(--particles), var(--grain-mobile);
+    background-image: var(--hero-particles), var(--hero-grain-mobile);
   }
 }


### PR DESCRIPTION
## Summary
- Enrich sacred hero surface manifests with named layer metadata and update surface mapping/resolution for the new stack
- Rework hero renderer and tokens to layer gradients, waves, overlays, motion, particles, and grain with prefers-reduced-motion handling
- Add /champagne/hero-preview route with controls to toggle theme, particles, grain, and reduced motion for testing

## Testing
- npm run lint --workspaces=false *(fails: missing @typescript-eslint/eslint-plugin)*
- npm run build --workspace @champagne/hero
- npm run build --workspace web *(Next build completes; lint step notes missing @typescript-eslint/eslint-plugin)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69372983cf708332b714324a2aef5e0f)