### PR TITLE
Harden launch SEO foundations

### DIFF
--- a/apps/web/app/(champagne)/legal/[slug]/page.tsx
+++ b/apps/web/app/(champagne)/legal/[slug]/page.tsx
@@ -1,9 +1,15 @@
 import path from "node:path";
+import type { Metadata } from "next";
+import { getAllPages, getPageManifest } from "@champagne/manifests";
 import { notFound } from "next/navigation";
 
 import ChampagnePageBuilder from "../../_builder/ChampagnePageBuilder";
 
+const PRODUCTION_CANONICAL_ORIGIN = "https://www.smhdental.co.uk";
+const LEGAL_ROUTE_PREFIX = "/legal/";
+
 type PageParams = Promise<{ slug: string }>;
+type LegalManifest = { path?: string; label?: string; title?: string; description?: string; intro?: string; category?: string };
 
 function resolvePagePath(slug?: string) {
   if (!slug) return null;
@@ -12,13 +18,66 @@ function resolvePagePath(slug?: string) {
     const decodedSlug = decodeURIComponent(slug);
     if (!decodedSlug.trim()) return null;
 
-    const normalizedPath = path.posix.normalize(`/legal/${decodedSlug}`);
-    if (!normalizedPath.startsWith("/legal/")) return null;
+    const normalizedPath = path.posix.normalize(`${LEGAL_ROUTE_PREFIX}${decodedSlug}`);
+    if (!normalizedPath.startsWith(LEGAL_ROUTE_PREFIX)) return null;
 
     return normalizedPath;
   } catch {
     return null;
   }
+}
+
+function getPublicLegalManifest(pagePath: string): LegalManifest | null {
+  const manifest = getPageManifest(pagePath) as LegalManifest | undefined;
+  if (manifest?.path !== pagePath || manifest.category !== "legal") return null;
+  return manifest;
+}
+
+function getLegalPageDetails(manifest: LegalManifest) {
+  const title = manifest.label ?? manifest.title ?? "Legal information";
+  const description = manifest.description ?? manifest.intro ?? `${title} for St Mary's House Dental Care.`;
+  const canonicalPath = manifest.path ?? LEGAL_ROUTE_PREFIX;
+
+  return {
+    title,
+    description,
+    canonicalPath,
+    canonicalUrl: `${PRODUCTION_CANONICAL_ORIGIN}${canonicalPath}`,
+  };
+}
+
+export function generateStaticParams() {
+  return getAllPages()
+    .filter((page) => page.category === "legal" && page.path?.startsWith(LEGAL_ROUTE_PREFIX) && page.path !== "/legal/privacy")
+    .map((page) => ({ slug: page.path?.replace(LEGAL_ROUTE_PREFIX, "") }));
+}
+
+export async function generateMetadata({ params }: { params: PageParams }): Promise<Metadata> {
+  const resolvedParams = await params;
+  const pagePath = resolvePagePath(resolvedParams.slug);
+  if (!pagePath) return { title: "Legal page not found" };
+
+  const manifest = getPublicLegalManifest(pagePath);
+  if (!manifest) return { title: "Legal page not found" };
+
+  const { title, description, canonicalPath } = getLegalPageDetails(manifest);
+  return {
+    title,
+    description,
+    alternates: {
+      canonical: canonicalPath,
+    },
+    openGraph: {
+      title,
+      description,
+      url: canonicalPath,
+    },
+    twitter: {
+      card: "summary_large_image",
+      title,
+      description,
+    },
+  };
 }
 
 export default async function Page({ params }: { params: PageParams }) {
@@ -29,5 +88,33 @@ export default async function Page({ params }: { params: PageParams }) {
     notFound();
   }
 
-  return <ChampagnePageBuilder slug={pagePath} />;
+  const manifest = getPublicLegalManifest(pagePath);
+  if (!manifest) {
+    notFound();
+  }
+
+  const { title, description, canonicalUrl } = getLegalPageDetails(manifest);
+  const legalJsonLd = {
+    "@context": "https://schema.org",
+    "@type": "WebPage",
+    name: title,
+    description,
+    url: canonicalUrl,
+    isPartOf: {
+      "@id": `${PRODUCTION_CANONICAL_ORIGIN}/#website`,
+    },
+    publisher: {
+      "@id": `${PRODUCTION_CANONICAL_ORIGIN}/#dentist`,
+    },
+  };
+
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(legalJsonLd) }}
+      />
+      <ChampagnePageBuilder slug={pagePath} />
+    </>
+  );
 }

--- a/apps/web/app/(champagne)/legal/privacy/page.tsx
+++ b/apps/web/app/(champagne)/legal/privacy/page.tsx
@@ -1,12 +1,58 @@
+import type { Metadata } from "next";
+import { getPageManifest } from "@champagne/manifests";
 import { ChampagneHeroFrame, getHeroBySlug } from "@champagne/hero";
 import { ChampagneSectionRenderer } from "@champagne/sections";
 
+const PAGE_PATH = "/legal/privacy";
+const PRODUCTION_CANONICAL_ORIGIN = "https://www.smhdental.co.uk";
+const manifest = getPageManifest(PAGE_PATH) as { label?: string; title?: string; description?: string; intro?: string } | undefined;
+const title = manifest?.label ?? manifest?.title ?? "Privacy Policy";
+const description = manifest?.description ?? manifest?.intro ?? "Privacy Policy for St Mary's House Dental Care.";
+
+export const metadata: Metadata = {
+  title,
+  description,
+  alternates: {
+    canonical: PAGE_PATH,
+  },
+  openGraph: {
+    title,
+    description,
+    url: PAGE_PATH,
+  },
+  twitter: {
+    card: "summary_large_image",
+    title,
+    description,
+  },
+};
+
 export default function Page() {
-  const hero = getHeroBySlug("/legal/privacy");
+  const hero = getHeroBySlug(PAGE_PATH);
+  const legalJsonLd = {
+    "@context": "https://schema.org",
+    "@type": "WebPage",
+    name: title,
+    description,
+    url: `${PRODUCTION_CANONICAL_ORIGIN}${PAGE_PATH}`,
+    isPartOf: {
+      "@id": `${PRODUCTION_CANONICAL_ORIGIN}/#website`,
+    },
+    publisher: {
+      "@id": `${PRODUCTION_CANONICAL_ORIGIN}/#dentist`,
+    },
+  };
+
   return (
-    <main className="space-y-8">
-      <ChampagneHeroFrame heroId={hero.id} headline={hero.label ?? "Privacy surface"} />
-      <ChampagneSectionRenderer pageSlug="/legal/privacy" />
-    </main>
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(legalJsonLd) }}
+      />
+      <main className="space-y-8">
+        <ChampagneHeroFrame heroId={hero.id} headline={hero.label ?? "Privacy surface"} />
+        <ChampagneSectionRenderer pageSlug={PAGE_PATH} />
+      </main>
+    </>
   );
 }

--- a/apps/web/app/robots.ts
+++ b/apps/web/app/robots.ts
@@ -1,6 +1,7 @@
 import type { MetadataRoute } from "next";
 
 const PRODUCTION_CANONICAL_ORIGIN = "https://www.smhdental.co.uk";
+const INTERNAL_DISALLOW_PATHS = ["/champagne/", "/api/", "/patient-portal"];
 
 function isProductionIndexable() {
   return process.env.VERCEL_ENV === "production";
@@ -12,6 +13,7 @@ export default function robots(): MetadataRoute.Robots {
       rules: {
         userAgent: "*",
         allow: "/",
+        disallow: INTERNAL_DISALLOW_PATHS,
       },
       sitemap: `${PRODUCTION_CANONICAL_ORIGIN}/sitemap.xml`,
       host: PRODUCTION_CANONICAL_ORIGIN,

--- a/apps/web/app/sitemap.ts
+++ b/apps/web/app/sitemap.ts
@@ -4,24 +4,63 @@ import { getAllPages } from "@champagne/manifests";
 const PRODUCTION_CANONICAL_ORIGIN = "https://www.smhdental.co.uk";
 const EXCLUDED_PREFIXES = ["/champagne/", "/api/"];
 const EXCLUDED_PATHS = new Set(["/patient-portal"]);
+const SEO_FOUNDATION_LAST_MODIFIED = new Date("2026-05-28T00:00:00.000Z");
 
-function isPublicPath(path: string | undefined): path is string {
-  if (!path || !path.startsWith("/")) return false;
-  if (EXCLUDED_PATHS.has(path)) return false;
-  if (EXCLUDED_PREFIXES.some((prefix) => path.startsWith(prefix))) return false;
-  return true;
+type SitemapChangeFrequency = NonNullable<MetadataRoute.Sitemap[number]["changeFrequency"]>;
+
+type PublicRoutePolicy = {
+  changeFrequency: SitemapChangeFrequency;
+  priority: number;
+  lastModified?: Date;
+};
+
+function normalizePublicPath(path: string | undefined): string | null {
+  if (!path || !path.startsWith("/")) return null;
+  const normalizedPath = path.length > 1 && path.endsWith("/") ? path.slice(0, -1) : path;
+  if (EXCLUDED_PATHS.has(normalizedPath)) return null;
+  if (EXCLUDED_PREFIXES.some((prefix) => normalizedPath.startsWith(prefix))) return null;
+  return normalizedPath;
+}
+
+function getRoutePolicy(path: string): PublicRoutePolicy {
+  if (path === "/") {
+    return { changeFrequency: "weekly", priority: 1, lastModified: SEO_FOUNDATION_LAST_MODIFIED };
+  }
+
+  if (path === "/treatments") {
+    return { changeFrequency: "weekly", priority: 0.9, lastModified: SEO_FOUNDATION_LAST_MODIFIED };
+  }
+
+  if (path.startsWith("/treatments/")) {
+    return { changeFrequency: "monthly", priority: 0.82, lastModified: SEO_FOUNDATION_LAST_MODIFIED };
+  }
+
+  if (["/contact", "/fees", "/team", "/about"].includes(path)) {
+    return { changeFrequency: "monthly", priority: 0.76, lastModified: SEO_FOUNDATION_LAST_MODIFIED };
+  }
+
+  if (path.startsWith("/team/")) {
+    return { changeFrequency: "monthly", priority: 0.68, lastModified: SEO_FOUNDATION_LAST_MODIFIED };
+  }
+
+  if (path.startsWith("/legal/")) {
+    return { changeFrequency: "yearly", priority: 0.35, lastModified: SEO_FOUNDATION_LAST_MODIFIED };
+  }
+
+  return { changeFrequency: "monthly", priority: 0.6, lastModified: SEO_FOUNDATION_LAST_MODIFIED };
 }
 
 export default function sitemap(): MetadataRoute.Sitemap {
   const uniquePaths = Array.from(
     new Set(
       getAllPages()
-        .map((page) => page.path)
-        .filter(isPublicPath),
+        .map((page) => normalizePublicPath(page.path))
+        .filter((path): path is string => Boolean(path)),
     ),
   ).sort((a, b) => a.localeCompare(b));
 
   return uniquePaths.map((path) => ({
     url: `${PRODUCTION_CANONICAL_ORIGIN}${path}`,
+    ...getRoutePolicy(path),
   }));
 }

--- a/ops/contracts/WEBSITE_TRUTH_EXPORT_CONTRACT_V1.json
+++ b/ops/contracts/WEBSITE_TRUTH_EXPORT_CONTRACT_V1.json
@@ -1,6 +1,6 @@
 {
   "version": "CHAMPAGNE_WEBSITE_TRUTH_EXPORT_CONTRACT_V1",
-  "generatedAt": "2026-05-28T18:25:26.967Z",
+  "generatedAt": "2026-05-28T19:10:45.734Z",
   "purpose": "Champagne-side static website truth export contract for the frontier dominance agent repo.",
   "producer": {
     "repo": "drnickmaxwell-wq/champagne",
@@ -52,7 +52,8 @@
       "sitemap",
       "robots",
       "root metadata",
-      "support metadata"
+      "support metadata",
+      "legal metadata"
     ]
   },
   "reportShape": {

--- a/reports/WEBSITE_TRUTH_EXPORT_REPORT_V1.json
+++ b/reports/WEBSITE_TRUTH_EXPORT_REPORT_V1.json
@@ -1,6 +1,6 @@
 {
   "version": "WEBSITE_TRUTH_EXPORT_REPORT_V1",
-  "generatedAt": "2026-05-28T18:25:26.967Z",
+  "generatedAt": "2026-05-28T19:10:45.734Z",
   "contract": {
     "file": "ops/contracts/WEBSITE_TRUTH_EXPORT_CONTRACT_V1.json",
     "version": "CHAMPAGNE_WEBSITE_TRUTH_EXPORT_CONTRACT_V1"
@@ -42,7 +42,9 @@
           "WebSite",
           "WebPage"
         ],
-        "evidence": "Inferred from layout.tsx global JSON-LD plus route page JSON-LD patterns; payloads are not rendered by this static export."
+        "sourceFile": "apps/web/app/page.tsx",
+        "hasRouteJsonLdScript": true,
+        "evidence": "Route source contains an application/ld+json script; payload is not rendered by this static export."
       },
       "pageTruth": {
         "file": "page-truth/home.txt",
@@ -92,7 +94,9 @@
           "WebSite",
           "WebPage"
         ],
-        "evidence": "Inferred from layout.tsx global JSON-LD plus route page JSON-LD patterns; payloads are not rendered by this static export."
+        "sourceFile": "apps/web/app/(site)/[page]/page.tsx",
+        "hasRouteJsonLdScript": true,
+        "evidence": "Route source contains an application/ld+json script; payload is not rendered by this static export."
       },
       "pageTruth": {
         "file": "page-truth/[page].txt",
@@ -136,6 +140,8 @@
           "WebSite",
           "WebPage"
         ],
+        "sourceFile": "apps/web/app/(champagne)/about/page.tsx",
+        "hasRouteJsonLdScript": false,
         "evidence": "Inferred from layout.tsx global JSON-LD plus route page JSON-LD patterns; payloads are not rendered by this static export."
       },
       "pageTruth": {
@@ -185,6 +191,8 @@
           "LocalBusiness",
           "WebSite"
         ],
+        "sourceFile": "apps/web/app/api/converse/route.ts",
+        "hasRouteJsonLdScript": false,
         "evidence": "Inferred from layout.tsx global JSON-LD plus route page JSON-LD patterns; payloads are not rendered by this static export."
       },
       "pageTruth": {
@@ -227,6 +235,8 @@
           "LocalBusiness",
           "WebSite"
         ],
+        "sourceFile": "apps/web/app/api/handoff/booking/route.ts",
+        "hasRouteJsonLdScript": false,
         "evidence": "Inferred from layout.tsx global JSON-LD plus route page JSON-LD patterns; payloads are not rendered by this static export."
       },
       "pageTruth": {
@@ -269,6 +279,8 @@
           "LocalBusiness",
           "WebSite"
         ],
