### PR TITLE
Rebuild sacred hero surface stack

### DIFF
--- a/packages/champagne-hero/src/HeroAssetRegistry.ts
+++ b/packages/champagne-hero/src/HeroAssetRegistry.ts
@@ -63,29 +63,36 @@ export const HERO_ASSET_REGISTRY: Record<string, HeroAssetEntry> = {
   "sacred.particles.gold": {
     id: "sacred.particles.gold",
     type: "image",
-    path: `${HERO_ASSET_BASE}/particles/particles-gold .webp`,
+    path: `${HERO_ASSET_BASE}/particles/particles-gold%20.webp`,
   },
   "sacred.particles.magenta": {
     id: "sacred.particles.magenta",
     type: "image",
-    path: `${HERO_ASSET_BASE}/particles/particles-magenta .webp`,
+    path: `${HERO_ASSET_BASE}/particles/particles-magenta%20.webp`,
   },
   "sacred.particles.teal": {
     id: "sacred.particles.teal",
     type: "image",
-    path: `${HERO_ASSET_BASE}/particles/particles-teal .webp`,
+    path: `${HERO_ASSET_BASE}/particles/particles-teal%20.webp`,
   },
 
   // Grain
   "sacred.grain.desktop": {
     id: "sacred.grain.desktop",
     type: "image",
-    path: `${HERO_ASSET_BASE}/film-grain/film-grain-desktop .webp`,
+    path: `${HERO_ASSET_BASE}/film-grain/film-grain-desktop%20.webp`,
   },
   "sacred.grain.mobile": {
     id: "sacred.grain.mobile",
     type: "image",
-    path: `${HERO_ASSET_BASE}/film-grain/film-grain-mobile .webp`,
+    path: `${HERO_ASSET_BASE}/film-grain/film-grain-mobile%20.webp`,
+  },
+
+  // Textures
+  "sacred.texture.causticsOverlay": {
+    id: "sacred.texture.causticsOverlay",
+    type: "image",
+    path: `${HERO_ASSET_BASE}/textures/wave-light-overlay.webp`,
   },
 
   // Motion

--- a/packages/champagne-hero/src/hero-engine/HeroSurfaceMap.ts
+++ b/packages/champagne-hero/src/hero-engine/HeroSurfaceMap.ts
@@ -30,12 +30,13 @@ export interface HeroSurfaceDefinitionMap {
 }
 
 const SURFACE_TOKEN_CLASS_MAP: Record<string, string> = {
-  gradientField: "hero-surface-layer hero-surface--gradient-field",
-  waveMask: "hero-surface-layer hero-surface--wave-mask",
-  dotField: "hero-surface-layer hero-surface--dot-field",
-  filmGrain: "hero-surface-layer hero-surface--film-grain",
-  particles: "hero-surface-layer hero-surface--particles",
-  caustics: "hero-surface-layer hero-surface--caustics",
+  "gradient.base": "hero-surface-layer hero-surface--gradient-field",
+  "mask.waveHeader": "hero-surface-layer hero-surface--wave-mask",
+  "field.waveRings": "hero-surface-layer hero-surface--wave-field",
+  "field.dotGrid": "hero-surface-layer hero-surface--dot-field",
+  "overlay.filmGrain": "hero-surface-layer hero-surface--film-grain",
+  "overlay.particles": "hero-surface-layer hero-surface--particles",
+  "overlay.caustics": "hero-surface-layer hero-surface--caustics",
 };
 
 function normalizeLayer(entry: unknown): HeroSurfaceLayerDefinition | undefined {

--- a/packages/champagne-manifests/data/hero/sacred_hero_base.json
+++ b/packages/champagne-manifests/data/hero/sacred_hero_base.json
@@ -10,14 +10,14 @@
   "defaults": {
     "tone": "night",
     "surfaces": {
-      "gradient": "base.gradientField",
-      "waveMask": { "desktop": "base.waveMask", "mobile": "base.waveMask.mobile" },
-      "background": { "desktop": "base.waveField", "mobile": "base.waveField" },
-      "overlays": { "dots": "base.dotsTexture", "field": "base.waveFieldLines" },
-      "particles": "fx.particlesPrimary",
-      "grain": { "desktop": "overlay.filmGrain", "mobile": "overlay.filmGrain.mobile" },
-      "motion": ["fx.caustics", "fx.glass", "fx.goldDust", "fx.particleDrift"],
-      "video": "heroVideo"
+      "gradient": "gradient.base",
+      "waveMask": { "desktop": "mask.waveHeader", "mobile": "mask.waveHeader.mobile" },
+      "background": { "desktop": "field.waveBackdrop", "mobile": "field.waveBackdrop" },
+      "overlays": { "dots": "field.dotGrid", "field": "field.waveRings" },
+      "particles": "overlay.particlesPrimary",
+      "grain": { "desktop": "overlay.filmGrain.desktop", "mobile": "overlay.filmGrain.mobile" },
+      "motion": ["overlay.caustics", "overlay.glassShimmer", "overlay.goldDust", "overlay.particlesDrift"],
+      "video": "hero.video"
     },
     "layout": {
       "contentAlign": "start",

--- a/packages/champagne-manifests/data/hero/sacred_hero_surfaces.json
+++ b/packages/champagne-manifests/data/hero/sacred_hero_surfaces.json
@@ -1,48 +1,49 @@
 {
   "waveMasks": {
-    "base.waveMask": "sacred.wave.mask.desktop",
-    "base.waveMask.mobile": "sacred.wave.mask.mobile",
-    "header": "sacred.wave.mask.header",
-    "smh": "sacred.wave.mask.smh"
+    "mask.waveHeader.desktop": "sacred.wave.mask.desktop",
+    "mask.waveHeader.mobile": "sacred.wave.mask.mobile",
+    "mask.waveHeader": "sacred.wave.mask.desktop",
+    "mask.wave.smh": "sacred.wave.mask.smh"
   },
   "surfaceStack": [
-    { "id": "bg.gradientField", "role": "background", "token": "gradientField", "prmSafe": true },
-    { "id": "bg.waveMask", "role": "background", "token": "waveMask", "prmSafe": true },
-    { "id": "bg.dotField", "role": "background", "token": "dotField", "prmSafe": true },
-    { "id": "fx.filmGrain", "role": "fx", "token": "filmGrain", "prmSafe": true },
-    { "id": "fx.particles", "role": "fx", "token": "particles" },
-    { "id": "fx.caustics", "role": "fx", "token": "caustics" }
+    { "id": "gradient.base", "role": "background", "token": "gradient.base", "prmSafe": true },
+    { "id": "mask.waveHeader", "role": "background", "token": "mask.waveHeader", "prmSafe": true },
+    { "id": "field.waveRings", "role": "background", "token": "field.waveRings", "prmSafe": true },
+    { "id": "field.dotGrid", "role": "background", "token": "field.dotGrid", "prmSafe": true },
+    { "id": "overlay.filmGrain", "role": "fx", "token": "overlay.filmGrain", "prmSafe": true },
+    { "id": "overlay.particles", "role": "fx", "token": "overlay.particles" },
+    { "id": "overlay.caustics", "role": "fx", "token": "overlay.caustics", "prmSafe": true }
   ],
   "waveBackgrounds": {
-    "base.waveField": {
+    "field.waveBackdrop": {
       "desktop": "sacred.wave.background.desktop",
       "mobile": "sacred.wave.background.mobile"
     }
   },
   "gradients": {
-    "base.gradientField": "var(--smh-gradient)"
+    "gradient.base": "var(--smh-gradient)"
   },
   "overlays": {
-    "base.waveFieldLines": { "asset": "sacred.wave.overlay.field", "blendMode": "soft-light", "opacity": 0.85 },
-    "base.dotsTexture": { "asset": "sacred.wave.overlay.dots", "blendMode": "screen", "opacity": 0.58, "prmSafe": true }
+    "field.waveRings": { "asset": "sacred.wave.overlay.field", "blendMode": "soft-light", "opacity": 0.85, "prmSafe": true },
+    "field.dotGrid": { "asset": "sacred.wave.overlay.dots", "blendMode": "screen", "opacity": 0.58, "prmSafe": true }
   },
   "particles": {
-    "fx.particlesPrimary": { "asset": "sacred.particles.home", "blendMode": "screen", "opacity": 0.48 },
-    "fx.particlesGold": { "asset": "sacred.particles.gold", "blendMode": "screen", "opacity": 0.52 },
-    "fx.particlesMagenta": { "asset": "sacred.particles.magenta", "blendMode": "screen", "opacity": 0.46 },
-    "fx.particlesTeal": { "asset": "sacred.particles.teal", "blendMode": "screen", "opacity": 0.46 }
+    "overlay.particlesPrimary": { "asset": "sacred.particles.home", "blendMode": "screen", "opacity": 0.48 },
+    "overlay.particlesGold": { "asset": "sacred.particles.gold", "blendMode": "screen", "opacity": 0.52 },
+    "overlay.particlesMagenta": { "asset": "sacred.particles.magenta", "blendMode": "screen", "opacity": 0.46 },
+    "overlay.particlesTeal": { "asset": "sacred.particles.teal", "blendMode": "screen", "opacity": 0.46 }
   },
   "grain": {
-    "overlay.filmGrain": { "asset": "sacred.grain.desktop", "blendMode": "soft-light", "opacity": 0.32, "prmSafe": true },
+    "overlay.filmGrain.desktop": { "asset": "sacred.grain.desktop", "blendMode": "soft-light", "opacity": 0.32, "prmSafe": true },
     "overlay.filmGrain.mobile": { "asset": "sacred.grain.mobile", "blendMode": "soft-light", "opacity": 0.32, "prmSafe": true }
   },
   "motion": {
-    "fx.caustics": { "asset": "sacred.motion.waveCaustics", "blendMode": "screen", "opacity": 0.9 },
-    "fx.glass": { "asset": "sacred.motion.glassShimmer", "blendMode": "screen", "opacity": 0.85 },
-    "fx.goldDust": { "asset": "sacred.motion.goldDust", "blendMode": "screen", "opacity": 0.7 },
-    "fx.particleDrift": { "asset": "sacred.motion.particleDrift", "blendMode": "screen", "opacity": 0.6 }
+    "overlay.caustics": { "asset": "sacred.motion.waveCaustics", "blendMode": "screen", "opacity": 0.9 },
+    "overlay.glassShimmer": { "asset": "sacred.motion.glassShimmer", "blendMode": "screen", "opacity": 0.85 },
+    "overlay.goldDust": { "asset": "sacred.motion.goldDust", "blendMode": "screen", "opacity": 0.7 },
+    "overlay.particlesDrift": { "asset": "sacred.motion.particleDrift", "blendMode": "screen", "opacity": 0.6 }
   },
   "video": {
-    "heroVideo": { "asset": "sacred.motion.heroVideo", "blendMode": "screen" }
+    "hero.video": { "asset": "sacred.motion.heroVideo", "blendMode": "screen", "prmSafe": false }
   }
 }

--- a/packages/champagne-manifests/data/hero/sacred_hero_variants.json
+++ b/packages/champagne-manifests/data/hero/sacred_hero_variants.json
@@ -5,8 +5,8 @@
       "label": "Sacred night base",
       "tone": "night",
       "surfaces": {
-        "particles": "fx.particlesPrimary",
-        "motion": ["fx.caustics", "fx.glass", "fx.goldDust"]
+        "particles": "overlay.particlesPrimary",
+        "motion": ["overlay.caustics", "overlay.glassShimmer", "overlay.goldDust"]
       }
     },
     {
@@ -15,8 +15,8 @@
       "timeOfDay": "day",
       "tone": "day",
       "surfaces": {
-        "particles": "fx.particlesTeal",
-        "motion": ["fx.glass"]
+        "particles": "overlay.particlesTeal",
+        "motion": ["overlay.glassShimmer"]
       },
       "content": {
         "headline": "Daylight smile confidence.",
@@ -36,8 +36,8 @@
         "secondaryCta": { "label": "Compare options", "href": "/treatments" }
       },
       "surfaces": {
-        "particles": "fx.particlesMagenta",
-        "motion": ["fx.glass"]
+        "particles": "overlay.particlesMagenta",
+        "motion": ["overlay.glassShimmer"]
       },
       "motion": {
         "energyMode": "dynamic",
@@ -57,8 +57,8 @@
         "secondaryCta": { "label": "See pricing", "href": "/contact" }
       },
       "surfaces": {
-        "particles": "fx.particlesGold",
-        "motion": ["fx.caustics"]
+        "particles": "overlay.particlesGold",
+        "motion": ["overlay.caustics"]
       },
       "motion": {
         "energyMode": "calm",
@@ -78,8 +78,8 @@
         "secondaryCta": { "label": "How aligners work", "href": "/treatments" }
       },
       "surfaces": {
-        "particles": "fx.particlesTeal",
-        "motion": ["fx.glass"]
+        "particles": "overlay.particlesTeal",
+        "motion": ["overlay.glassShimmer"]
       },
       "motion": {
         "energyMode": "balanced",
@@ -99,8 +99,8 @@
         "secondaryCta": { "label": "Preview cases", "href": "/smile-gallery" }
       },
       "surfaces": {
-        "particles": "fx.particlesGold",
-        "motion": ["fx.glass", "fx.caustics"]
+        "particles": "overlay.particlesGold",
+        "motion": ["overlay.glassShimmer", "overlay.caustics"]
       },
       "motion": {
         "energyMode": "balanced",
@@ -120,8 +120,8 @@
         "secondaryCta": { "label": "See the studio", "href": "/about" }
       },
       "surfaces": {
-        "particles": "fx.particlesMagenta",
-        "motion": ["fx.glass", "fx.goldDust"]
+        "particles": "overlay.particlesMagenta",
+        "motion": ["overlay.glassShimmer", "overlay.goldDust"]
       },
       "motion": {
         "energyMode": "dynamic",

--- a/packages/champagne-manifests/data/hero/sacred_hero_weather.json
+++ b/packages/champagne-manifests/data/hero/sacred_hero_weather.json
@@ -2,22 +2,22 @@
   "day": {
     "tone": "day",
     "surfaces": {
-      "particles": "fx.particlesTeal",
-      "motion": ["fx.glass"]
+      "particles": "overlay.particlesTeal",
+      "motion": ["overlay.glassShimmer"]
     }
   },
   "evening": {
     "tone": "evening",
     "surfaces": {
-      "particles": "fx.particlesGold",
-      "motion": ["fx.goldDust"]
+      "particles": "overlay.particlesGold",
+      "motion": ["overlay.goldDust"]
     }
   },
   "night": {
     "tone": "night",
     "surfaces": {
-      "particles": "fx.particlesPrimary",
-      "motion": ["fx.caustics"]
+      "particles": "overlay.particlesPrimary",
+      "motion": ["overlay.caustics"]
     }
   }
 }

--- a/packages/champagne-tokens/styles/champagne/surface.css
+++ b/packages/champagne-tokens/styles/champagne/surface.css
@@ -1,7 +1,7 @@
 :root {
   --champagne-wave-mask-desktop: url("/assets/champagne/waves/wave-mask-desktop.webp");
   --champagne-wave-mask-mobile: url("/assets/champagne/waves/wave-mask-mobile.webp");
-  --champagne-wave-bg-desktop: url("/assets/champagne/waves/waves-bg-2560.webp");
+  --champagne-wave-bg-desktop: url("/assets/champagne/waves/waves-bg-1920.webp");
   --champagne-wave-bg-mobile: url("/assets/champagne/waves/waves-bg-768.webp");
   --champagne-overlay-dots: url("/assets/champagne/waves/wave-dots.svg");
   --champagne-overlay-field: url("/assets/champagne/waves/wave-field.svg");
@@ -23,6 +23,7 @@
   --hero-grain-mobile: var(--champagne-grain-mobile);
   --hero-film-grain-opacity: 0.32;
   --hero-caustics-overlay: var(--champagne-caustics-overlay);
+  --hero-particles-opacity: 0.4;
 }
 
 @media (max-width: 640px) {
@@ -53,22 +54,29 @@
   opacity: 0.92;
 }
 
-.hero-surface-layer.hero-surface--dot-field {
-  background-image: var(--hero-overlay-field), var(--hero-overlay-dots);
+.hero-surface-layer.hero-surface--wave-field {
+  background-image: var(--hero-overlay-field);
   mix-blend-mode: soft-light;
-  opacity: 0.8;
+  opacity: 0.85;
+}
+
+.hero-surface-layer.hero-surface--dot-field {
+  background-image: var(--hero-overlay-dots);
+  mix-blend-mode: screen;
+  opacity: 0.58;
 }
 
 .hero-surface-layer.hero-surface--particles {
   background-image: var(--hero-particles);
   mix-blend-mode: screen;
-  opacity: 0.4;
+  opacity: var(--hero-particles-opacity, 0.4);
 }
 
 .hero-surface-layer.hero-surface--film-grain {
   background-image: var(--hero-grain-desktop);
   background-repeat: repeat;
-  mix-blend-mode: soft-light;
+  mix-blend-mode: var(--hero-film-grain-blend, soft-light);
+  opacity: var(--hero-film-grain-opacity, 0.32);
 }
 
 .hero-surface-layer.hero-surface--caustics {
@@ -82,6 +90,10 @@
     background-image: var(--hero-wave-background-mobile);
     mask-image: var(--hero-wave-mask-mobile);
     -webkit-mask-image: var(--hero-wave-mask-mobile);
+  }
+
+  .hero-surface-layer.hero-surface--wave-field {
+    background-image: var(--hero-overlay-field);
   }
 
   .hero-surface-layer.hero-surface--film-grain {


### PR DESCRIPTION
## Summary
- Reconstructed Sacred Hero surface manifests and asset registry to map canonical gradients, wave fields, particles, grain, and motion assets
- Updated hero surface map, renderer, and surface styling to render the donor stack with PRM-aware fallbacks and proper layering
- Retuned Sacred Hero variants and weather mappings to the new surface tokens for consistent visuals

## Testing
- npm run lint --workspaces=false *(fails: missing @typescript-eslint/eslint-plugin in shared config)*
- npm run build --workspace @champagne/hero
- npm run build --workspace web *(completes after lint step warns about missing @typescript-eslint/eslint-plugin)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69378ee982f48321ba6669d56e04cf9e)