### PR TITLE
Add Telegram capability deck and onboarding playbook with tests

### DIFF
--- a/tools/agent/src/chat/telegram-capability-deck.v1.js
+++ b/tools/agent/src/chat/telegram-capability-deck.v1.js
@@ -1,0 +1,104 @@
+const SAFE_COMMAND_EXAMPLES = Object.freeze([
+  'help',
+  'onboarding',
+  'status',
+  'queue',
+  'approve 42',
+  'reject 42',
+]);
+
+const SAFE_PROMPT_EXAMPLES = Object.freeze([
+  'Help me understand what this assistant can do.',
+  'Show onboarding for a first-time user.',
+  'Summarise what is waiting in the queue before I approve anything.',
+  'Draft a safe reply for a customer asking for next steps.',
+  'Explain why a task needs approval in plain language.',
+]);
+
+const CAN_DO = Object.freeze([
+  'Explain available bot features in plain language.',
+  'Show onboarding steps for first-time users.',
+  'Provide safe command examples before a user acts.',
+  'Describe how the queue and approval flow works.',
+  'Offer prompt examples for common low-risk tasks.',
+]);
+
+const CANNOT_DO = Object.freeze([
+  'Approve, reject, or execute queued work without an explicit user command.',
+  'Suggest bypasses, hidden admin verbs, or unsafe escalation shortcuts.',
+  'Promise external side effects that are not confirmed by the queue state.',
+  'Invent unsupported capabilities or claim full autonomy.',
+  'Encourage users to share secrets, credentials, or sensitive personal data.',
+]);
+
+function createCapabilityDeck() {
+  return {
+    title: 'Champagne Telegram Help',
+    intro:
+      'Use this assistant to learn the workflow, preview safe commands, and understand which actions stay queued until you approve them.',
+    sections: [
+      {
+        key: 'can_do',
+        title: 'What the system can do',
+        items: CAN_DO,
+      },
+      {
+        key: 'cannot_do',
+        title: 'What the system cannot do',
+        items: CANNOT_DO,
+      },
+      {
+        key: 'safe_commands',
+        title: 'Safe command examples',
+        items: SAFE_COMMAND_EXAMPLES,
+      },
+      {
+        key: 'prompt_examples',
+        title: 'Prompt examples',
+        items: SAFE_PROMPT_EXAMPLES,
+      },
+      {
+        key: 'queue_approvals',
+        title: 'Queue and approvals',
+        items: [
+          'Low-risk help text can render immediately.',
+          'Anything that would change state should stay in the queue until you explicitly approve or reject it.',
+          'Approval messages should explain what is waiting, why it is waiting, and what happens after approval.',
+        ],
+      },
+    ],
+  };
+}
+
+function renderCapabilityDeck(deck = createCapabilityDeck()) {
+  const body = deck.sections
+    .map((section) => {
+      const items = section.items.map((item) => `- ${item}`).join('\n');
+      return `${section.title}\n${items}`;
+    })
+    .join('\n\n');
+
+  return `${deck.title}\n\n${deck.intro}\n\n${body}`;
+}
+
+function isHelpRequest(input = '') {
+  const normalized = String(input).trim().toLowerCase();
+  return normalized === 'help' || normalized === '/help' || normalized === 'onboarding';
+}
+
+function hasUnsafeSuggestion(text = '') {
+  return /(^|\n)-\s*(bypass approval|override guard|admin token|sudo|ignore approval|force approve|share your secret key)\b/im.test(
+    String(text),
+  );
+}
+
+module.exports = {
+  CAN_DO,
+  CANNOT_DO,
+  SAFE_COMMAND_EXAMPLES,
+  SAFE_PROMPT_EXAMPLES,
+  createCapabilityDeck,
+  renderCapabilityDeck,
+  isHelpRequest,
+  hasUnsafeSuggestion,
+};