+        "sourceFile": "apps/web/app/api/handoff/emergency-callback/route.ts",
+        "hasRouteJsonLdScript": false,
         "evidence": "Inferred from layout.tsx global JSON-LD plus route page JSON-LD patterns; payloads are not rendered by this static export."
       },
       "pageTruth": {
@@ -311,6 +323,8 @@
           "LocalBusiness",
           "WebSite"
         ],
+        "sourceFile": "apps/web/app/api/handoff/new-patient/route.ts",
+        "hasRouteJsonLdScript": false,
         "evidence": "Inferred from layout.tsx global JSON-LD plus route page JSON-LD patterns; payloads are not rendered by this static export."
       },
       "pageTruth": {
@@ -353,6 +367,8 @@
           "LocalBusiness",
           "WebSite"
         ],
+        "sourceFile": "apps/web/app/api/health/route.ts",
+        "hasRouteJsonLdScript": false,
         "evidence": "Inferred from layout.tsx global JSON-LD plus route page JSON-LD patterns; payloads are not rendered by this static export."
       },
       "pageTruth": {
@@ -397,7 +413,9 @@
           "WebSite",
           "WebPage"
         ],
-        "evidence": "Inferred from layout.tsx global JSON-LD plus route page JSON-LD patterns; payloads are not rendered by this static export."
+        "sourceFile": "apps/web/app/blog/page.tsx",
+        "hasRouteJsonLdScript": true,
+        "evidence": "Route source contains an application/ld+json script; payload is not rendered by this static export."
       },
       "pageTruth": {
         "file": "page-truth/blog.txt",
@@ -446,6 +464,8 @@
           "LocalBusiness",
           "WebSite"
         ],
+        "sourceFile": "apps/web/app/champagne/hero-asset-lab/page.tsx",
+        "hasRouteJsonLdScript": false,
         "evidence": "Inferred from layout.tsx global JSON-LD plus route page JSON-LD patterns; payloads are not rendered by this static export."
       },
       "pageTruth": {
@@ -488,6 +508,8 @@
           "LocalBusiness",
           "WebSite"
         ],
+        "sourceFile": "apps/web/app/champagne/hero-debug/page.tsx",
+        "hasRouteJsonLdScript": false,
         "evidence": "Inferred from layout.tsx global JSON-LD plus route page JSON-LD patterns; payloads are not rendered by this static export."
       },
       "pageTruth": {
@@ -530,6 +552,8 @@
           "LocalBusiness",
           "WebSite"
         ],
+        "sourceFile": "apps/web/app/champagne/hero-lab/page.tsx",
+        "hasRouteJsonLdScript": false,
         "evidence": "Inferred from layout.tsx global JSON-LD plus route page JSON-LD patterns; payloads are not rendered by this static export."
       },
       "pageTruth": {
@@ -572,6 +596,8 @@
           "LocalBusiness",
           "WebSite"
         ],
+        "sourceFile": "apps/web/app/champagne/hero-lab/concierge/page.tsx",
+        "hasRouteJsonLdScript": false,
         "evidence": "Inferred from layout.tsx global JSON-LD plus route page JSON-LD patterns; payloads are not rendered by this static export."
       },
       "pageTruth": {
@@ -614,6 +640,8 @@
           "LocalBusiness",
           "WebSite"
         ],
+        "sourceFile": "apps/web/app/champagne/hero-preview/page.tsx",
+        "hasRouteJsonLdScript": false,
         "evidence": "Inferred from layout.tsx global JSON-LD plus route page JSON-LD patterns; payloads are not rendered by this static export."
       },
       "pageTruth": {
@@ -656,6 +684,8 @@
           "LocalBusiness",
           "WebSite"
         ],
+        "sourceFile": "apps/web/app/champagne/sections-debug/page.tsx",
+        "hasRouteJsonLdScript": false,
         "evidence": "Inferred from layout.tsx global JSON-LD plus route page JSON-LD patterns; payloads are not rendered by this static export."
       },
       "pageTruth": {
@@ -700,7 +730,9 @@
           "WebSite",
           "ContactPage"
         ],
-        "evidence": "Inferred from layout.tsx global JSON-LD plus route page JSON-LD patterns; payloads are not rendered by this static export."
+        "sourceFile": "apps/web/app/contact/page.tsx",
+        "hasRouteJsonLdScript": true,
+        "evidence": "Route source contains an application/ld+json script; payload is not rendered by this static export."
       },
       "pageTruth": {
         "file": "page-truth/contact.txt",
@@ -752,6 +784,8 @@
           "WebSite",
           "WebPage"
         ],
+        "sourceFile": "apps/web/app/dental-checkups-oral-cancer-screening/route.ts",
+        "hasRouteJsonLdScript": false,
         "evidence": "Inferred from layout.tsx global JSON-LD plus route page JSON-LD patterns; payloads are not rendered by this static export."
       },
       "pageTruth": {
@@ -803,7 +837,9 @@
           "WebSite",
           "WebPage"
         ],
-        "evidence": "Inferred from layout.tsx global JSON-LD plus route page JSON-LD patterns; payloads are not rendered by this static export."
+        "sourceFile": "apps/web/app/(site)/[page]/page.tsx",
+        "hasRouteJsonLdScript": true,
+        "evidence": "Route source contains an application/ld+json script; payload is not rendered by this static export."
       },
       "pageTruth": {
         "file": "page-truth/downloads.txt",
@@ -855,7 +891,9 @@
           "WebSite",
           "WebPage"
         ],
-        "evidence": "Inferred from layout.tsx global JSON-LD plus route page JSON-LD patterns; payloads are not rendered by this static export."
+        "sourceFile": "apps/web/app/fees/page.tsx",
+        "hasRouteJsonLdScript": true,
+        "evidence": "Route source contains an application/ld+json script; payload is not rendered by this static export."
       },
       "pageTruth": {
         "file": "page-truth/fees.txt",
@@ -906,7 +944,9 @@
           "WebSite",
           "WebPage"
         ],
-        "evidence": "Inferred from layout.tsx global JSON-LD plus route page JSON-LD patterns; payloads are not rendered by this static export."
+        "sourceFile": "apps/web/app/(site)/[page]/page.tsx",
+        "hasRouteJsonLdScript": true,
+        "evidence": "Route source contains an application/ld+json script; payload is not rendered by this static export."
       },
       "pageTruth": {
         "file": "page-truth/finance.txt",
@@ -946,7 +986,7 @@
         "canonicalUrl": null,
         "source": "app_metadata_or_manifest_inference",
         "sourceFile": "apps/web/app/(champagne)/legal/[slug]/page.tsx",
-        "hasRouteMetadataHook": false,
+        "hasRouteMetadataHook": true,
         "hasRootFallbackMetadata": true
       },
       "schema": {
@@ -957,7 +997,9 @@
           "WebSite",
           "WebPage"
         ],
-        "evidence": "Inferred from layout.tsx global JSON-LD plus route page JSON-LD patterns; payloads are not rendered by this static export."
+        "sourceFile": "apps/web/app/(champagne)/legal/[slug]/page.tsx",
+        "hasRouteJsonLdScript": true,
+        "evidence": "Route source contains an application/ld+json script; payload is not rendered by this static export."
       },
       "pageTruth": {
         "file": "page-truth/legal-[slug].txt",
@@ -990,7 +1032,7 @@
         "canonicalUrl": "https://www.smhdental.co.uk/legal/accessibility",
         "source": "app_metadata_or_manifest_inference",
         "sourceFile": "apps/web/app/(champagne)/legal/[slug]/page.tsx",
-        "hasRouteMetadataHook": false,
+        "hasRouteMetadataHook": true,
         "hasRootFallbackMetadata": true
       },
       "schema": {
@@ -1001,7 +1043,9 @@
           "WebSite",
           "WebPage"
         ],
-        "evidence": "Inferred from layout.tsx global JSON-LD plus route page JSON-LD patterns; payloads are not rendered by this static export."
+        "sourceFile": "apps/web/app/(champagne)/legal/[slug]/page.tsx",
+        "hasRouteJsonLdScript": true,
+        "evidence": "Route source contains an application/ld+json script; payload is not rendered by this static export."
       },
       "pageTruth": {
         "file": "page-truth/legal-accessibility.txt",
@@ -1042,7 +1086,7 @@
         "canonicalUrl": "https://www.smhdental.co.uk/legal/complaints",
         "source": "app_metadata_or_manifest_inference",
         "sourceFile": "apps/web/app/(champagne)/legal/[slug]/page.tsx",
-        "hasRouteMetadataHook": false,
+        "hasRouteMetadataHook": true,
         "hasRootFallbackMetadata": true
       },
       "schema": {
@@ -1053,7 +1097,9 @@
           "WebSite",
           "WebPage"
         ],
