### PR TITLE
perf(web): lazy-load hero renderer variants in HeroMount

### DIFF
--- a/apps/web/app/_components/HeroMount.tsx
+++ b/apps/web/app/_components/HeroMount.tsx
@@ -1,14 +1,9 @@
-import { HeroRenderer } from "../components/hero/HeroRenderer";
-import {
-  HeroContentV2,
-  HeroRendererV2,
-  HeroV2Frame,
-  type HeroRendererV2Props,
-} from "../components/hero/v2/HeroRendererV2";
+import { headers } from "next/headers";
+
+import type { HeroRendererProps } from "../components/hero/HeroRenderer";
 import { buildHeroV2Model } from "../components/hero/v2/buildHeroV2Model";
 import { HeroContentFade, HeroSurfaceStackV2 } from "../components/hero/v2/HeroV2Client";
-import type { HeroRendererProps } from "../components/hero/HeroRenderer";
-import { headers } from "next/headers";
+import type { HeroRendererV2Props } from "../components/hero/v2/HeroRendererV2";
 
 const normalizeHeroPathname = (path?: string) => {
   if (!path) return "/";
@@ -27,7 +22,6 @@ export async function HeroMount(props: HeroRendererProps) {
     .replace(/^'(.*)'$/, "$1")
     .toLowerCase();
   const useV2 = normalized === "v2";
-  const Renderer = useV2 ? HeroRendererV2 : HeroRenderer;
 
   if (useV2) {
     const headersList = await headers();
@@ -51,6 +45,7 @@ export async function HeroMount(props: HeroRendererProps) {
       }
     }
 
+    const { HeroContentV2, HeroRendererV2, HeroV2Frame } = await import("../components/hero/v2/HeroRendererV2");
     const v2Props = props as HeroRendererV2Props;
     const v2PropsWithPath = { ...v2Props, pageSlugOrPath: pathname };
     const v2Model = await buildHeroV2Model(v2PropsWithPath);
@@ -103,6 +98,8 @@ export async function HeroMount(props: HeroRendererProps) {
     );
   }
 
+  const { HeroRenderer } = await import("../components/hero/HeroRenderer");
+
   return (
     <div
       data-hero-engine="v1"
@@ -110,7 +107,7 @@ export async function HeroMount(props: HeroRendererProps) {
       data-hero-flag-normalized={normalized}
       style={{ minHeight: "72vh" }}
     >
-      <Renderer {...props} />
+      <HeroRenderer {...props} />
     </div>
   );
 }


### PR DESCRIPTION
### Motivation
- Reduce initial JS work and improve route-level code-splitting for the hero entrypoint by ensuring only the active hero renderer module is loaded at runtime.
- Keep the change minimal and non-visual to avoid UX or layout regressions while improving main-thread pressure around above-the-fold hero rendering.
- Preserve sacred hero files and existing behavior by confining the change to the `_components` area only.

### Description
- Replaced eager top-level imports of both hero renderer implementations with conditional dynamic imports inside the matching engine branch (lazy `await import(...)` for `v2` and for the `v1` fallback) in `apps/web/app/_components/HeroMount.tsx`.
- Removed the previous `Renderer` switch that relied on both renderers being imported and directly render the lazily-imported component in each path while preserving all props and the `minHeight: '72vh'` wrapper.
- Kept type imports and the `buildHeroV2Model`/surface stack flow intact so runtime behavior and debug attributes remain unchanged.

### Testing
- Ran `npm run guard:hero` and it passed (Hero Guard verification OK).
- Ran `npm run guard:canon` and it passed (Canon Guard including patient-portal SSR probe passed).
- Ran `npm run verify` which runs token-purity, workspace guards, `pnpm run guard:all`, `lint`, `typecheck`, and `CI=1 pnpm run build:web`, and the verification and production build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de4e15b3788332a2ad219877f0398a)