--- a/tools/agent/src/chat/telegram-capability-deck.v1.test.js
+++ b/tools/agent/src/chat/telegram-capability-deck.v1.test.js
@@ -1,0 +1,37 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const {
+  createCapabilityDeck,
+  hasUnsafeSuggestion,
+  renderCapabilityDeck,
+} = require('./telegram-capability-deck.v1');
+const {
+  createOnboardingMessage,
+  resolveTelegramFirstUseResponse,
+} = require('./telegram-first-use-playbook.v1');
+
+test('renders the required help sections', () => {
+  const rendered = renderCapabilityDeck(createCapabilityDeck());
+
+  assert.match(rendered, /What the system can do/);
+  assert.match(rendered, /What the system cannot do/);
+  assert.match(rendered, /Safe command examples/);
+  assert.match(rendered, /Prompt examples/);
+  assert.match(rendered, /Queue and approvals/);
+  assert.match(rendered, /approve 42/);
+  assert.match(rendered, /Help me understand what this assistant can do\./);
+});
+
+test('keeps onboarding help free of unsafe suggestions', () => {
+  const onboarding = createOnboardingMessage();
+
+  assert.equal(hasUnsafeSuggestion(onboarding.body), false);
+  assert.match(onboarding.approvalNote, /Queued actions remain pending/);
+});
+
+test('serves help and onboarding triggers only', () => {
+  assert.equal(resolveTelegramFirstUseResponse('help')?.trigger, 'onboarding');
+  assert.equal(resolveTelegramFirstUseResponse('/help')?.trigger, 'onboarding');
+  assert.equal(resolveTelegramFirstUseResponse('onboarding')?.trigger, 'onboarding');
+  assert.equal(resolveTelegramFirstUseResponse('book appointment'), null);
+});

--- a/tools/agent/src/chat/telegram-first-use-playbook.v1.js
+++ b/tools/agent/src/chat/telegram-first-use-playbook.v1.js
@@ -1,0 +1,36 @@
+const {
+  createCapabilityDeck,
+  hasUnsafeSuggestion,
+  isHelpRequest,
+  renderCapabilityDeck,
+} = require('./telegram-capability-deck.v1');
+
+function createOnboardingMessage() {
+  const deck = createCapabilityDeck();
+  return {
+    trigger: 'onboarding',
+    title: 'Champagne Telegram Onboarding',
+    body: renderCapabilityDeck(deck),
+    approvalNote:
+      'Queued actions remain pending until you explicitly approve them. Help text does not auto-approve anything.',
+  };
+}
+
+function resolveTelegramFirstUseResponse(input = '') {
+  if (!isHelpRequest(input)) {
+    return null;
+  }
+
+  const onboarding = createOnboardingMessage();
+
+  if (hasUnsafeSuggestion(onboarding.body)) {
+    throw new Error('Unsafe suggestion detected in onboarding output.');
+  }
+
+  return onboarding;
+}
+
+module.exports = {
+  createOnboardingMessage,
+  resolveTelegramFirstUseResponse,
+};


### PR DESCRIPTION
### Motivation
- Provide an in-chat help / capability system so Telegram users can discover what the assistant can do, what it cannot do, and how queue/approval works. 
- Ensure onboarding/help content is safe by detecting and blocking any unsafe suggestions (e.g. bypasses, admin tokens, force-approve verbs). 
- Offer concrete safe command and prompt examples to reduce risk of unsafe or state-changing actions being executed implicitly.

### Description
- Added `tools/agent/src/chat/telegram-capability-deck.v1.js` which defines the capability deck, render helpers, `isHelpRequest`, and `hasUnsafeSuggestion` checks. 
- Added `tools/agent/src/chat/telegram-first-use-playbook.v1.js` which wires onboarding behavior so `help`, `/help`, and `onboarding` resolve to the capability deck and enforces the unsafe-suggestion check. 
- Added tests at `tools/agent/src/chat/telegram-capability-deck.v1.test.js` using `node --test` to validate rendered output, onboarding safety, and trigger handling. 
- Implemented a narrow unsafe-suggestion pattern matcher and safe example lists covering commands and prompt templates to make usage explicit and auditable.

### Testing
- Ran `node --test tools/agent/src/chat/telegram-capability-deck.v1.test.js` and all tests passed. 
- Ran `npm run guard:hero` which passed the hero guard checks. 
- Ran `npm run guard:canon` which failed due to an existing repository patient-portal SSR smoke-test warmup abort unrelated to these changes. 
- Ran `npm run verify` which also failed for the same existing `guard:canon` smoke-test issue; token-purity and other local checks passed prior to that guard step.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd753a7a448332b863ab6311eac7f9)