-        "evidence": "Inferred from layout.tsx global JSON-LD plus route page JSON-LD patterns; payloads are not rendered by this static export."
+        "sourceFile": "apps/web/app/(champagne)/legal/[slug]/page.tsx",
+        "hasRouteJsonLdScript": true,
+        "evidence": "Route source contains an application/ld+json script; payload is not rendered by this static export."
       },
       "pageTruth": {
         "file": "page-truth/legal-complaints.txt",
@@ -1094,7 +1140,7 @@
         "canonicalUrl": "https://www.smhdental.co.uk/legal/cookies",
         "source": "app_metadata_or_manifest_inference",
         "sourceFile": "apps/web/app/(champagne)/legal/[slug]/page.tsx",
-        "hasRouteMetadataHook": false,
+        "hasRouteMetadataHook": true,
         "hasRootFallbackMetadata": true
       },
       "schema": {
@@ -1105,7 +1151,9 @@
           "WebSite",
           "WebPage"
         ],
-        "evidence": "Inferred from layout.tsx global JSON-LD plus route page JSON-LD patterns; payloads are not rendered by this static export."
+        "sourceFile": "apps/web/app/(champagne)/legal/[slug]/page.tsx",
+        "hasRouteJsonLdScript": true,
+        "evidence": "Route source contains an application/ld+json script; payload is not rendered by this static export."
       },
       "pageTruth": {
         "file": "page-truth/legal-cookies.txt",
@@ -1146,7 +1194,7 @@
         "canonicalUrl": "https://www.smhdental.co.uk/legal/privacy",
         "source": "app_metadata_or_manifest_inference",
         "sourceFile": "apps/web/app/(champagne)/legal/privacy/page.tsx",
-        "hasRouteMetadataHook": false,
+        "hasRouteMetadataHook": true,
         "hasRootFallbackMetadata": true
       },
       "schema": {
@@ -1157,7 +1205,9 @@
           "WebSite",
           "WebPage"
         ],
-        "evidence": "Inferred from layout.tsx global JSON-LD plus route page JSON-LD patterns; payloads are not rendered by this static export."
+        "sourceFile": "apps/web/app/(champagne)/legal/privacy/page.tsx",
+        "hasRouteJsonLdScript": true,
+        "evidence": "Route source contains an application/ld+json script; payload is not rendered by this static export."
       },
       "pageTruth": {
         "file": "page-truth/legal-privacy.txt",
@@ -1198,7 +1248,7 @@
         "canonicalUrl": "https://www.smhdental.co.uk/legal/terms",
         "source": "app_metadata_or_manifest_inference",
         "sourceFile": "apps/web/app/(champagne)/legal/[slug]/page.tsx",
-        "hasRouteMetadataHook": false,
+        "hasRouteMetadataHook": true,
         "hasRootFallbackMetadata": true
       },
       "schema": {
@@ -1209,7 +1259,9 @@
           "WebSite",
           "WebPage"
         ],
-        "evidence": "Inferred from layout.tsx global JSON-LD plus route page JSON-LD patterns; payloads are not rendered by this static export."
+        "sourceFile": "apps/web/app/(champagne)/legal/[slug]/page.tsx",
+        "hasRouteJsonLdScript": true,
+        "evidence": "Route source contains an application/ld+json script; payload is not rendered by this static export."
       },
       "pageTruth": {
         "file": "page-truth/legal-terms.txt",
@@ -1261,7 +1313,9 @@
           "WebSite",
           "WebPage"
         ],
-        "evidence": "Inferred from layout.tsx global JSON-LD plus route page JSON-LD patterns; payloads are not rendered by this static export."
+        "sourceFile": "apps/web/app/(site)/[page]/page.tsx",
+        "hasRouteJsonLdScript": true,
+        "evidence": "Route source contains an application/ld+json script; payload is not rendered by this static export."
       },
       "pageTruth": {
         "file": "page-truth/newsletter.txt",
@@ -1312,6 +1366,8 @@
           "LocalBusiness",
           "WebSite"
         ],
+        "sourceFile": "apps/web/app/patient-portal/page.tsx",
+        "hasRouteJsonLdScript": false,
         "evidence": "Inferred from layout.tsx global JSON-LD plus route page JSON-LD patterns; payloads are not rendered by this static export."
       },
       "pageTruth": {
@@ -1363,7 +1419,9 @@
           "WebSite",
           "WebPage"
         ],
-        "evidence": "Inferred from layout.tsx global JSON-LD plus route page JSON-LD patterns; payloads are not rendered by this static export."
+        "sourceFile": "apps/web/app/(site)/[page]/page.tsx",
+        "hasRouteJsonLdScript": true,
+        "evidence": "Route source contains an application/ld+json script; payload is not rendered by this static export."
       },
       "pageTruth": {
         "file": "page-truth/practice-plan.txt",
@@ -1414,6 +1472,8 @@
           "WebSite",
           "WebPage"
         ],
+        "sourceFile": "apps/web/app/(champagne)/smile-gallery/page.tsx",
+        "hasRouteJsonLdScript": false,
         "evidence": "Inferred from layout.tsx global JSON-LD plus route page JSON-LD patterns; payloads are not rendered by this static export."
       },
       "pageTruth": {
@@ -1465,7 +1525,9 @@
           "WebSite",
           "WebPage"
         ],
-        "evidence": "Inferred from layout.tsx global JSON-LD plus route page JSON-LD patterns; payloads are not rendered by this static export."
+        "sourceFile": "apps/web/app/team/page.tsx",
+        "hasRouteJsonLdScript": true,
+        "evidence": "Route source contains an application/ld+json script; payload is not rendered by this static export."
       },
       "pageTruth": {
         "file": "page-truth/team.txt",
@@ -1516,7 +1578,9 @@
           "ProfilePage",
           "Person"
         ],
-        "evidence": "Inferred from layout.tsx global JSON-LD plus route page JSON-LD patterns; payloads are not rendered by this static export."
+        "sourceFile": "apps/web/app/team/[slug]/page.tsx",
+        "hasRouteJsonLdScript": true,
+        "evidence": "Route source contains an application/ld+json script; payload is not rendered by this static export."
       },
       "pageTruth": {
         "file": "page-truth/team-[slug].txt",
@@ -1561,7 +1625,9 @@
           "ProfilePage",
           "Person"
         ],
-        "evidence": "Inferred from layout.tsx global JSON-LD plus route page JSON-LD patterns; payloads are not rendered by this static export."
+        "sourceFile": "apps/web/app/team/[slug]/page.tsx",
+        "hasRouteJsonLdScript": true,
+        "evidence": "Route source contains an application/ld+json script; payload is not rendered by this static export."
       },
       "pageTruth": {
         "file": "page-truth/team-nick-maxwell.txt",
@@ -1613,7 +1679,9 @@
           "ProfilePage",
           "Person"
         ],
-        "evidence": "Inferred from layout.tsx global JSON-LD plus route page JSON-LD patterns; payloads are not rendered by this static export."
+        "sourceFile": "apps/web/app/team/[slug]/page.tsx",
+        "hasRouteJsonLdScript": true,
+        "evidence": "Route source contains an application/ld+json script; payload is not rendered by this static export."
       },
       "pageTruth": {
         "file": "page-truth/team-sara-burden.txt",
@@ -1666,7 +1734,9 @@
           "ProfilePage",
           "Person"
         ],
-        "evidence": "Inferred from layout.tsx global JSON-LD plus route page JSON-LD patterns; payloads are not rendered by this static export."
+        "sourceFile": "apps/web/app/team/[slug]/page.tsx",
+        "hasRouteJsonLdScript": true,
+        "evidence": "Route source contains an application/ld+json script; payload is not rendered by this static export."
       },
       "pageTruth": {
         "file": "page-truth/team-sylvia-krafft.txt",
@@ -1718,7 +1788,9 @@
           "WebSite",
           "WebPage"
         ],
-        "evidence": "Inferred from layout.tsx global JSON-LD plus route page JSON-LD patterns; payloads are not rendered by this static export."
+        "sourceFile": "apps/web/app/(site)/[page]/page.tsx",
+        "hasRouteJsonLdScript": true,
+        "evidence": "Route source contains an application/ld+json script; payload is not rendered by this static export."
       },
       "pageTruth": {
         "file": "page-truth/technology.txt",
@@ -1770,7 +1842,9 @@
           "WebSite",
           "WebPage"
         ],
-        "evidence": "Inferred from layout.tsx global JSON-LD plus route page JSON-LD patterns; payloads are not rendered by this static export."
+        "sourceFile": "apps/web/app/treatments/page.tsx",
+        "hasRouteJsonLdScript": true,
+        "evidence": "Route source contains an application/ld+json script; payload is not rendered by this static export."
       },
       "pageTruth": {
         "file": "page-truth/treatments.txt",
@@ -1822,7 +1896,9 @@
           "Service",
           "BreadcrumbList"
         ],
-        "evidence": "Inferred from layout.tsx global JSON-LD plus route page JSON-LD patterns; payloads are not rendered by this static export."
+        "sourceFile": "apps/web/app/treatments/[slug]/page.tsx",
+        "hasRouteJsonLdScript": true,
+        "evidence": "Route source contains an application/ld+json script; payload is not rendered by this static export."
       },
       "pageTruth": {
         "file": "page-truth/treatments-[slug].txt",
@@ -1868,7 +1944,9 @@
           "Service",
           "BreadcrumbList"
         ],
-        "evidence": "Inferred from layout.tsx global JSON-LD plus route page JSON-LD patterns; payloads are not rendered by this static export."
+        "sourceFile": "apps/web/app/treatments/[slug]/page.tsx",
+        "hasRouteJsonLdScript": true,
+        "evidence": "Route source contains an application/ld+json script; payload is not rendered by this static export."
       },
       "pageTruth": {
         "file": "page-truth/treatments-3d-dentistry-and-technology.txt",
@@ -1922,7 +2000,9 @@
           "Service",
           "BreadcrumbList"
         ],
-        "evidence": "Inferred from layout.tsx global JSON-LD plus route page JSON-LD patterns; payloads are not rendered by this static export."
+        "sourceFile": "apps/web/app/treatments/[slug]/page.tsx",
+        "hasRouteJsonLdScript": true,
+        "evidence": "Route source contains an application/ld+json script; payload is not rendered by this static export."
       },
       "pageTruth": {
         "file": "page-truth/treatments-3d-digital-dentistry.txt",
@@ -1976,7 +2056,9 @@
           "Service",
           "BreadcrumbList"
         ],
-        "evidence": "Inferred from layout.tsx global JSON-LD plus route page JSON-LD patterns; payloads are not rendered by this static export."
+        "sourceFile": "apps/web/app/treatments/[slug]/page.tsx",
+        "hasRouteJsonLdScript": true,
+        "evidence": "Route source contains an application/ld+json script; payload is not rendered by this static export."
       },
       "pageTruth": {
         "file": "page-truth/treatments-3d-implant-restorations.txt",
@@ -2030,7 +2112,9 @@
           "Service",
           "BreadcrumbList"
         ],
-        "evidence": "Inferred from layout.tsx global JSON-LD plus route page JSON-LD patterns; payloads are not rendered by this static export."
+        "sourceFile": "apps/web/app/treatments/[slug]/page.tsx",
+        "hasRouteJsonLdScript": true,
+        "evidence": "Route source contains an application/ld+json script; payload is not rendered by this static export."
       },
       "pageTruth": {
         "file": "page-truth/treatments-3d-printed-dentures.txt",
@@ -2084,7 +2168,9 @@
           "Service",
           "BreadcrumbList"
         ],
-        "evidence": "Inferred from layout.tsx global JSON-LD plus route page JSON-LD patterns; payloads are not rendered by this static export."
+        "sourceFile": "apps/web/app/treatments/[slug]/page.tsx",
+        "hasRouteJsonLdScript": true,
+        "evidence": "Route source contains an application/ld+json script; payload is not rendered by this static export."
       },
       "pageTruth": {
         "file": "page-truth/treatments-3d-printed-veneers.txt",
@@ -2138,7 +2224,9 @@
           "Service",
           "BreadcrumbList"
         ],
-        "evidence": "Inferred from layout.tsx global JSON-LD plus route page JSON-LD patterns; payloads are not rendered by this static export."
+        "sourceFile": "apps/web/app/treatments/[slug]/page.tsx",
+        "hasRouteJsonLdScript": true,
+        "evidence": "Route source contains an application/ld+json script; payload is not rendered by this static export."
       },
       "pageTruth": {
         "file": "page-truth/treatments-3d-printing-lab.txt",
@@ -2192,7 +2280,9 @@
           "Service",
           "BreadcrumbList"
         ],
-        "evidence": "Inferred from layout.tsx global JSON-LD plus route page JSON-LD patterns; payloads are not rendered by this static export."
+        "sourceFile": "apps/web/app/treatments/[slug]/page.tsx",
+        "hasRouteJsonLdScript": true,
+        "evidence": "Route source contains an application/ld+json script; payload is not rendered by this static export."
       },
       "pageTruth": {
         "file": "page-truth/treatments-acrylic-dentures.txt",
@@ -2245,7 +2335,9 @@
           "Service",
           "BreadcrumbList"
         ],
-        "evidence": "Inferred from layout.tsx global JSON-LD plus route page JSON-LD patterns; payloads are not rendered by this static export."
+        "sourceFile": "apps/web/app/treatments/[slug]/page.tsx",
+        "hasRouteJsonLdScript": true,
+        "evidence": "Route source contains an application/ld+json script; payload is not rendered by this static export."
       },
       "pageTruth": {
         "file": "page-truth/treatments-anti-wrinkle-treatments.txt",
@@ -2298,7 +2390,9 @@
           "Service",
           "BreadcrumbList"
         ],
-        "evidence": "Inferred from layout.tsx global JSON-LD plus route page JSON-LD patterns; payloads are not rendered by this static export."
+        "sourceFile": "apps/web/app/treatments/[slug]/page.tsx",
+        "hasRouteJsonLdScript": true,
+        "evidence": "Route source contains an application/ld+json script; payload is not rendered by this static export."
       },
       "pageTruth": {
         "file": "page-truth/treatments-broken-chipped-cracked-teeth.txt",
@@ -2351,7 +2445,9 @@
           "Service",
           "BreadcrumbList"
         ],
-        "evidence": "Inferred from layout.tsx global JSON-LD plus route page JSON-LD patterns; payloads are not rendered by this static export."
+        "sourceFile": "apps/web/app/treatments/[slug]/page.tsx",
+        "hasRouteJsonLdScript": true,
+        "evidence": "Route source contains an application/ld+json script; payload is not rendered by this static export."
       },
       "pageTruth": {
         "file": "page-truth/treatments-bruxism-and-jaw-clenching.txt",
@@ -2405,7 +2501,9 @@
           "Service",
           "BreadcrumbList"
         ],
-        "evidence": "Inferred from layout.tsx global JSON-LD plus route page JSON-LD patterns; payloads are not rendered by this static export."
+        "sourceFile": "apps/web/app/treatments/[slug]/page.tsx",
+        "hasRouteJsonLdScript": true,
+        "evidence": "Route source contains an application/ld+json script; payload is not rendered by this static export."
       },
       "pageTruth": {
         "file": "page-truth/treatments-cbct-3d-scanning.txt",
@@ -2459,7 +2557,9 @@
           "Service",
           "BreadcrumbList"
         ],
-        "evidence": "Inferred from layout.tsx global JSON-LD plus route page JSON-LD patterns; payloads are not rendered by this static export."
+        "sourceFile": "apps/web/app/treatments/[slug]/page.tsx",
+        "hasRouteJsonLdScript": true,
+        "evidence": "Route source contains an application/ld+json script; payload is not rendered by this static export."
       },
       "pageTruth": {
         "file": "page-truth/treatments-childrens-dentistry.txt",
@@ -2513,7 +2613,9 @@
           "Service",
           "BreadcrumbList"
         ],
-        "evidence": "Inferred from layout.tsx global JSON-LD plus route page JSON-LD patterns; payloads are not rendered by this static export."
+        "sourceFile": "apps/web/app/treatments/[slug]/page.tsx",
+        "hasRouteJsonLdScript": true,
+        "evidence": "Route source contains an application/ld+json script; payload is not rendered by this static export."
       },
       "pageTruth": {
         "file": "page-truth/treatments-chrome-dentures.txt",
@@ -2566,7 +2668,9 @@
           "Service",
           "BreadcrumbList"
         ],
-        "evidence": "Inferred from layout.tsx global JSON-LD plus route page JSON-LD patterns; payloads are not rendered by this static export."
+        "sourceFile": "apps/web/app/treatments/[slug]/page.tsx",
+        "hasRouteJsonLdScript": true,
+        "evidence": "Route source contains an application/ld+json script; payload is not rendered by this static export."
       },
       "pageTruth": {
         "file": "page-truth/treatments-clear-aligners.txt",
@@ -2620,7 +2724,9 @@
           "Service",
           "BreadcrumbList"
         ],
-        "evidence": "Inferred from layout.tsx global JSON-LD plus route page JSON-LD patterns; payloads are not rendered by this static export."
+        "sourceFile": "apps/web/app/treatments/[slug]/page.tsx",
+        "hasRouteJsonLdScript": true,
+        "evidence": "Route source contains an application/ld+json script; payload is not rendered by this static export."
       },
       "pageTruth": {
         "file": "page-truth/treatments-clear-aligners-spark.txt",
@@ -2674,7 +2780,9 @@
           "Service",
           "BreadcrumbList"
         ],
-        "evidence": "Inferred from layout.tsx global JSON-LD plus route page JSON-LD patterns; payloads are not rendered by this static export."
+        "sourceFile": "apps/web/app/treatments/[slug]/page.tsx",
+        "hasRouteJsonLdScript": true,
+        "evidence": "Route source contains an application/ld+json script; payload is not rendered by this static export."
       },
       "pageTruth": {
         "file": "page-truth/treatments-composite-bonding.txt",
@@ -2727,7 +2835,9 @@
           "Service",
           "BreadcrumbList"
         ],
-        "evidence": "Inferred from layout.tsx global JSON-LD plus route page JSON-LD patterns; payloads are not rendered by this static export."
+        "sourceFile": "apps/web/app/treatments/[slug]/page.tsx",
+        "hasRouteJsonLdScript": true,
+        "evidence": "Route source contains an application/ld+json script; payload is not rendered by this static export."
       },
       "pageTruth": {
         "file": "page-truth/treatments-cosmetic-dentistry.txt",
@@ -2773,7 +2883,9 @@
           "Service",
           "BreadcrumbList"
         ],
-        "evidence": "Inferred from layout.tsx global JSON-LD plus route page JSON-LD patterns; payloads are not rendered by this static export."
+        "sourceFile": "apps/web/app/treatments/[slug]/page.tsx",
+        "hasRouteJsonLdScript": true,
+        "evidence": "Route source contains an application/ld+json script; payload is not rendered by this static export."
       },
       "pageTruth": {
         "file": "page-truth/treatments-dental-abscess-infection.txt",
@@ -2827,7 +2939,9 @@
           "Service",
           "BreadcrumbList"
         ],
-        "evidence": "Inferred from layout.tsx global JSON-LD plus route page JSON-LD patterns; payloads are not rendered by this static export."
+        "sourceFile": "apps/web/app/treatments/[slug]/page.tsx",
+        "hasRouteJsonLdScript": true,
+        "evidence": "Route source contains an application/ld+json script; payload is not rendered by this static export."
       },
       "pageTruth": {
         "file": "page-truth/treatments-dental-bridges.txt",
@@ -2881,7 +2995,9 @@
           "Service",
           "BreadcrumbList"
         ],
-        "evidence": "Inferred from layout.tsx global JSON-LD plus route page JSON-LD patterns; payloads are not rendered by this static export."
+        "sourceFile": "apps/web/app/treatments/[slug]/page.tsx",
+        "hasRouteJsonLdScript": true,
+        "evidence": "Route source contains an application/ld+json script; payload is not rendered by this static export."
       },
       "pageTruth": {
         "file": "page-truth/treatments-dental-checkups-oral-cancer-screening.txt",
@@ -2934,7 +3050,9 @@
           "Service",
           "BreadcrumbList"
         ],
-        "evidence": "Inferred from layout.tsx global JSON-LD plus route page JSON-LD patterns; payloads are not rendered by this static export."
+        "sourceFile": "apps/web/app/treatments/[slug]/page.tsx",
+        "hasRouteJsonLdScript": true,
+        "evidence": "Route source contains an application/ld+json script; payload is not rendered by this static export."
       },
       "pageTruth": {
         "file": "page-truth/treatments-dental-crowns.txt",
@@ -2988,7 +3106,9 @@
           "Service",
           "BreadcrumbList"
         ],
-        "evidence": "Inferred from layout.tsx global JSON-LD plus route page JSON-LD patterns; payloads are not rendered by this static export."
+        "sourceFile": "apps/web/app/treatments/[slug]/page.tsx",
+        "hasRouteJsonLdScript": true,
+        "evidence": "Route source contains an application/ld+json script; payload is not rendered by this static export."
       },
       "pageTruth": {
         "file": "page-truth/treatments-dental-fillings.txt",
@@ -3041,7 +3161,9 @@
           "Service",
           "BreadcrumbList"
         ],
-        "evidence": "Inferred from layout.tsx global JSON-LD plus route page JSON-LD patterns; payloads are not rendered by this static export."
+        "sourceFile": "apps/web/app/treatments/[slug]/page.tsx",
+        "hasRouteJsonLdScript": true,
+        "evidence": "Route source contains an application/ld+json script; payload is not rendered by this static export."
       },
       "pageTruth": {
         "file": "page-truth/treatments-dental-retainers.txt",
@@ -3095,7 +3217,9 @@
           "Service",
           "BreadcrumbList"
         ],
-        "evidence": "Inferred from layout.tsx global JSON-LD plus route page JSON-LD patterns; payloads are not rendered by this static export."
+        "sourceFile": "apps/web/app/treatments/[slug]/page.tsx",
+        "hasRouteJsonLdScript": true,
+        "evidence": "Route source contains an application/ld+json script; payload is not rendered by this static export."
       },
       "pageTruth": {
         "file": "page-truth/treatments-dental-trauma-accidents.txt",
@@ -3148,7 +3272,9 @@
           "Service",
           "BreadcrumbList"
         ],
-        "evidence": "Inferred from layout.tsx global JSON-LD plus route page JSON-LD patterns; payloads are not rendered by this static export."
+        "sourceFile": "apps/web/app/treatments/[slug]/page.tsx",
+        "hasRouteJsonLdScript": true,
+        "evidence": "Route source contains an application/ld+json script; payload is not rendered by this static export."
       },
       "pageTruth": {
         "file": "page-truth/treatments-dentures.txt",
@@ -3201,7 +3327,9 @@
           "Service",
           "BreadcrumbList"
         ],
-        "evidence": "Inferred from layout.tsx global JSON-LD plus route page JSON-LD patterns; payloads are not rendered by this static export."
+        "sourceFile": "apps/web/app/treatments/[slug]/page.tsx",
+        "hasRouteJsonLdScript": true,
+        "evidence": "Route source contains an application/ld+json script; payload is not rendered by this static export."
       },
       "pageTruth": {
         "file": "page-truth/treatments-dermal-fillers.txt",
@@ -3255,7 +3383,9 @@
           "Service",
           "BreadcrumbList"
         ],
-        "evidence": "Inferred from layout.tsx global JSON-LD plus route page JSON-LD patterns; payloads are not rendered by this static export."
+        "sourceFile": "apps/web/app/treatments/[slug]/page.tsx",
+        "hasRouteJsonLdScript": true,
+        "evidence": "Route source contains an application/ld+json script; payload is not rendered by this static export."
       },
       "pageTruth": {
         "file": "page-truth/treatments-digital-smile-design.txt",
@@ -3309,7 +3439,9 @@
           "Service",
           "BreadcrumbList"
         ],
-        "evidence": "Inferred from layout.tsx global JSON-LD plus route page JSON-LD patterns; payloads are not rendered by this static export."
+        "sourceFile": "apps/web/app/treatments/[slug]/page.tsx",
+        "hasRouteJsonLdScript": true,
+        "evidence": "Route source contains an application/ld+json script; payload is not rendered by this static export."
       },
       "pageTruth": {
         "file": "page-truth/treatments-emergency-dental-appointments.txt",
@@ -3362,7 +3494,9 @@
           "Service",
           "BreadcrumbList"
         ],
-        "evidence": "Inferred from layout.tsx global JSON-LD plus route page JSON-LD patterns; payloads are not rendered by this static export."
+        "sourceFile": "apps/web/app/treatments/[slug]/page.tsx",
+        "hasRouteJsonLdScript": true,
+        "evidence": "Route source contains an application/ld+json script; payload is not rendered by this static export."
       },
       "pageTruth": {
         "file": "page-truth/treatments-emergency-dentistry.txt",
@@ -3416,7 +3550,9 @@
           "Service",
           "BreadcrumbList"
         ],
-        "evidence": "Inferred from layout.tsx global JSON-LD plus route page JSON-LD patterns; payloads are not rendered by this static export."
+        "sourceFile": "apps/web/app/treatments/[slug]/page.tsx",
+        "hasRouteJsonLdScript": true,
+        "evidence": "Route source contains an application/ld+json script; payload is not rendered by this static export."
       },
       "pageTruth": {
         "file": "page-truth/treatments-endodontics-root-canal.txt",
@@ -3469,7 +3605,9 @@
           "Service",
           "BreadcrumbList"
         ],
-        "evidence": "Inferred from layout.tsx global JSON-LD plus route page JSON-LD patterns; payloads are not rendered by this static export."
+        "sourceFile": "apps/web/app/treatments/[slug]/page.tsx",
+        "hasRouteJsonLdScript": true,
+        "evidence": "Route source contains an application/ld+json script; payload is not rendered by this static export."
       },
       "pageTruth": {
         "file": "page-truth/treatments-extractions-and-oral-surgery.txt",
@@ -3522,7 +3660,9 @@
           "Service",
           "BreadcrumbList"
         ],
-        "evidence": "Inferred from layout.tsx global JSON-LD plus route page JSON-LD patterns; payloads are not rendered by this static export."
+        "sourceFile": "apps/web/app/treatments/[slug]/page.tsx",
+        "hasRouteJsonLdScript": true,
+        "evidence": "Route source contains an application/ld+json script; payload is not rendered by this static export."
       },
       "pageTruth": {
         "file": "page-truth/treatments-facial-aesthetics.txt",
@@ -3576,7 +3716,9 @@
           "Service",
           "BreadcrumbList"
         ],
-        "evidence": "Inferred from layout.tsx global JSON-LD plus route page JSON-LD patterns; payloads are not rendered by this static export."
+        "sourceFile": "apps/web/app/treatments/[slug]/page.tsx",
+        "hasRouteJsonLdScript": true,
+        "evidence": "Route source contains an application/ld+json script; payload is not rendered by this static export."
       },
       "pageTruth": {
         "file": "page-truth/treatments-facial-pain-and-headache.txt",
@@ -3630,7 +3772,9 @@
           "Service",
           "BreadcrumbList"
         ],
-        "evidence": "Inferred from layout.tsx global JSON-LD plus route page JSON-LD patterns; payloads are not rendered by this static export."
+        "sourceFile": "apps/web/app/treatments/[slug]/page.tsx",
+        "hasRouteJsonLdScript": true,
+        "evidence": "Route source contains an application/ld+json script; payload is not rendered by this static export."
       },
       "pageTruth": {
         "file": "page-truth/treatments-facial-therapeutics.txt",
@@ -3684,7 +3828,9 @@
           "Service",
           "BreadcrumbList"
         ],
-        "evidence": "Inferred from layout.tsx global JSON-LD plus route page JSON-LD patterns; payloads are not rendered by this static export."
+        "sourceFile": "apps/web/app/treatments/[slug]/page.tsx",
+        "hasRouteJsonLdScript": true,
+        "evidence": "Route source contains an application/ld+json script; payload is not rendered by this static export."
       },
       "pageTruth": {
         "file": "page-truth/treatments-failed-implant-replacement.txt",
@@ -3738,7 +3884,9 @@
           "Service",
           "BreadcrumbList"
         ],
-        "evidence": "Inferred from layout.tsx global JSON-LD plus route page JSON-LD patterns; payloads are not rendered by this static export."
+        "sourceFile": "apps/web/app/treatments/[slug]/page.tsx",
+        "hasRouteJsonLdScript": true,
+        "evidence": "Route source contains an application/ld+json script; payload is not rendered by this static export."
       },
       "pageTruth": {
         "file": "page-truth/treatments-fixed-braces.txt",
@@ -3791,7 +3939,9 @@
           "Service",
           "BreadcrumbList"
         ],
-        "evidence": "Inferred from layout.tsx global JSON-LD plus route page JSON-LD patterns; payloads are not rendered by this static export."
+        "sourceFile": "apps/web/app/treatments/[slug]/page.tsx",
+        "hasRouteJsonLdScript": true,
+        "evidence": "Route source contains an application/ld+json script; payload is not rendered by this static export."
       },
       "pageTruth": {
         "file": "page-truth/treatments-full-smile-makeover.txt",
@@ -3844,7 +3994,9 @@
           "Service",
           "BreadcrumbList"
         ],
-        "evidence": "Inferred from layout.tsx global JSON-LD plus route page JSON-LD patterns; payloads are not rendered by this static export."
+        "sourceFile": "apps/web/app/treatments/[slug]/page.tsx",
+        "hasRouteJsonLdScript": true,
+        "evidence": "Route source contains an application/ld+json script; payload is not rendered by this static export."
       },
       "pageTruth": {
         "file": "page-truth/treatments-home-teeth-whitening.txt",
@@ -3897,7 +4049,9 @@
           "Service",
           "BreadcrumbList"
         ],
-        "evidence": "Inferred from layout.tsx global JSON-LD plus route page JSON-LD patterns; payloads are not rendered by this static export."
+        "sourceFile": "apps/web/app/treatments/[slug]/page.tsx",
+        "hasRouteJsonLdScript": true,
+        "evidence": "Route source contains an application/ld+json script; payload is not rendered by this static export."
       },
       "pageTruth": {
         "file": "page-truth/treatments-implant-aftercare.txt",
@@ -3950,7 +4104,9 @@
           "Service",
           "BreadcrumbList"
         ],
-        "evidence": "Inferred from layout.tsx global JSON-LD plus route page JSON-LD patterns; payloads are not rendered by this static export."
+        "sourceFile": "apps/web/app/treatments/[slug]/page.tsx",
+        "hasRouteJsonLdScript": true,
+        "evidence": "Route source contains an application/ld+json script; payload is not rendered by this static export."
       },
       "pageTruth": {
         "file": "page-truth/treatments-implant-consultation.txt",
@@ -4004,7 +4160,9 @@
           "Service",
           "BreadcrumbList"
         ],
-        "evidence": "Inferred from layout.tsx global JSON-LD plus route page JSON-LD patterns; payloads are not rendered by this static export."
+        "sourceFile": "apps/web/app/treatments/[slug]/page.tsx",
+        "hasRouteJsonLdScript": true,
+        "evidence": "Route source contains an application/ld+json script; payload is not rendered by this static export."
       },
       "pageTruth": {
         "file": "page-truth/treatments-implant-retained-dentures.txt",
@@ -4057,7 +4215,9 @@
           "Service",
           "BreadcrumbList"
         ],
-        "evidence": "Inferred from layout.tsx global JSON-LD plus route page JSON-LD patterns; payloads are not rendered by this static export."
+        "sourceFile": "apps/web/app/treatments/[slug]/page.tsx",
+        "hasRouteJsonLdScript": true,
+        "evidence": "Route source contains an application/ld+json script; payload is not rendered by this static export."
       },
       "pageTruth": {
         "file": "page-truth/treatments-implants.txt",
@@ -4111,7 +4271,9 @@
           "Service",
           "BreadcrumbList"
         ],
-        "evidence": "Inferred from layout.tsx global JSON-LD plus route page JSON-LD patterns; payloads are not rendered by this static export."
+        "sourceFile": "apps/web/app/treatments/[slug]/page.tsx",
+        "hasRouteJsonLdScript": true,
+        "evidence": "Route source contains an application/ld+json script; payload is not rendered by this static export."
       },
       "pageTruth": {
         "file": "page-truth/treatments-implants-bone-grafting.txt",
@@ -4165,7 +4327,9 @@
           "Service",
           "BreadcrumbList"
         ],
-        "evidence": "Inferred from layout.tsx global JSON-LD plus route page JSON-LD patterns; payloads are not rendered by this static export."
+        "sourceFile": "apps/web/app/treatments/[slug]/page.tsx",
+        "hasRouteJsonLdScript": true,
+        "evidence": "Route source contains an application/ld+json script; payload is not rendered by this static export."
       },
       "pageTruth": {
         "file": "page-truth/treatments-implants-full-arch.txt",
@@ -4218,7 +4382,9 @@
           "Service",
           "BreadcrumbList"
         ],
-        "evidence": "Inferred from layout.tsx global JSON-LD plus route page JSON-LD patterns; payloads are not rendered by this static export."
+        "sourceFile": "apps/web/app/treatments/[slug]/page.tsx",
+        "hasRouteJsonLdScript": true,
+        "evidence": "Route source contains an application/ld+json script; payload is not rendered by this static export."
       },
       "pageTruth": {
         "file": "page-truth/treatments-implants-multiple-teeth.txt",
@@ -4272,7 +4438,9 @@
           "Service",
           "BreadcrumbList"
         ],
-        "evidence": "Inferred from layout.tsx global JSON-LD plus route page JSON-LD patterns; payloads are not rendered by this static export."
+        "sourceFile": "apps/web/app/treatments/[slug]/page.tsx",
+        "hasRouteJsonLdScript": true,
+        "evidence": "Route source contains an application/ld+json script; payload is not rendered by this static export."
       },
       "pageTruth": {
         "file": "page-truth/treatments-implants-single-tooth.txt",
@@ -4326,7 +4494,9 @@
           "Service",
           "BreadcrumbList"
         ],
-        "evidence": "Inferred from layout.tsx global JSON-LD plus route page JSON-LD patterns; payloads are not rendered by this static export."
+        "sourceFile": "apps/web/app/treatments/[slug]/page.tsx",
+        "hasRouteJsonLdScript": true,
+        "evidence": "Route source contains an application/ld+json script; payload is not rendered by this static export."
       },
       "pageTruth": {
         "file": "page-truth/treatments-injection-moulded-composite.txt",
@@ -4380,7 +4550,9 @@
           "Service",
           "BreadcrumbList"
         ],
-        "evidence": "Inferred from layout.tsx global JSON-LD plus route page JSON-LD patterns; payloads are not rendered by this static export."
+        "sourceFile": "apps/web/app/treatments/[slug]/page.tsx",
+        "hasRouteJsonLdScript": true,
+        "evidence": "Route source contains an application/ld+json script; payload is not rendered by this static export."
       },
       "pageTruth": {
         "file": "page-truth/treatments-inlays-onlays.txt",
@@ -4433,7 +4605,9 @@
           "Service",
           "BreadcrumbList"
         ],
-        "evidence": "Inferred from layout.tsx global JSON-LD plus route page JSON-LD patterns; payloads are not rendered by this static export."
+        "sourceFile": "apps/web/app/treatments/[slug]/page.tsx",
+        "hasRouteJsonLdScript": true,
+        "evidence": "Route source contains an application/ld+json script; payload is not rendered by this static export."
       },
       "pageTruth": {
         "file": "page-truth/treatments-knocked-out-tooth.txt",
@@ -4487,7 +4661,9 @@
           "Service",
           "BreadcrumbList"
         ],
-        "evidence": "Inferred from layout.tsx global JSON-LD plus route page JSON-LD patterns; payloads are not rendered by this static export."
+        "sourceFile": "apps/web/app/treatments/[slug]/page.tsx",
+        "hasRouteJsonLdScript": true,
+        "evidence": "Route source contains an application/ld+json script; payload is not rendered by this static export."
       },
       "pageTruth": {
         "file": "page-truth/treatments-lost-crowns-veneers-fillings.txt",
@@ -4541,7 +4717,9 @@
           "Service",
           "BreadcrumbList"
         ],
-        "evidence": "Inferred from layout.tsx global JSON-LD plus route page JSON-LD patterns; payloads are not rendered by this static export."
+        "sourceFile": "apps/web/app/treatments/[slug]/page.tsx",
+        "hasRouteJsonLdScript": true,
+        "evidence": "Route source contains an application/ld+json script; payload is not rendered by this static export."
       },
       "pageTruth": {
         "file": "page-truth/treatments-mouthguards-and-retainers.txt",
@@ -4595,7 +4773,9 @@
           "Service",
           "BreadcrumbList"
         ],
-        "evidence": "Inferred from layout.tsx global JSON-LD plus route page JSON-LD patterns; payloads are not rendered by this static export."
+        "sourceFile": "apps/web/app/treatments/[slug]/page.tsx",
+        "hasRouteJsonLdScript": true,
+        "evidence": "Route source contains an application/ld+json script; payload is not rendered by this static export."
       },
       "pageTruth": {
         "file": "page-truth/treatments-nervous-patients.txt",
@@ -4648,7 +4828,9 @@
           "Service",
           "BreadcrumbList"
         ],
-        "evidence": "Inferred from layout.tsx global JSON-LD plus route page JSON-LD patterns; payloads are not rendered by this static export."
+        "sourceFile": "apps/web/app/treatments/[slug]/page.tsx",
+        "hasRouteJsonLdScript": true,
+        "evidence": "Route source contains an application/ld+json script; payload is not rendered by this static export."
       },
       "pageTruth": {
         "file": "page-truth/treatments-night-guards-occlusal-splints.txt",
@@ -4701,7 +4883,9 @@
           "Service",
           "BreadcrumbList"
         ],
-        "evidence": "Inferred from layout.tsx global JSON-LD plus route page JSON-LD patterns; payloads are not rendered by this static export."
+        "sourceFile": "apps/web/app/treatments/[slug]/page.tsx",
+        "hasRouteJsonLdScript": true,
+        "evidence": "Route source contains an application/ld+json script; payload is not rendered by this static export."
       },
       "pageTruth": {
         "file": "page-truth/treatments-orthodontics.txt",
@@ -4755,7 +4939,9 @@
           "Service",
           "BreadcrumbList"
         ],
-        "evidence": "Inferred from layout.tsx global JSON-LD plus route page JSON-LD patterns; payloads are not rendered by this static export."
+        "sourceFile": "apps/web/app/treatments/[slug]/page.tsx",
+        "hasRouteJsonLdScript": true,
+        "evidence": "Route source contains an application/ld+json script; payload is not rendered by this static export."
       },
       "pageTruth": {
         "file": "page-truth/treatments-painless-numbing-the-wand.txt",
@@ -4809,7 +4995,9 @@
           "Service",
           "BreadcrumbList"
         ],
-        "evidence": "Inferred from layout.tsx global JSON-LD plus route page JSON-LD patterns; payloads are not rendered by this static export."
+        "sourceFile": "apps/web/app/treatments/[slug]/page.tsx",
+        "hasRouteJsonLdScript": true,
+        "evidence": "Route source contains an application/ld+json script; payload is not rendered by this static export."
       },
       "pageTruth": {
         "file": "page-truth/treatments-peek-partial-dentures.txt",
@@ -4863,7 +5051,9 @@
           "Service",
           "BreadcrumbList"
         ],
-        "evidence": "Inferred from layout.tsx global JSON-LD plus route page JSON-LD patterns; payloads are not rendered by this static export."
+        "sourceFile": "apps/web/app/treatments/[slug]/page.tsx",
+        "hasRouteJsonLdScript": true,
+        "evidence": "Route source contains an application/ld+json script; payload is not rendered by this static export."
       },
       "pageTruth": {
         "file": "page-truth/treatments-periodontal-gum-care.txt",
@@ -4916,7 +5106,9 @@
           "Service",
           "BreadcrumbList"
         ],
-        "evidence": "Inferred from layout.tsx global JSON-LD plus route page JSON-LD patterns; payloads are not rendered by this static export."
+        "sourceFile": "apps/web/app/treatments/[slug]/page.tsx",
+        "hasRouteJsonLdScript": true,
+        "evidence": "Route source contains an application/ld+json script; payload is not rendered by this static export."
       },
       "pageTruth": {
         "file": "page-truth/treatments-polynucleotides.txt",
@@ -4969,7 +5161,9 @@
           "Service",
           "BreadcrumbList"
         ],
-        "evidence": "Inferred from layout.tsx global JSON-LD plus route page JSON-LD patterns; payloads are not rendered by this static export."
+        "sourceFile": "apps/web/app/treatments/[slug]/page.tsx",
+        "hasRouteJsonLdScript": true,
+        "evidence": "Route source contains an application/ld+json script; payload is not rendered by this static export."
       },
       "pageTruth": {
         "file": "page-truth/treatments-preventative-and-general-dentistry.txt",
@@ -5023,7 +5217,9 @@
           "Service",
           "BreadcrumbList"
         ],
-        "evidence": "Inferred from layout.tsx global JSON-LD plus route page JSON-LD patterns; payloads are not rendered by this static export."
+        "sourceFile": "apps/web/app/treatments/[slug]/page.tsx",
+        "hasRouteJsonLdScript": true,
+        "evidence": "Route source contains an application/ld+json script; payload is not rendered by this static export."
       },
       "pageTruth": {
         "file": "page-truth/treatments-preventive-dentistry.txt",
@@ -5069,7 +5265,9 @@
           "Service",
           "BreadcrumbList"
         ],
-        "evidence": "Inferred from layout.tsx global JSON-LD plus route page JSON-LD patterns; payloads are not rendered by this static export."
+        "sourceFile": "apps/web/app/treatments/[slug]/page.tsx",
+        "hasRouteJsonLdScript": true,
+        "evidence": "Route source contains an application/ld+json script; payload is not rendered by this static export."
       },
       "pageTruth": {
         "file": "page-truth/treatments-sedation-dentistry.txt",
@@ -5122,7 +5320,9 @@
           "Service",
           "BreadcrumbList"
         ],
-        "evidence": "Inferred from layout.tsx global JSON-LD plus route page JSON-LD patterns; payloads are not rendered by this static export."
+        "sourceFile": "apps/web/app/treatments/[slug]/page.tsx",
+        "hasRouteJsonLdScript": true,
+        "evidence": "Route source contains an application/ld+json script; payload is not rendered by this static export."
       },
       "pageTruth": {
         "file": "page-truth/treatments-sedation-for-implants.txt",
@@ -5175,7 +5375,9 @@
           "Service",
           "BreadcrumbList"
         ],
-        "evidence": "Inferred from layout.tsx global JSON-LD plus route page JSON-LD patterns; payloads are not rendered by this static export."
+        "sourceFile": "apps/web/app/treatments/[slug]/page.tsx",
+        "hasRouteJsonLdScript": true,
+        "evidence": "Route source contains an application/ld+json script; payload is not rendered by this static export."
       },
       "pageTruth": {
         "file": "page-truth/treatments-senior-mature-smile-care.txt",
@@ -5228,7 +5430,9 @@
           "Service",
           "BreadcrumbList"
         ],
-        "evidence": "Inferred from layout.tsx global JSON-LD plus route page JSON-LD patterns; payloads are not rendered by this static export."
+        "sourceFile": "apps/web/app/treatments/[slug]/page.tsx",
+        "hasRouteJsonLdScript": true,
+        "evidence": "Route source contains an application/ld+json script; payload is not rendered by this static export."
       },
       "pageTruth": {
         "file": "page-truth/treatments-severe-toothache-dental-pain.txt",
@@ -5281,7 +5485,9 @@
           "Service",
           "BreadcrumbList"
         ],
-        "evidence": "Inferred from layout.tsx global JSON-LD plus route page JSON-LD patterns; payloads are not rendered by this static export."
+        "sourceFile": "apps/web/app/treatments/[slug]/page.tsx",
+        "hasRouteJsonLdScript": true,
+        "evidence": "Route source contains an application/ld+json script; payload is not rendered by this static export."
       },
       "pageTruth": {
         "file": "page-truth/treatments-sinus-lift.txt",
@@ -5335,7 +5541,9 @@
           "Service",
           "BreadcrumbList"
         ],
-        "evidence": "Inferred from layout.tsx global JSON-LD plus route page JSON-LD patterns; payloads are not rendered by this static export."
+        "sourceFile": "apps/web/app/treatments/[slug]/page.tsx",
+        "hasRouteJsonLdScript": true,
+        "evidence": "Route source contains an application/ld+json script; payload is not rendered by this static export."
       },
       "pageTruth": {
         "file": "page-truth/treatments-skin-boosters.txt",
@@ -5388,7 +5596,9 @@
           "Service",
           "BreadcrumbList"
         ],
-        "evidence": "Inferred from layout.tsx global JSON-LD plus route page JSON-LD patterns; payloads are not rendered by this static export."
+        "sourceFile": "apps/web/app/treatments/[slug]/page.tsx",
+        "hasRouteJsonLdScript": true,
+        "evidence": "Route source contains an application/ld+json script; payload is not rendered by this static export."
       },
       "pageTruth": {
         "file": "page-truth/treatments-sports-mouthguards.txt",
@@ -5441,7 +5651,9 @@
           "Service",
           "BreadcrumbList"
         ],
-        "evidence": "Inferred from layout.tsx global JSON-LD plus route page JSON-LD patterns; payloads are not rendered by this static export."
+        "sourceFile": "apps/web/app/treatments/[slug]/page.tsx",
+        "hasRouteJsonLdScript": true,
+        "evidence": "Route source contains an application/ld+json script; payload is not rendered by this static export."
       },
       "pageTruth": {
         "file": "page-truth/treatments-surgically-guided-implants.txt",
@@ -5487,7 +5699,9 @@
           "Service",
           "BreadcrumbList"
         ],
-        "evidence": "Inferred from layout.tsx global JSON-LD plus route page JSON-LD patterns; payloads are not rendered by this static export."
+        "sourceFile": "apps/web/app/treatments/[slug]/page.tsx",
+        "hasRouteJsonLdScript": true,
+        "evidence": "Route source contains an application/ld+json script; payload is not rendered by this static export."
       },
       "pageTruth": {
         "file": "page-truth/treatments-teeth-in-a-day.txt",
@@ -5541,7 +5755,9 @@
           "Service",
           "BreadcrumbList"
         ],
-        "evidence": "Inferred from layout.tsx global JSON-LD plus route page JSON-LD patterns; payloads are not rendered by this static export."
+        "sourceFile": "apps/web/app/treatments/[slug]/page.tsx",
+        "hasRouteJsonLdScript": true,
+        "evidence": "Route source contains an application/ld+json script; payload is not rendered by this static export."
       },
       "pageTruth": {
         "file": "page-truth/treatments-teeth-whitening.txt",
@@ -5595,7 +5811,9 @@
           "Service",
           "BreadcrumbList"
         ],
-        "evidence": "Inferred from layout.tsx global JSON-LD plus route page JSON-LD patterns; payloads are not rendered by this static export."
+        "sourceFile": "apps/web/app/treatments/[slug]/page.tsx",
+        "hasRouteJsonLdScript": true,
+        "evidence": "Route source contains an application/ld+json script; payload is not rendered by this static export."
       },
       "pageTruth": {
         "file": "page-truth/treatments-teeth-whitening-faqs.txt",
@@ -5648,7 +5866,9 @@
           "Service",
           "BreadcrumbList"
         ],
-        "evidence": "Inferred from layout.tsx global JSON-LD plus route page JSON-LD patterns; payloads are not rendered by this static export."
+        "sourceFile": "apps/web/app/treatments/[slug]/page.tsx",
+        "hasRouteJsonLdScript": true,
+        "evidence": "Route source contains an application/ld+json script; payload is not rendered by this static export."
       },
       "pageTruth": {
         "file": "page-truth/treatments-therapeutic-facial-injectables.txt",
@@ -5702,7 +5922,9 @@
           "Service",
           "BreadcrumbList"
         ],
-        "evidence": "Inferred from layout.tsx global JSON-LD plus route page JSON-LD patterns; payloads are not rendered by this static export."
+        "sourceFile": "apps/web/app/treatments/[slug]/page.tsx",
+        "hasRouteJsonLdScript": true,
+        "evidence": "Route source contains an application/ld+json script; payload is not rendered by this static export."
       },
       "pageTruth": {
         "file": "page-truth/treatments-tmj-disorder-treatment.txt",
@@ -5755,7 +5977,9 @@
           "Service",
           "BreadcrumbList"
         ],
-        "evidence": "Inferred from layout.tsx global JSON-LD plus route page JSON-LD patterns; payloads are not rendered by this static export."
+        "sourceFile": "apps/web/app/treatments/[slug]/page.tsx",
+        "hasRouteJsonLdScript": true,
+        "evidence": "Route source contains an application/ld+json script; payload is not rendered by this static export."
       },
       "pageTruth": {
         "file": "page-truth/treatments-tmj-jaw-comfort.txt",
@@ -5808,7 +6032,9 @@
           "Service",
           "BreadcrumbList"
         ],
-        "evidence": "Inferred from layout.tsx global JSON-LD plus route page JSON-LD patterns; payloads are not rendered by this static export."
+        "sourceFile": "apps/web/app/treatments/[slug]/page.tsx",
+        "hasRouteJsonLdScript": true,
+        "evidence": "Route source contains an application/ld+json script; payload is not rendered by this static export."
       },
       "pageTruth": {
         "file": "page-truth/treatments-tooth-wear-broken-teeth.txt",
@@ -5862,7 +6088,9 @@
           "Service",
           "BreadcrumbList"
         ],
-        "evidence": "Inferred from layout.tsx global JSON-LD plus route page JSON-LD patterns; payloads are not rendered by this static export."
+        "sourceFile": "apps/web/app/treatments/[slug]/page.tsx",
+        "hasRouteJsonLdScript": true,
+        "evidence": "Route source contains an application/ld+json script; payload is not rendered by this static export."
       },
       "pageTruth": {
         "file": "page-truth/treatments-veneers.txt",
@@ -5915,7 +6143,9 @@
           "Service",
           "BreadcrumbList"
         ],
-        "evidence": "Inferred from layout.tsx global JSON-LD plus route page JSON-LD patterns; payloads are not rendered by this static export."
+        "sourceFile": "apps/web/app/treatments/[slug]/page.tsx",
+        "hasRouteJsonLdScript": true,
+        "evidence": "Route source contains an application/ld+json script; payload is not rendered by this static export."
       },
       "pageTruth": {
         "file": "page-truth/treatments-whitening-sensitive-teeth.txt",
@@ -5968,7 +6198,9 @@
           "Service",
           "BreadcrumbList"
         ],
-        "evidence": "Inferred from layout.tsx global JSON-LD plus route page JSON-LD patterns; payloads are not rendered by this static export."
+        "sourceFile": "apps/web/app/treatments/[slug]/page.tsx",
+        "hasRouteJsonLdScript": true,
+        "evidence": "Route source contains an application/ld+json script; payload is not rendered by this static export."
       },
       "pageTruth": {
         "file": "page-truth/treatments-whitening-top-ups.txt",
@@ -6019,7 +6251,9 @@
           "WebSite",
           "WebPage"
         ],
-        "evidence": "Inferred from layout.tsx global JSON-LD plus route page JSON-LD patterns; payloads are not rendered by this static export."
+        "sourceFile": "apps/web/app/(site)/[page]/page.tsx",
+        "hasRouteJsonLdScript": true,
+        "evidence": "Route source contains an application/ld+json script; payload is not rendered by this static export."
       },
       "pageTruth": {
         "file": "page-truth/video-consultation.txt",
@@ -6058,15 +6292,25 @@
       "/patient-portal"
     ],
     "inferredPublicRouteCount": 101,
-    "weakness": "No lastModified/changeFrequency/priority fields discovered in sitemap.ts static export."
+    "hasLastModified": true,
+    "hasChangeFrequency": true,
+    "hasPriority": true,
+    "enriched": true,
+    "weakness": null
   },
   "robotsStatus": {
     "exists": true,
     "sourceFile": "apps/web/app/robots.ts",
     "productionAllowsRoot": true,
+    "productionExplicitDisallows": [
+      "/champagne/",
+      "/api/",
+      "/patient-portal"
+    ],
     "nonProductionDisallowsAll": true,
     "sitemapAdvertised": "https://www.smhdental.co.uk/sitemap.xml",
-    "weakness": "Production robots allows root and does not explicitly disallow /champagne/, /api/, or /patient-portal; launch safety relies on sitemap exclusion and route classification."
+    "hardened": true,
+    "weakness": null
   },
   "treatmentManifestInventory": [
     {
@@ -14136,31 +14380,6 @@
       "severity": "info",
       "message": "This export is an evidence layer only and does not certify clean launch readiness.",
       "evidence": null
-    },
-    {
-      "code": "SITEMAP_WEAK_METADATA",
-      "severity": "warning",
-      "message": "No lastModified/changeFrequency/priority fields discovered in sitemap.ts static export.",
-      "evidence": "apps/web/app/sitemap.ts"
-    },
-    {
-      "code": "ROBOTS_WEAK_EXCLUSIONS",
-      "severity": "warning",
-      "message": "Production robots allows root and does not explicitly disallow /champagne/, /api/, or /patient-portal; launch safety relies on sitemap exclusion and route classification.",
-      "evidence": "apps/web/app/robots.ts"
-    },
-    {
-      "code": "LEGAL_METADATA_WEAK",
-      "severity": "warning",
-      "message": "Legal routes are present but route-specific metadata/canonical/schema was not discovered on the dynamic legal route.",
-      "evidence": [
-        "/legal/[slug]",
-        "/legal/accessibility",
-        "/legal/complaints",
-        "/legal/cookies",
-        "/legal/privacy",
-        "/legal/terms"
-      ]
     },
     {
       "code": "LAUNCH_EXCLUDED_ROUTES_PRESENT",

--- a/scripts/export-website-truth.mjs
+++ b/scripts/export-website-truth.mjs
@@ -25,6 +25,14 @@ const readJsonOptional = async (relativePath, fallback) => {
   }
 };
 
+const readTextOptional = async (relativePath, fallback = "") => {
+  try {
+    return await readText(relativePath);
+  } catch {
+    return fallback;
+  }
+};
+
 const writeJson = async (relativePath, value) => {
   const fullPath = path.join(rootDir, relativePath);
   await fs.mkdir(path.dirname(fullPath), { recursive: true });
@@ -117,21 +125,29 @@ const extractRouteMetadata = (route, manifestPage, matchedAppRoute, rootMetadata
   };
 };
 
-const inferSchema = (route, classification) => {
+const inferSchema = (route, classification, matchedAppRoute) => {
   const schemas = ["Dentist", "LocalBusiness", "WebSite"];
+  const sourceFile = matchedAppRoute?.sourceFile ?? null;
+  const sourceMetadata = sourceFile ? metadataSourceByFile.get(sourceFile) : null;
   if (classification.routeFamily === "treatment_detail") {
     schemas.push("WebPage", "Service", "BreadcrumbList");
   } else if (route === "/contact") {
     schemas.push("ContactPage");
   } else if (classification.routeFamily === "team_detail") {
     schemas.push("ProfilePage", "Person");
+  } else if (classification.routeFamily === "legal") {
+    schemas.push("WebPage");
   } else if (classification.publicness === "public") {
     schemas.push("WebPage");
   }
   return {
     discoverable: schemas.length > 0,
     schemaTypes: Array.from(new Set(schemas)),
-    evidence: "Inferred from layout.tsx global JSON-LD plus route page JSON-LD patterns; payloads are not rendered by this static export.",
+    sourceFile,
+    hasRouteJsonLdScript: Boolean(sourceMetadata?.hasJsonLdScript),
+    evidence: sourceMetadata?.hasJsonLdScript
+      ? "Route source contains an application/ld+json script; payload is not rendered by this static export."
+      : "Inferred from layout.tsx global JSON-LD plus route page JSON-LD patterns; payloads are not rendered by this static export.",
   };
 };
 
@@ -231,6 +247,8 @@ const main = async () => {
 
   const sitemapExists = await fileExists("apps/web/app/sitemap.ts");
   const robotsExists = await fileExists("apps/web/app/robots.ts");
+  const sitemapText = await readTextOptional("apps/web/app/sitemap.ts");
+  const robotsText = await readTextOptional("apps/web/app/robots.ts");
   const layoutText = await readText("apps/web/app/layout.tsx");
   const rootMetadataPresent = /export\s+const\s+metadata/.test(layoutText);
 
@@ -294,7 +312,7 @@ const main = async () => {
         pageId: manifestEntry?.pageId ?? null,
         classification,
         metadata: extractRouteMetadata(route, manifestEntry?.page, matchedAppRoute, rootMetadataPresent),
-        schema: inferSchema(route, classification),
+        schema: inferSchema(route, classification, matchedAppRoute),
         pageTruth: {
           file: pageTruthFile,
           exists: false,
@@ -309,23 +327,36 @@ const main = async () => {
   }
 
   const sitemapPublicRoutes = routeInventory.filter((entry) => entry.classification.publicness === "public" && !entry.route.includes("[")).map((entry) => entry.route);
+  const sitemapHasLastModified = /lastModified/.test(sitemapText);
+  const sitemapHasChangeFrequency = /changeFrequency/.test(sitemapText);
+  const sitemapHasPriority = /priority/.test(sitemapText);
+  const sitemapExcludedPrefixes = ["/champagne/", "/api/"].filter((prefix) => sitemapText.includes(prefix));
+  const sitemapExcludedPaths = ["/patient-portal"].filter((excludedPath) => sitemapText.includes(excludedPath));
+  const sitemapEnriched = sitemapExists && sitemapHasChangeFrequency && sitemapHasPriority && sitemapExcludedPrefixes.length === 2 && sitemapExcludedPaths.length === 1;
   const sitemapStatus = {
     exists: sitemapExists,
     sourceFile: sitemapExists ? "apps/web/app/sitemap.ts" : null,
     productionOrigin: siteOrigin,
-    excludesPrefixes: ["/champagne/", "/api/"],
-    excludesPaths: ["/patient-portal"],
+    excludesPrefixes: sitemapExcludedPrefixes,
+    excludesPaths: sitemapExcludedPaths,
     inferredPublicRouteCount: sitemapPublicRoutes.length,
-    weakness: "No lastModified/changeFrequency/priority fields discovered in sitemap.ts static export.",
+    hasLastModified: sitemapHasLastModified,
+    hasChangeFrequency: sitemapHasChangeFrequency,
+    hasPriority: sitemapHasPriority,
+    enriched: sitemapEnriched,
+    weakness: sitemapEnriched ? null : "Sitemap export is missing one or more launch SEO fields or private-route exclusions.",
   };
 
+  const robotsExplicitDisallows = ["/champagne/", "/api/", "/patient-portal"].filter((excludedPath) => robotsText.includes(excludedPath));
   const robotsStatus = {
     exists: robotsExists,
     sourceFile: robotsExists ? "apps/web/app/robots.ts" : null,
-    productionAllowsRoot: robotsExists,
-    nonProductionDisallowsAll: robotsExists,
-    sitemapAdvertised: robotsExists ? `${siteOrigin}/sitemap.xml` : null,
-    weakness: "Production robots allows root and does not explicitly disallow /champagne/, /api/, or /patient-portal; launch safety relies on sitemap exclusion and route classification.",
+    productionAllowsRoot: robotsExists && /allow:\s*["']\/["']/.test(robotsText),
+    productionExplicitDisallows: robotsExplicitDisallows,
+    nonProductionDisallowsAll: robotsExists && /disallow:\s*["']\/["']/.test(robotsText),
+    sitemapAdvertised: robotsExists && robotsText.includes("sitemap.xml") ? `${siteOrigin}/sitemap.xml` : null,
+    hardened: robotsExists && robotsExplicitDisallows.length === 3 && robotsText.includes("process.env.VERCEL_ENV === \"production\"") && robotsText.includes("sitemap.xml"),
+    weakness: robotsExists && robotsExplicitDisallows.length === 3 ? null : "Production robots does not explicitly disallow all internal/private launch-excluded paths.",
   };
 
   const treatmentManifestInventory = manifestRoutes
@@ -374,13 +405,18 @@ const main = async () => {
   const addBlocker = (code, severity, message, evidence) => blockers.push({ code, severity, message, evidence });
   addBlocker("NO_CLEAN_LAUNCH_ASSERTION", "info", "This export is an evidence layer only and does not certify clean launch readiness.", null);
   if (!sitemapExists) addBlocker("SITEMAP_MISSING", "critical", "Sitemap file was not discovered.", "apps/web/app/sitemap.ts");
-  else addBlocker("SITEMAP_WEAK_METADATA", "warning", sitemapStatus.weakness, sitemapStatus.sourceFile);
+  else if (!sitemapStatus.enriched) addBlocker("SITEMAP_WEAK_METADATA", "warning", sitemapStatus.weakness, sitemapStatus.sourceFile);
   if (!robotsExists) addBlocker("ROBOTS_MISSING", "critical", "Robots file was not discovered.", "apps/web/app/robots.ts");
-  else addBlocker("ROBOTS_WEAK_EXCLUSIONS", "warning", robotsStatus.weakness, robotsStatus.sourceFile);
+  else if (!robotsStatus.hardened) addBlocker("ROBOTS_WEAK_EXCLUSIONS", "warning", robotsStatus.weakness, robotsStatus.sourceFile);
   if (!rootMetadataPresent) addBlocker("ROOT_METADATA_MISSING", "critical", "Root metadata export was not discovered.", "apps/web/app/layout.tsx");
-  const legalWeak = routeInventory.filter((entry) => entry.classification.routeFamily === "legal" && !entry.metadata.hasRouteMetadataHook);
+  const legalWeak = routeInventory.filter(
+    (entry) =>
+      entry.classification.routeFamily === "legal" &&
+      !entry.route.includes("[") &&
+      (!entry.metadata.hasRouteMetadataHook || !entry.metadata.canonicalUrl || !entry.schema.hasRouteJsonLdScript),
+  );
   if (legalWeak.length > 0) {
-    addBlocker("LEGAL_METADATA_WEAK", "warning", "Legal routes are present but route-specific metadata/canonical/schema was not discovered on the dynamic legal route.", legalWeak.map((entry) => entry.route));
+    addBlocker("LEGAL_METADATA_WEAK", "warning", "Legal routes are present but route-specific metadata/canonical/schema was not discovered consistently.", legalWeak.map((entry) => ({ route: entry.route, metadata: entry.metadata, schema: entry.schema })));
   }
   const privateRoutes = routeInventory.filter((entry) => entry.classification.publicness !== "public");
   if (privateRoutes.length > 0) {
@@ -485,7 +521,7 @@ const main = async () => {
       neverClaimCleanLaunch: true,
       classifyAsLaunchExcluded: ["/champagne/*", "/api/*", "/patient-portal", "hero labs/debug/preview routes"],
       classifyAsReviewRequired: ["treatment pages", "support pages", "legal pages if present"],
-      blockersRequiredWhenWeakOrMissing: ["sitemap", "robots", "root metadata", "support metadata"],
+      blockersRequiredWhenWeakOrMissing: ["sitemap", "robots", "root metadata", "support metadata", "legal metadata"],
     },
     reportShape: {
       version: "string",

--- a/scripts/seo-launch-safety-check.mjs
+++ b/scripts/seo-launch-safety-check.mjs
@@ -29,15 +29,33 @@ if (!robots.includes("process.env.VERCEL_ENV === \"production\"")) {
   fail("robots.ts must only allow indexing for Vercel production");
 }
 if (!robots.includes("disallow: \"/\"")) fail("robots.ts must disallow non-production indexing");
+for (const required of ["/champagne/", "/api/", "/patient-portal"]) {
+  if (!robots.includes(required)) fail(`robots.ts does not explicitly disallow ${required}`);
+}
 if (!robots.includes("sitemap.xml")) fail("robots.ts must advertise sitemap.xml");
-pass("robots.ts production/non-production indexing posture looks safe");
+pass("robots.ts production/non-production indexing posture and private-path disallows look safe");
 
 if (!sitemap.includes(CANONICAL_ORIGIN)) fail("sitemap.ts does not use the production canonical origin");
 for (const required of ["/champagne/", "/api/", "/patient-portal"]) {
   if (!sitemap.includes(required)) fail(`sitemap.ts does not explicitly exclude ${required}`);
 }
 if (!sitemap.includes("getAllPages()")) fail("sitemap.ts must be generated from the canonical page manifest");
-pass("sitemap.ts canonical origin, manifest source, and private-path exclusions look safe");
+for (const required of ["changeFrequency", "priority", "lastModified"]) {
+  if (!sitemap.includes(required)) fail(`sitemap.ts does not include ${required} enrichment`);
+}
+pass("sitemap.ts canonical origin, manifest source, enrichment fields, and private-path exclusions look safe");
+
+const legalRouteFiles = [
+  "apps/web/app/(champagne)/legal/privacy/page.tsx",
+  "apps/web/app/(champagne)/legal/[slug]/page.tsx",
+];
+for (const relativePath of legalRouteFiles) {
+  const legalSource = read(path.join(ROOT, relativePath));
+  if (!legalSource.includes("Metadata")) fail(`${relativePath} does not expose route metadata`);
+  if (!legalSource.includes("canonical")) fail(`${relativePath} does not expose canonical metadata`);
+  if (!legalSource.includes("application/ld+json")) fail(`${relativePath} does not emit JSON-LD schema`);
+}
+pass("legal routes expose metadata, canonical, and JSON-LD schema evidence");
 
 const routeRegex = /\|\s*[^|]+\s*\|\s*[^|]+\s*\|\s*(\/treatments\/[a-z0-9-]+)\s*\|/g;
 const treatmentRoutes = new Set();


### PR DESCRIPTION
### Motivation
- Close SEO launch surface gaps the truth importer flagged: weak sitemap metadata, robots exclusions, and ambiguous legal-route indexing policy.
- Ensure canonical public routes are exported and that internal/debug/patient routes remain explicitly launch-excluded while preserving existing treatment coverage and hero behavior.

### Description
- Enriched `apps/web/app/sitemap.ts` to emit manifest-derived public canonical routes with `lastModified`, `changeFrequency`, and `priority` fields and to explicitly exclude `/champagne/`, `/api/`, and `/patient-portal`.
- Hardened `apps/web/app/robots.ts` to be production-indexable only, advertise the sitemap, and explicitly disallow internal/private paths in production while keeping non-production noindex/disallow posture.
- Made legal pages explicit and public-safe by adding route metadata/canonical handling, JSON-LD `WebPage` schema emission, and a safe `generateStaticParams` filter for dynamic legal routes, and adjusted the privacy page to expose metadata and JSON-LD (no copy or visual changes to content).
- Updated `scripts/export-website-truth.mjs` and `scripts/seo-launch-safety-check.mjs` to detect sitemap enrichment and robots hardening, to evaluate legal metadata/JSON-LD evidence, and to regenerate the contract/report; regenerated `ops/contracts/WEBSITE_TRUTH_EXPORT_CONTRACT_V1.json` and `reports/WEBSITE_TRUTH_EXPORT_REPORT_V1.json` accordingly.
- Files changed: `apps/web/app/sitemap.ts`, `apps/web/app/robots.ts`, `apps/web/app/(champagne)/legal/[slug]/page.tsx`, `apps/web/app/(champagne)/legal/privacy/page.tsx`, `scripts/export-website-truth.mjs`, `scripts/seo-launch-safety-check.mjs`, `ops/contracts/WEBSITE_TRUTH_EXPORT_CONTRACT_V1.json`, and `reports/WEBSITE_TRUTH_EXPORT_REPORT_V1.json`.

### Testing
- Ran `pnpm run export:website-truth` and `node --check scripts/export-website-truth.mjs` which succeeded and produced an updated report with `sitemapStatus.enriched = true` and `robotsStatus.hardened = true`.
- Validated JSON parsing of `ops/contracts/WEBSITE_TRUTH_EXPORT_CONTRACT_V1.json` and `reports/WEBSITE_TRUTH_EXPORT_REPORT_V1.json` with `node -e` which passed.
- Ran `pnpm run guard:seo-launch-safety`, `pnpm run guard:canon`, and `pnpm run guard:hero` which all passed (the SEO guard emitted warnings about treatment layout coverage/cannibalisation as informational review items).
- Built the site with `pnpm run build:web` which completed successfully; note `readyForLaunch` remains `false` and the truth report preserves remaining blockers: `NO_CLEAN_LAUNCH_ASSERTION`, `LAUNCH_EXCLUDED_ROUTES_PRESENT` (internal/API/patient-portal routes intentionally present), and `CONTENT_READINESS_NOT_GREEN` (POLISH:39 / REWRITE:55).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a189194c4a48332aefda1ee3c1f6146)