### PR TITLE
Add treatment answer-surface framework and export/guard integration

### DIFF
--- a/ops/contracts/WEBSITE_TRUTH_EXPORT_CONTRACT_V1.json
+++ b/ops/contracts/WEBSITE_TRUTH_EXPORT_CONTRACT_V1.json
@@ -1,6 +1,6 @@
 {
   "version": "CHAMPAGNE_WEBSITE_TRUTH_EXPORT_CONTRACT_V1",
-  "generatedAt": "2026-05-28T19:10:45.734Z",
+  "generatedAt": "2026-05-29T13:45:44.821Z",
   "purpose": "Champagne-side static website truth export contract for the frontier dominance agent repo.",
   "producer": {
     "repo": "drnickmaxwell-wq/champagne",
@@ -17,6 +17,7 @@
     "sitemap status",
     "robots status",
     "treatment manifest inventory",
+    "treatment answer-surface coverage and validation",
     "page text/page truth inventory",
     "internal link inventory if discoverable",
     "FAQ block inventory if discoverable",
@@ -63,6 +64,7 @@
     "sitemapStatus": "object",
     "robotsStatus": "object",
     "treatmentManifestInventory": "array",
+    "answerSurfaceCoverage": "object",
     "pageTextInventory": "object",
     "launchBlockersDetected": "array",
     "readyForLaunch": "boolean; expected false unless a separate launch audit proves otherwise",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "guard:no-phi-logs-stock": "node scripts/guard-no-phi-logs-stock.mjs",
     "guard:stock-proxy-no-phi": "node scripts/guard-stock-proxy-no-phi.mjs",
     "guard:concierge-contract": "node scripts/guard-concierge-engine-contract.mjs",
-    "export:website-truth": "node scripts/export-website-truth.mjs"
+    "export:website-truth": "node scripts/export-website-truth.mjs",
+    "guard:treatment-answer-surface": "node scripts/guard-treatment-answer-surface.mjs"
   },
   "dependencies": {
     "framer-motion": "^11.11.17",

--- a/packages/champagne-manifests/data/champagne_machine_manifest_full.json
+++ b/packages/champagne-manifests/data/champagne_machine_manifest_full.json
@@ -43,14 +43,14 @@
           "type": "copy-block",
           "title": "Dentistry planned carefully, delivered properly",
           "label": "Overview",
-          "copy": "St Mary\u2019s House Dental Care is a long-established private practice in Shoreham-by-Sea. We focus on careful planning, calm delivery, and dentistry that makes sense for the long term.\n\nWe look after everyday oral health and also support complex cases involving tooth wear, missing teeth, implant-supported restorations, heavily restored mouths, and bite-related problems.\n\nAppointments are structured so you understand what we\u2019ve found, what it means, and what your realistic options are. If you\u2019re anxious, short on time, or simply want things explained properly, we\u2019ll take a measured approach and agree the next step together."
+          "copy": "St Mary’s House Dental Care is a long-established private practice in Shoreham-by-Sea. We focus on careful planning, calm delivery, and dentistry that makes sense for the long term.\n\nWe look after everyday oral health and also support complex cases involving tooth wear, missing teeth, implant-supported restorations, heavily restored mouths, and bite-related problems.\n\nAppointments are structured so you understand what we’ve found, what it means, and what your realistic options are. If you’re anxious, short on time, or simply want things explained properly, we’ll take a measured approach and agree the next step together."
         },
         {
           "id": "home_who_we_are",
           "type": "copy-block",
           "label": "Who we are",
           "title": "Dentistry designed for clarity, comfort, and long-term confidence",
-          "copy": "Care at St Mary\u2019s House is built around time, explanation, and respect for every patient\u2019s circumstances.\n\nWe provide general, restorative, implant, orthodontic, and aesthetic dentistry, but we don\u2019t rush decisions or push treatment. Appointments are unhurried, explanations are clear, and choices are made collaboratively."
+          "copy": "Care at St Mary’s House is built around time, explanation, and respect for every patient’s circumstances.\n\nWe provide general, restorative, implant, orthodontic, and aesthetic dentistry, but we don’t rush decisions or push treatment. Appointments are unhurried, explanations are clear, and choices are made collaboratively."
         },
         {
           "id": "home_authority",
@@ -69,7 +69,7 @@
           "type": "copy-block",
           "label": "Clinical philosophy",
           "title": "Care that values planning as much as precision",
-          "copy": "Good dentistry isn\u2019t just about a single procedure. It\u2019s about understanding bite, function, health, aesthetics, and long-term stability \u2014 and planning accordingly.\n\nWe take a conservative, evidence-led approach. When care becomes complex or irreversible \u2014 implants, extractions, root canal treatment, veneers, larger restorative plans \u2014 we slow things down, map out options clearly, and proceed step by step with your comfort and understanding at the centre."
+          "copy": "Good dentistry isn’t just about a single procedure. It’s about understanding bite, function, health, aesthetics, and long-term stability — and planning accordingly.\n\nWe take a conservative, evidence-led approach. When care becomes complex or irreversible — implants, extractions, root canal treatment, veneers, larger restorative plans — we slow things down, map out options clearly, and proceed step by step with your comfort and understanding at the centre."
         },
         {
           "id": "home_treatment_hub",
@@ -98,7 +98,7 @@
           "type": "copy-block",
           "label": "Complex & multidisciplinary care",
           "title": "Structured care for complex situations",
-          "copy": "Many patients come to us after years of piecemeal dentistry, unresolved problems, or uncertainty about what should happen next. These cases need structure, not speed.\n\nOur approach brings disciplines together \u2014 restorative, orthodontic, implant, and digital planning \u2014 so treatment is sequenced sensibly and reviewed carefully. For missing teeth, that may include implant-supported restorations or implant-retained dentures, planned with stability, comfort, and ease of maintenance in mind.\n\nThe aim is a clearer path forward before anything irreversible begins."
+          "copy": "Many patients come to us after years of piecemeal dentistry, unresolved problems, or uncertainty about what should happen next. These cases need structure, not speed.\n\nOur approach brings disciplines together — restorative, orthodontic, implant, and digital planning — so treatment is sequenced sensibly and reviewed carefully. For missing teeth, that may include implant-supported restorations or implant-retained dentures, planned with stability, comfort, and ease of maintenance in mind.\n\nThe aim is a clearer path forward before anything irreversible begins."
         },
         {
           "id": "home_treatment_routing",
@@ -173,7 +173,7 @@
           "type": "media",
           "label": "Tech & tools",
           "title": "Technology that keeps planning clear",
-          "copy": "Diagnostics, digital planning, and 3D workflows help you see the steps before they happen \u2014 particularly for implants and complex restorative work \u2014 so decisions feel clearer and more predictable."
+          "copy": "Diagnostics, digital planning, and 3D workflows help you see the steps before they happen — particularly for implants and complex restorative work — so decisions feel clearer and more predictable."
         },
         {
           "id": "home_patient_stories",
@@ -217,7 +217,7 @@
               "source": "Google"
             },
             {
-              "quote": "Felt listened to and not often rushed\u2014highly recommend.",
+              "quote": "Felt listened to and not often rushed—highly recommend.",
               "name": "Google reviewer",
               "rating": 5,
               "source": "Google"
@@ -240,7 +240,7 @@
           "type": "copy-block",
           "label": "Local trust & continuity",
           "title": "Established care for Shoreham-by-Sea and surrounding communities",
-          "copy": "We\u2019ve cared for patients from Shoreham-by-Sea and surrounding towns for many years. Many stay with us long-term \u2014 not because they need ongoing treatment, but because they value consistency and knowing who is looking after them.\n\nDentistry works best when your dentist understands your history, priorities, and concerns. That continuity matters whether you\u2019re visiting for routine care, managing dental wear over time, or planning something more involved."
+          "copy": "We’ve cared for patients from Shoreham-by-Sea and surrounding towns for many years. Many stay with us long-term — not because they need ongoing treatment, but because they value consistency and knowing who is looking after them.\n\nDentistry works best when your dentist understands your history, priorities, and concerns. That continuity matters whether you’re visiting for routine care, managing dental wear over time, or planning something more involved."
         },
         {
           "id": "home_locality_nap",
@@ -249,7 +249,7 @@
           "title": "Private dental care in Shoreham-by-Sea",
           "copy": "A long-established Shoreham-by-Sea dental practice for patients who value experience, continuity, and well-planned care.",
           "items": [
-            "Practice: St Mary\u2019s House Dental Care, Shoreham-by-Sea",
+            "Practice: St Mary’s House Dental Care, Shoreham-by-Sea",
             "Address area: Central Shoreham-by-Sea near the River Adur",
             "Phone: Reach the team through the contact page for a call-back"
           ],
@@ -333,7 +333,7 @@
           "faqs": [
             {
               "question": "Do you help with directions or parking?",
-              "answer": "Yes \u2014 call or message ahead and we can outline nearby parking options and the easiest way to enter the practice."
+              "answer": "Yes — call or message ahead and we can outline nearby parking options and the easiest way to enter the practice."
             },
             {
               "question": "Can I start with a phone discussion?",
@@ -345,7 +345,7 @@
             },
             {
               "question": "Is the practice suitable for nervous patients?",
-              "answer": "Yes\u2014gentle pacing, clear numbing options, and calm explanations are part of every visit."
+              "answer": "Yes—gentle pacing, clear numbing options, and calm explanations are part of every visit."
             }
           ]
         },
@@ -354,7 +354,7 @@
           "type": "copy-block",
           "label": "Patient journey",
           "title": "A clear, supportive first step",
-          "copy": "Your first visit is about listening, understanding your concerns, and gathering the information needed to guide you properly. You don\u2019t need to know where to start. We\u2019ll take things step by step.\n\nWhere treatment is required, options are explained clearly, including benefits, limitations, costs, and timescales. From there, you can decide how \u2014 or whether \u2014 to proceed, with support available at every stage."
+          "copy": "Your first visit is about listening, understanding your concerns, and gathering the information needed to guide you properly. You don’t need to know where to start. We’ll take things step by step.\n\nWhere treatment is required, options are explained clearly, including benefits, limitations, costs, and timescales. From there, you can decide how — or whether — to proceed, with support available at every stage."
         },
         {
           "id": "home_closing_cta",
@@ -659,7 +659,7 @@
               "href": "/treatments/periodontal-gum-care"
             },
             {
-              "title": "Children\u2019s dentistry",
+              "title": "Children’s dentistry",
               "description": "",
               "href": "/treatments/childrens-dentistry"
             },
@@ -1042,7 +1042,7 @@
                 "href": "/treatments/periodontal-gum-care"
               },
               {
-                "title": "Children\u2019s dentistry",
+                "title": "Children’s dentistry",
                 "description": "",
                 "href": "/treatments/childrens-dentistry"
               },
@@ -1845,7 +1845,7 @@
           "type": "copy-block",
           "title": "Planning first, surgery second",
           "label": "Introduction",
-          "copy": "Dental implants replace missing teeth using a small titanium post that supports a crown, bridge, or implant-retained denture. Planning matters: before any surgery we assess your mouth, review your medical history, and use CBCT imaging and digital scans to map bone, nerves, bite and the final tooth shape. This allows us to discuss realistic options, timing, and whether additional steps such as bone grafting or sinus lift assessment may be relevant. If implants aren\u2019t the right fit, we\u2019ll explain alternatives such as bridges or removable solutions and help you choose an approach that\u2019s stable, maintainable and comfortable long-term."
+          "copy": "Dental implants replace missing teeth using a small titanium post that supports a crown, bridge, or implant-retained denture. Planning matters: before any surgery we assess your mouth, review your medical history, and use CBCT imaging and digital scans to map bone, nerves, bite and the final tooth shape. This allows us to discuss realistic options, timing, and whether additional steps such as bone grafting or sinus lift assessment may be relevant. If implants aren’t the right fit, we’ll explain alternatives such as bridges or removable solutions and help you choose an approach that’s stable, maintainable and comfortable long-term."
         },
         {
           "id": "treatment.trustSignals"
@@ -1917,7 +1917,7 @@
         {
           "id": "implants_full_inventory",
           "type": "routing_cards",
-          "title": "Dental Implants \u2014 full treatment list",
+          "title": "Dental Implants — full treatment list",
           "label": "Full list",
           "items": [
             {
@@ -2034,7 +2034,193 @@
         }
       ],
       "surface": "champagne/surface/treatment",
-      "heroFamily": "treatments.implants"
+      "heroFamily": "treatments.implants",
+      "answerSurface": {
+        "version": "TREATMENT_ANSWER_SURFACE_V1",
+        "status": "example_seed",
+        "frameworkOnly": true,
+        "exampleSeed": true,
+        "primaryGeography": "Shoreham-by-Sea",
+        "secondaryGeographies": [
+          "Brighton",
+          "Worthing",
+          "Lancing",
+          "Southwick"
+        ],
+        "sections": [
+          {
+            "id": "direct_answer",
+            "heading": "Direct answer",
+            "body": "Dental implants can replace one or more missing teeth when assessment shows there is suitable health, bone, space and maintenance capacity. This is an example seed for the answer-surface framework, not final launch copy."
+          },
+          {
+            "id": "what_this_treatment_is",
+            "heading": "What this treatment is",
+            "body": "An implant is a titanium fixture placed in the jaw to support a crown, bridge or implant-retained denture after planning and healing checks."
+          },
+          {
+            "id": "who_it_is_for",
+            "heading": "Who it is for",
+            "items": [
+              "Adults with missing teeth who want a fixed or more stable replacement option.",
+              "Patients willing to attend planning, healing reviews and long-term hygiene maintenance.",
+              "People whose medical history and oral health are suitable after clinical assessment."
+            ]
+          },
+          {
+            "id": "who_it_may_not_be_suitable_for",
+            "heading": "Who it may not be suitable for",
+            "items": [
+              "Patients with active gum disease or untreated infection until this is stabilised.",
+              "People whose medical history, smoking status or bone levels make surgery higher risk.",
+              "Anyone seeking a same-day promise before diagnostics have confirmed suitability."
+            ]
+          },
+          {
+            "id": "benefits",
+            "heading": "Benefits",
+            "items": [
+              "Can provide a stable replacement for missing teeth.",
+              "Can avoid preparing neighbouring teeth in some cases.",
+              "Can support chewing comfort and confidence when maintained well."
+            ]
+          },
+          {
+            "id": "risks_and_limitations",
+            "heading": "Risks and limitations",
+            "items": [
+              "Implants require surgery and healing time.",
+              "Integration is not guaranteed and maintenance is essential.",
+              "Risks such as infection, gum recession, peri-implant inflammation, nerve or sinus complications are discussed before treatment."
+            ]
+          },
+          {
+            "id": "alternatives",
+            "heading": "Alternatives",
+            "items": [
+              "Dental bridges where neighbouring teeth and bite make this suitable.",
+              "Removable dentures or implant-retained dentures depending on stability needs.",
+              "Leaving a space may sometimes be reasonable after discussing consequences."
+            ],
+            "links": [
+              {
+                "label": "Dental bridges",
+                "href": "/treatments/dental-bridges",
+                "relationship": "alternative"
+              },
+              {
+                "label": "Dentures",
+                "href": "/treatments/dentures",
+                "relationship": "alternative"
+              }
+            ]
+          },
+          {
+            "id": "process",
+            "heading": "Process",
+            "items": [
+              "Consultation and medical history review.",
+              "Clinical examination, photographs, digital scans and CBCT where indicated.",
+              "Option discussion, written plan and staged appointments if proceeding.",
+              "Placement, healing review, restoration and maintenance planning."
+            ]
+          },
+          {
+            "id": "timeline",
+            "heading": "Timeline",
+            "body": "Timing varies by the number of teeth, healing, bone levels and whether grafting or sinus assessment is needed. The personalised timeline is confirmed after diagnostics."
+          },
+          {
+            "id": "aftercare",
+            "heading": "Aftercare",
+            "items": [
+              "Clean carefully around the implant and gumline every day.",
+              "Attend hygiene maintenance and clinical reviews.",
+              "Report looseness, swelling, bleeding or discomfort promptly."
+            ]
+          },
+          {
+            "id": "cost_fee_logic",
+            "heading": "Cost and fee logic",
+            "body": "Fees depend on diagnostics, the number of implants, grafting needs, components, restoration design and maintenance requirements. A written estimate follows assessment before treatment decisions are made."
+          },
+          {
+            "id": "local_shoreham_context",
+            "heading": "Local Shoreham-by-Sea context",
+            "body": "Implant planning is provided at St Mary’s House Dental Care in Shoreham-by-Sea, with diagnostics and follow-up arranged locally so the pathway remains practical for ongoing reviews."
+          },
+          {
+            "id": "clinician_expertise",
+            "heading": "Clinician expertise",
+            "body": "Implant planning and placement are clinician-led, combining case selection, restorative planning, digital diagnostics and long-term maintenance advice."
+          },
+          {
+            "id": "technology_used",
+            "heading": "Technology used where relevant",
+            "items": [
+              "CBCT imaging for three-dimensional planning where indicated.",
+              "Digital scanning for restorative design and bite assessment.",
+              "Guided surgery planning where suitable for the case."
+            ]
+          },
+          {
+            "id": "faq",
+            "heading": "FAQ",
+            "faqs": [
+              {
+                "question": "Do I always need a CBCT scan?",
+                "answer": "Most implant cases need three-dimensional assessment, but the clinician confirms the right diagnostics after examination."
+              },
+              {
+                "question": "Are implants guaranteed?",
+                "answer": "No. Success depends on planning, health, healing, maintenance and risk factors that are discussed before treatment."
+              }
+            ]
+          },
+          {
+            "id": "related_treatments_internal_links",
+            "heading": "Related treatments and internal links",
+            "links": [
+              {
+                "label": "Implant consultation",
+                "href": "/treatments/implants-consultation",
+                "relationship": "next_step"
+              },
+              {
+                "label": "CBCT 3D scanning",
+                "href": "/treatments/cbct-3d-scanning",
+                "relationship": "prerequisite"
+              },
+              {
+                "label": "Implants aftercare",
+                "href": "/treatments/implants-aftercare",
+                "relationship": "maintenance"
+              }
+            ]
+          },
+          {
+            "id": "last_reviewed_clinical_review",
+            "heading": "Last reviewed and clinical review metadata",
+            "review": {
+              "lastReviewed": "2026-05-29",
+              "clinicalReviewer": "Example seed pending clinical review",
+              "nextReviewDue": "2026-11-29"
+            }
+          },
+          {
+            "id": "cta",
+            "heading": "CTA",
+            "body": "Use the existing treatment CTA surfaces for appointment requests; this answer-surface CTA record exists for export coverage only.",
+            "ctas": [
+              {
+                "label": "Request an implant assessment",
+                "href": "/contact",
+                "relationship": "next_step"
+              }
+            ]
+          }
+        ]
+      }
     },
     "veneers": {
       "id": "veneers",
@@ -2055,7 +2241,7 @@
           "type": "copy-block",
           "title": "A conservative route to refined change",
           "label": "Introduction",
-          "copy": "Veneers are thin restorations placed on the front surface of teeth to refine shape, colour and alignment. They can be an excellent option when the teeth underneath are healthy enough, and when the plan is conservative and carefully staged. We start by understanding what you\u2019d like to change, then assess enamel, bite, gum health and wear patterns so the result is stable and maintainable. In many cases, we can explore minimal-prep or additive approaches, or consider alternatives such as whitening, bonding, or aligners first. If veneers are suitable, we\u2019ll talk through preview options, longevity factors and how to protect the finished work."
+          "copy": "Veneers are thin restorations placed on the front surface of teeth to refine shape, colour and alignment. They can be an excellent option when the teeth underneath are healthy enough, and when the plan is conservative and carefully staged. We start by understanding what you’d like to change, then assess enamel, bite, gum health and wear patterns so the result is stable and maintainable. In many cases, we can explore minimal-prep or additive approaches, or consider alternatives such as whitening, bonding, or aligners first. If veneers are suitable, we’ll talk through preview options, longevity factors and how to protect the finished work."
         },
         {
           "id": "treatment.trustSignals"
@@ -2149,7 +2335,7 @@
           "type": "copy-block",
           "title": "Clear aligners with clear diagnosis",
           "label": "Introduction",
-          "copy": "Clear aligners straighten teeth using a series of custom trays that move teeth in small, planned steps. The key is diagnosis and planning: we assess your bite, gum health, tooth wear and any jaw symptoms, then use digital scans to model movement and discuss what\u2019s realistic. Aligners can help with crowding, spacing and some bite corrections, but not every case is suitable \u2014 and retention is essential to keep results stable. We\u2019ll also discuss where aligners fit alongside whitening, bonding or restorative work, especially if you\u2019re planning a broader smile refresh. If aligners are recommended, you\u2019ll receive a clear timeline, check-in plan and aftercare guidance."
+          "copy": "Clear aligners straighten teeth using a series of custom trays that move teeth in small, planned steps. The key is diagnosis and planning: we assess your bite, gum health, tooth wear and any jaw symptoms, then use digital scans to model movement and discuss what’s realistic. Aligners can help with crowding, spacing and some bite corrections, but not every case is suitable — and retention is essential to keep results stable. We’ll also discuss where aligners fit alongside whitening, bonding or restorative work, especially if you’re planning a broader smile refresh. If aligners are recommended, you’ll receive a clear timeline, check-in plan and aftercare guidance."
         },
         {
           "id": "treatment.trustSignals"
@@ -2344,14 +2530,14 @@
           "id": "smile_gallery_intro_copy",
           "type": "copy-block",
           "title": "Smile transformations, simplified",
-          "copy": "Our smile gallery shares examples of treatments carried out at St Mary\u2019s House Dental Care, with the aim of helping you understand what different options can look like in real life. Every smile is unique and results vary, so these cases are here to support informed conversations \u2014 not to promise a specific outcome. Where we share before-and-after images, we do so with consent and with context about the type of work involved. If you see a result you like, we can discuss whether a similar approach is clinically suitable for you, and what the planning would involve.",
+          "copy": "Our smile gallery shares examples of treatments carried out at St Mary’s House Dental Care, with the aim of helping you understand what different options can look like in real life. Every smile is unique and results vary, so these cases are here to support informed conversations — not to promise a specific outcome. Where we share before-and-after images, we do so with consent and with context about the type of work involved. If you see a result you like, we can discuss whether a similar approach is clinically suitable for you, and what the planning would involve.",
           "label": "Overview"
         },
         {
           "id": "smile_gallery_cases_overview",
           "type": "copy-block",
           "title": "Cases overview",
-          "copy": "Each case includes a brief summary of the starting point, the type of treatment provided, and the kind of planning involved.\n\nWhere before-and-after images are shown, they are there to help you understand what may be possible \u2014 not to suggest you will get an identical result. Photographs also don\u2019t show everything that matters in dentistry, such as bite, gum health, long-term maintenance, or the stability of the underlying teeth.\n\nIf you see a style of outcome you like, we can talk through whether a similar approach is clinically suitable for you and what would need to be assessed first.",
+          "copy": "Each case includes a brief summary of the starting point, the type of treatment provided, and the kind of planning involved.\n\nWhere before-and-after images are shown, they are there to help you understand what may be possible — not to suggest you will get an identical result. Photographs also don’t show everything that matters in dentistry, such as bite, gum health, long-term maintenance, or the stability of the underlying teeth.\n\nIf you see a style of outcome you like, we can talk through whether a similar approach is clinically suitable for you and what would need to be assessed first.",
           "label": "Cases"
         },
         {
@@ -2385,26 +2571,26 @@
         {
           "id": "practice_overview_authority_frame",
           "type": "story",
-          "title": "About St Mary\u2019s House Dental Care",
-          "copy": "St Mary\u2019s House Dental Care is a long-established private dental practice in Shoreham-by-Sea.\n\nWe work in a calm, clinician-led way: careful assessment, clear explanation, and treatment planned for long-term stability rather than quick fixes.\n\nIf you\u2019re nervous about dentistry, or you\u2019ve had mixed experiences in the past, we\u2019ll take things at a pace that feels manageable and explain what we\u2019re doing as we go."
+          "title": "About St Mary’s House Dental Care",
+          "copy": "St Mary’s House Dental Care is a long-established private dental practice in Shoreham-by-Sea.\n\nWe work in a calm, clinician-led way: careful assessment, clear explanation, and treatment planned for long-term stability rather than quick fixes.\n\nIf you’re nervous about dentistry, or you’ve had mixed experiences in the past, we’ll take things at a pace that feels manageable and explain what we’re doing as we go."
         },
         {
           "id": "philosophy_and_standards",
           "type": "story",
           "title": "An independent practice by choice",
-          "copy": "How we work is simple, even if the dentistry isn\u2019t.\n\nWe start with understanding the problem properly before talking about solutions. We explain options in plain English, including limits and trade-offs. Where it helps outcomes and costs, we plan treatment in stages. And we focus on comfort, fit, and long-term maintenance \u2014 not hype."
+          "copy": "How we work is simple, even if the dentistry isn’t.\n\nWe start with understanding the problem properly before talking about solutions. We explain options in plain English, including limits and trade-offs. Where it helps outcomes and costs, we plan treatment in stages. And we focus on comfort, fit, and long-term maintenance — not hype."
         },
         {
           "id": "history_and_evolution",
           "type": "story",
           "title": "A practice built on relationships",
-          "copy": "The practice has been part of the Shoreham area for many years, and the building itself reflects that history.\n\nDentistry has changed a lot over time, but the principles haven\u2019t: careful diagnosis, sensible planning, and work you can live with comfortably. We continue to improve how we assess, plan, and deliver care, while keeping the experience calm and straightforward."
+          "copy": "The practice has been part of the Shoreham area for many years, and the building itself reflects that history.\n\nDentistry has changed a lot over time, but the principles haven’t: careful diagnosis, sensible planning, and work you can live with comfortably. We continue to improve how we assess, plan, and deliver care, while keeping the experience calm and straightforward."
         },
         {
           "id": "commitment_to_patients_and_community",
           "type": "story",
           "title": "Part of Shoreham, not just located in it",
-          "copy": "Good dentistry should feel understandable and unrushed.\n\nWhether you need a simple check-up or more involved restorative work, our job is to help you make clear decisions you\u2019ll still feel comfortable with in five and ten years\u2019 time."
+          "copy": "Good dentistry should feel understandable and unrushed.\n\nWhether you need a simple check-up or more involved restorative work, our job is to help you make clear decisions you’ll still feel comfortable with in five and ten years’ time."
         },
         {
           "id": "cta_gold_bar",
@@ -2428,7 +2614,7 @@
           "id": "team_intro_copy",
           "type": "copy-block",
           "title": "Our team",
-          "copy": "Dentistry works best when it\u2019s delivered by people who know each other well.\n\nAt St Mary\u2019s House Dental Care, we\u2019re a small, experienced team who work together every day \u2014 not a rotating cast. That continuity matters. It affects communication, planning, and how calmly care is delivered.\n\nPatients often tell us they value recognising familiar faces and feeling understood rather than processed.",
+          "copy": "Dentistry works best when it’s delivered by people who know each other well.\n\nAt St Mary’s House Dental Care, we’re a small, experienced team who work together every day — not a rotating cast. That continuity matters. It affects communication, planning, and how calmly care is delivered.\n\nPatients often tell us they value recognising familiar faces and feeling understood rather than processed.",
           "label": "Team"
         },
         {
@@ -2485,42 +2671,42 @@
               "role": "Practice Manager",
               "summary": "Joanna Dobson oversees the day-to-day running of the practice, supporting patients with clear communication and a calm, organised approach that helps visits feel smooth and well-coordinated.",
               "imageSrc": "placeholder",
-              "imageAlt": "Joanna Dobson, Practice Manager at St Mary\u2019s House Dental Care, Shoreham-by-Sea"
+              "imageAlt": "Joanna Dobson, Practice Manager at St Mary’s House Dental Care, Shoreham-by-Sea"
             },
             {
               "name": "Riz Deen",
               "role": "Complex Treatment Co-ordinator",
               "summary": "Riz Deen supports patients through complex treatment planning, helping them understand options clearly and feel comfortable making decisions that fit their needs.",
               "imageSrc": "placeholder",
-              "imageAlt": "Riz Deen, Complex Treatment Co-ordinator at St Mary\u2019s House Dental Care, Shoreham-by-Sea"
+              "imageAlt": "Riz Deen, Complex Treatment Co-ordinator at St Mary’s House Dental Care, Shoreham-by-Sea"
             },
             {
               "name": "Gill Bentley",
               "role": "Head Nurse (GDC registered)",
               "summary": "Gill Bentley leads the nursing team with a calm, organised approach, supporting patient care while maintaining consistently high clinical and infection-control standards.",
               "imageSrc": "placeholder",
-              "imageAlt": "Gill Bentley, Head Dental Nurse at St Mary\u2019s House Dental Care, Shoreham-by-Sea"
+              "imageAlt": "Gill Bentley, Head Dental Nurse at St Mary’s House Dental Care, Shoreham-by-Sea"
             },
             {
               "name": "Sophia Ball",
               "role": "Dental Nurse & Receptionist (GDC registered)",
               "summary": "Sophia Ball supports patients both at reception and in surgery, helping visits feel calm, informed and well-coordinated through clear communication and reassurance.",
               "imageSrc": "placeholder",
-              "imageAlt": "Sophia Ball, Dental Nurse and Receptionist at St Mary\u2019s House Dental Care, Shoreham-by-Sea"
+              "imageAlt": "Sophia Ball, Dental Nurse and Receptionist at St Mary’s House Dental Care, Shoreham-by-Sea"
             },
             {
               "name": "Molly Pearce",
               "role": "Dental Nurse (GDC registered)",
               "summary": "Molly Pearce supports patients with a calm, detail-focused approach, helping appointments feel steady and well supported, particularly for nervous patients.",
               "imageSrc": "placeholder",
-              "imageAlt": "Molly Pearce, Dental Nurse at St Mary\u2019s House Dental Care, Shoreham-by-Sea"
+              "imageAlt": "Molly Pearce, Dental Nurse at St Mary’s House Dental Care, Shoreham-by-Sea"
             },
             {
               "name": "Marianne Fawbert",
               "role": "Receptionist",
               "summary": "Marianne Fawbert supports patients at reception, helping appointments run smoothly through careful organisation and clear, helpful communication.",
               "imageSrc": "placeholder",
-              "imageAlt": "Marianne Fawbert, Receptionist at St Mary\u2019s House Dental Care, Shoreham-by-Sea"
+              "imageAlt": "Marianne Fawbert, Receptionist at St Mary’s House Dental Care, Shoreham-by-Sea"
             }
           ]
         },
@@ -2568,25 +2754,25 @@
           "id": "profile_intro",
           "type": "copy-block",
           "label": "Profile intro",
-          "copy": "Dr Nick Maxwell\nPrincipal Dentist \u00b7 Restorative, Aesthetic & Digital Dentistry\n\nI\u2019m Dr Nick Maxwell, principal dentist at St Mary\u2019s House Dental Care in Shoreham-by-Sea.\nI\u2019ve been practising dentistry since 1998 and have spent much of my career focused on the kind of dentistry that needs calm judgment: complex restorative work, aesthetic planning, bite stability, and carefully selected implant and orthodontic cases.\nMy aim is simple: help patients make decisions they can feel good about years from now \u2014 not just next month."
+          "copy": "Dr Nick Maxwell\nPrincipal Dentist · Restorative, Aesthetic & Digital Dentistry\n\nI’m Dr Nick Maxwell, principal dentist at St Mary’s House Dental Care in Shoreham-by-Sea.\nI’ve been practising dentistry since 1998 and have spent much of my career focused on the kind of dentistry that needs calm judgment: complex restorative work, aesthetic planning, bite stability, and carefully selected implant and orthodontic cases.\nMy aim is simple: help patients make decisions they can feel good about years from now — not just next month."
         },
         {
           "id": "profile_credentials",
           "type": "copy-block",
           "label": "Credentials",
-          "copy": "Qualifications and training\n\nI hold:\n\u2022 BDS (King\u2019s College London)\n\u2022 MSc Restorative & Aesthetic Dentistry\n\u2022 PGDip Orthodontics & Facial Orthopaedics\nI\u2019ve also completed implant surgical training and intensive implant placement training (Cairo, 2014).\nQualifications matter, but what matters most is what they change in day-to-day care: the ability to plan, select cases carefully, and avoid unnecessary intervention."
+          "copy": "Qualifications and training\n\nI hold:\n• BDS (King’s College London)\n• MSc Restorative & Aesthetic Dentistry\n• PGDip Orthodontics & Facial Orthopaedics\nI’ve also completed implant surgical training and intensive implant placement training (Cairo, 2014).\nQualifications matter, but what matters most is what they change in day-to-day care: the ability to plan, select cases carefully, and avoid unnecessary intervention."
         },
         {
           "id": "profile_philosophy",
           "type": "copy-block",
           "label": "Care philosophy",
-          "copy": "How I work\n\nDentistry can be rushed. It can also be over-sold. I\u2019m not interested in either.\nMy approach is deliberately planning-first and case-by-case:\n\u2022 We start with diagnosis and stability, not \u201cwhat you\u2019d like done\u201d\n\u2022 We talk honestly about trade-offs and limitations\n\u2022 I\u2019m happy to recommend the simplest sensible option \u2014 and equally happy to advise against treatment that isn\u2019t in your long-term interest\nThat\u2019s what I mean by \u201csleep-at-night dentistry\u201d."
+          "copy": "How I work\n\nDentistry can be rushed. It can also be over-sold. I’m not interested in either.\nMy approach is deliberately planning-first and case-by-case:\n• We start with diagnosis and stability, not “what you’d like done”\n• We talk honestly about trade-offs and limitations\n• I’m happy to recommend the simplest sensible option — and equally happy to advise against treatment that isn’t in your long-term interest\nThat’s what I mean by “sleep-at-night dentistry”."
         },
         {
           "id": "profile_additional_media",
           "type": "copy-block",
           "label": "Additional media",
-          "copy": "Digital dentistry and 3D planning\n\nOver the past several years I\u2019ve developed a strong focus on digital dentistry \u2014 not as a gimmick, but as a way to plan more precisely and communicate more clearly.\nThis includes:\n\u2022 digital planning workflows for restorative and implant cases\n\u2022 CBCT-based assessment where appropriate\n\u2022 designing and 3D-printing surgical guides for guided implant placement\n\u2022 a strong emphasis on predictability and maintainability\nTechnology doesn\u2019t replace clinical judgment \u2014 but used properly, it helps reduce uncertainty and improves decision-making.\n\nPatients often come to see me when they want a calm, honest second opinion, a long-term plan rather than a quick fix, and careful aesthetic work that still respects tooth structure. If you\u2019re looking for rushed dentistry, I won\u2019t be the right fit. If you want careful, clinician-led planning, you probably will."
+          "copy": "Digital dentistry and 3D planning\n\nOver the past several years I’ve developed a strong focus on digital dentistry — not as a gimmick, but as a way to plan more precisely and communicate more clearly.\nThis includes:\n• digital planning workflows for restorative and implant cases\n• CBCT-based assessment where appropriate\n• designing and 3D-printing surgical guides for guided implant placement\n• a strong emphasis on predictability and maintainability\nTechnology doesn’t replace clinical judgment — but used properly, it helps reduce uncertainty and improves decision-making.\n\nPatients often come to see me when they want a calm, honest second opinion, a long-term plan rather than a quick fix, and careful aesthetic work that still respects tooth structure. If you’re looking for rushed dentistry, I won’t be the right fit. If you want careful, clinician-led planning, you probably will."
         },
         {
           "id": "team_connection_cta",
@@ -2632,19 +2818,19 @@
           "id": "profile_intro",
           "type": "copy-block",
           "label": "Profile intro",
-          "copy": "Dr Sylvia Krafft is an Associate Dentist at St Mary\u2019s House Dental Care in Shoreham-by-Sea. She qualified as a Zahnarzt (Dental Surgeon) at the University of Cologne and has over 20 years\u2019 experience working in general dentistry across Germany, the United States and the United Kingdom.\n\nPatients commonly see Dr Krafft for general dental care, prevention-focused treatment and aesthetic dentistry delivered with a conservative, minimally invasive approach. She has a particular interest in improving the appearance of teeth in ways that remain biologically sound and appropriate for long-term oral health.\n\nSince relocating to the UK in 2009, Dr Krafft has worked extensively in both NHS and private practice. Her international background allows her to draw on a broad range of clinical perspectives, supporting thoughtful, individualised care for patients of all ages.\n\nShe is especially valued by patients who want careful explanations, realistic expectations and treatment that enhances confidence without unnecessary intervention."
+          "copy": "Dr Sylvia Krafft is an Associate Dentist at St Mary’s House Dental Care in Shoreham-by-Sea. She qualified as a Zahnarzt (Dental Surgeon) at the University of Cologne and has over 20 years’ experience working in general dentistry across Germany, the United States and the United Kingdom.\n\nPatients commonly see Dr Krafft for general dental care, prevention-focused treatment and aesthetic dentistry delivered with a conservative, minimally invasive approach. She has a particular interest in improving the appearance of teeth in ways that remain biologically sound and appropriate for long-term oral health.\n\nSince relocating to the UK in 2009, Dr Krafft has worked extensively in both NHS and private practice. Her international background allows her to draw on a broad range of clinical perspectives, supporting thoughtful, individualised care for patients of all ages.\n\nShe is especially valued by patients who want careful explanations, realistic expectations and treatment that enhances confidence without unnecessary intervention."
         },
         {
           "id": "profile_credentials",
           "type": "copy-block",
           "label": "Credentials",
-          "copy": "Dr Krafft qualified as a Zahnarzt (Dental Surgeon) at the University of Cologne (Zahnklinik K\u00f6ln) in 2001. In addition to her dental qualification, she is also a trained dental technician, giving her a detailed understanding of dental materials, morphology and precision.\n\nEarly in her career, she worked in general practice in Germany before moving to the United States, where she volunteered at a dental charity hospital in Miami. This experience reinforced her commitment to ethical, patient-centred care and to providing treatment that balances clinical need with individual circumstance.\n\nSince moving to the UK in 2009, Dr Krafft has gained over 15 years\u2019 experience across NHS and private dentistry. She has developed a particular interest in aesthetic dentistry delivered conservatively, focusing on proportion, harmony and tooth preservation rather than aggressive cosmetic change.\n\nHer background as both clinician and technician informs a careful, detail-led approach, especially when planning aesthetic or restorative work. GDC: 174528."
+          "copy": "Dr Krafft qualified as a Zahnarzt (Dental Surgeon) at the University of Cologne (Zahnklinik Köln) in 2001. In addition to her dental qualification, she is also a trained dental technician, giving her a detailed understanding of dental materials, morphology and precision.\n\nEarly in her career, she worked in general practice in Germany before moving to the United States, where she volunteered at a dental charity hospital in Miami. This experience reinforced her commitment to ethical, patient-centred care and to providing treatment that balances clinical need with individual circumstance.\n\nSince moving to the UK in 2009, Dr Krafft has gained over 15 years’ experience across NHS and private dentistry. She has developed a particular interest in aesthetic dentistry delivered conservatively, focusing on proportion, harmony and tooth preservation rather than aggressive cosmetic change.\n\nHer background as both clinician and technician informs a careful, detail-led approach, especially when planning aesthetic or restorative work. GDC: 174528."
         },
         {
           "id": "profile_philosophy",
           "type": "copy-block",
           "label": "Care philosophy",
-          "copy": "Dr Krafft\u2019s clinical approach is centred on prevention, minimal intervention and patient understanding. She believes that aesthetic dentistry should enhance natural features rather than replace them, and that successful outcomes depend on respecting the biology of teeth and gums.\n\nShe prioritises conservative solutions wherever possible and takes time to explain options clearly, including what can be achieved predictably and what may introduce unnecessary risk. Patients are encouraged to make informed decisions at a pace that feels comfortable, with realistic expectations set from the outset.\n\nFor patients who feel anxious, Dr Krafft focuses on building trust through calm communication and a supportive, unhurried approach. Treatment is adapted to individual comfort levels, and patients are kept fully informed and in control throughout their care.\n\nHer dual training as a dentist and dental technician supports a precise, considered approach to both aesthetic and functional treatment. Long-term oral health, stability and maintainability are always prioritised over short-term cosmetic change."
+          "copy": "Dr Krafft’s clinical approach is centred on prevention, minimal intervention and patient understanding. She believes that aesthetic dentistry should enhance natural features rather than replace them, and that successful outcomes depend on respecting the biology of teeth and gums.\n\nShe prioritises conservative solutions wherever possible and takes time to explain options clearly, including what can be achieved predictably and what may introduce unnecessary risk. Patients are encouraged to make informed decisions at a pace that feels comfortable, with realistic expectations set from the outset.\n\nFor patients who feel anxious, Dr Krafft focuses on building trust through calm communication and a supportive, unhurried approach. Treatment is adapted to individual comfort levels, and patients are kept fully informed and in control throughout their care.\n\nHer dual training as a dentist and dental technician supports a precise, considered approach to both aesthetic and functional treatment. Long-term oral health, stability and maintainability are always prioritised over short-term cosmetic change."
         },
         {
           "id": "profile_additional_media",
@@ -2696,7 +2882,7 @@
           "id": "profile_intro",
           "type": "copy-block",
           "label": "Profile intro",
-          "copy": "Sara Burden is a Dental Hygienist at St Mary\u2019s House Dental Care, with over 30 years\u2019 experience in dental hygiene. She qualified from Birmingham Dental School in 1990 and has worked across general practice, specialist care and research settings.\n\nPatients commonly see Sara for periodontal care, maintenance appointments and support with gum health, particularly where long-term stability is essential. She is known for her gentle, thorough approach and for helping patients feel at ease, especially those who may feel anxious about hygiene treatment.\n\nSara plays an important role within the practice\u2019s preventative and long-term care philosophy, working closely with the dentists to support restorative and implant treatment planning through ongoing periodontal health."
+          "copy": "Sara Burden is a Dental Hygienist at St Mary’s House Dental Care, with over 30 years’ experience in dental hygiene. She qualified from Birmingham Dental School in 1990 and has worked across general practice, specialist care and research settings.\n\nPatients commonly see Sara for periodontal care, maintenance appointments and support with gum health, particularly where long-term stability is essential. She is known for her gentle, thorough approach and for helping patients feel at ease, especially those who may feel anxious about hygiene treatment.\n\nSara plays an important role within the practice’s preventative and long-term care philosophy, working closely with the dentists to support restorative and implant treatment planning through ongoing periodontal health."
         },
         {
           "id": "profile_credentials",
@@ -2708,7 +2894,7 @@
           "id": "profile_philosophy",
           "type": "copy-block",
           "label": "Care philosophy",
-          "copy": "Sara\u2019s approach to dental hygiene is preventative, methodical and patient-focused. She believes effective periodontal care relies on understanding, consistency and realistic guidance that patients can apply between visits.\n\nShe takes time to explain findings clearly, discuss contributing factors and demonstrate techniques where helpful, allowing patients to feel informed rather than overwhelmed. Appointments are unhurried and adapted to individual comfort levels, with particular consideration given to patients who may feel nervous or sensitive.\n\nSara places strong emphasis on long-term maintenance, recognising that stable gum health is essential for both natural teeth and restorative work. Her aim is to support predictable, sustainable oral health outcomes through collaborative care and clear communication."
+          "copy": "Sara’s approach to dental hygiene is preventative, methodical and patient-focused. She believes effective periodontal care relies on understanding, consistency and realistic guidance that patients can apply between visits.\n\nShe takes time to explain findings clearly, discuss contributing factors and demonstrate techniques where helpful, allowing patients to feel informed rather than overwhelmed. Appointments are unhurried and adapted to individual comfort levels, with particular consideration given to patients who may feel nervous or sensitive.\n\nSara places strong emphasis on long-term maintenance, recognising that stable gum health is essential for both natural teeth and restorative work. Her aim is to support predictable, sustainable oral health outcomes through collaborative care and clear communication."
         },
         {
           "id": "profile_additional_media",
@@ -2773,7 +2959,7 @@
           "id": "fees_what_fees_include",
           "type": "copy-block",
           "title": "What our fees include",
-          "copy": "Our fees are not just for the treatment you receive on the day. They reflect the full clinical process, which may include:\n\n\u2022 detailed assessment and diagnosis\n\u2022 digital imaging and planning where appropriate\n\u2022 high-quality materials and laboratory work\n\u2022 time for careful, unhurried delivery\n\u2022 follow-up care and review\n\nThis approach supports safe, well-planned care that is tailored to you \u2014 not simply completed quickly.",
+          "copy": "Our fees are not just for the treatment you receive on the day. They reflect the full clinical process, which may include:\n\n• detailed assessment and diagnosis\n• digital imaging and planning where appropriate\n• high-quality materials and laboratory work\n• time for careful, unhurried delivery\n• follow-up care and review\n\nThis approach supports safe, well-planned care that is tailored to you — not simply completed quickly.",
           "label": "What our fees include"
         },
         {
@@ -2787,7 +2973,7 @@
           "id": "fees_finance_and_affordability",
           "type": "copy-block",
           "title": "Finance and affordability",
-          "copy": "Payment is usually taken at the time of treatment. For larger treatment plans, finance options may be available to help spread the cost.\n\nIf finance is something you would like to consider, we can explain how it works and whether it may be suitable for your situation.\n\nWe\u2019ll always explain costs clearly before treatment starts, so you\u2019re not faced with surprises.",
+          "copy": "Payment is usually taken at the time of treatment. For larger treatment plans, finance options may be available to help spread the cost.\n\nIf finance is something you would like to consider, we can explain how it works and whether it may be suitable for your situation.\n\nWe’ll always explain costs clearly before treatment starts, so you’re not faced with surprises.",
           "label": "Finance and affordability"
         },
         {
@@ -2829,8 +3015,8 @@
         {
           "id": "contact_intro_copy",
           "type": "copy-block",
-          "title": "Contact St Mary\u2019s House Dental Care",
-          "copy": "Getting in touch should feel straightforward.\n\nWhether you\u2019d like to arrange an appointment, ask a question, or talk something through before deciding what to do next, our team will help guide you calmly and clearly.\n\nThere\u2019s no obligation to proceed with treatment simply by contacting us. Many people get in touch because they want to understand their options, what an initial appointment involves, or whether something sounds urgent.\n\nWe\u2019re a private dental practice based in Shoreham-by-Sea, and we see patients with a wide range of concerns \u2014 from routine check-ups to more complex dental problems.\n\nIf you feel unsure, or it\u2019s been a while since you last saw a dentist, that\u2019s very common. Let us know when you contact us and we can take things at a pace that feels manageable.",
+          "title": "Contact St Mary’s House Dental Care",
+          "copy": "Getting in touch should feel straightforward.\n\nWhether you’d like to arrange an appointment, ask a question, or talk something through before deciding what to do next, our team will help guide you calmly and clearly.\n\nThere’s no obligation to proceed with treatment simply by contacting us. Many people get in touch because they want to understand their options, what an initial appointment involves, or whether something sounds urgent.\n\nWe’re a private dental practice based in Shoreham-by-Sea, and we see patients with a wide range of concerns — from routine check-ups to more complex dental problems.\n\nIf you feel unsure, or it’s been a while since you last saw a dentist, that’s very common. Let us know when you contact us and we can take things at a pace that feels manageable.",
           "label": "Contact"
         },
         {
@@ -2839,8 +3025,8 @@
           "title": "Practice details",
           "items": [
             "Phone, email and opening hours are shown below",
-            "If you\u2019re unsure which appointment you need, tell us what\u2019s been happening",
-            "For urgent dental problems, it\u2019s best to telephone the practice during opening hours"
+            "If you’re unsure which appointment you need, tell us what’s been happening",
+            "For urgent dental problems, it’s best to telephone the practice during opening hours"
           ],
           "label": "Details"
         },
@@ -2860,7 +3046,7 @@
           "id": "contact_form_placeholder",
           "type": "copy-block",
           "title": "How to contact us",
-          "copy": "You\u2019re welcome to contact the practice by phone or by using the enquiry form on this page.\n\nIf your question is straightforward, our reception team can usually help directly. If it\u2019s more clinical, we\u2019ll make sure it\u2019s passed to the right person.\n\nMessages are read during normal opening hours and we aim to respond as promptly as we can. Email and online enquiries aren\u2019t suitable for urgent dental problems.\n\nAny information provided before an appointment is general in nature and can\u2019t replace a clinical assessment. Treatment recommendations, where appropriate, are only made after we\u2019ve seen you and discussed your individual circumstances.",
+          "copy": "You’re welcome to contact the practice by phone or by using the enquiry form on this page.\n\nIf your question is straightforward, our reception team can usually help directly. If it’s more clinical, we’ll make sure it’s passed to the right person.\n\nMessages are read during normal opening hours and we aim to respond as promptly as we can. Email and online enquiries aren’t suitable for urgent dental problems.\n\nAny information provided before an appointment is general in nature and can’t replace a clinical assessment. Treatment recommendations, where appropriate, are only made after we’ve seen you and discussed your individual circumstances.",
           "label": "Contact form"
         },
         {
@@ -2868,7 +3054,7 @@
           "type": "map",
           "label": "Map",
           "title": "Finding the practice",
-          "copy": "St Mary\u2019s House Dental Care is located in Shoreham-by-Sea, West Sussex.\n\nClear directions, accessibility information, and parking details are provided below to help your visit go smoothly.",
+          "copy": "St Mary’s House Dental Care is located in Shoreham-by-Sea, West Sussex.\n\nClear directions, accessibility information, and parking details are provided below to help your visit go smoothly.",
           "mediaHint": "Contact page map placeholder"
         },
         {
@@ -2961,7 +3147,7 @@
           "type": "copy-block",
           "title": "Care downloads",
           "label": "Overview",
-          "copy": "The documents on this page are provided to support your care with us.\n\nThey may include aftercare guidance, treatment information, and practical notes that are useful before or after an appointment. Not every document will apply to everyone, and some information is only relevant in certain situations.\n\nIf you\u2019ve been given a specific document by the team, you can usually find it here. If you\u2019re unsure which information applies to you, or if something isn\u2019t clear, we\u2019re always happy to help explain.\n\nWritten guidance is helpful, but it can\u2019t replace a proper conversation or clinical assessment. If something doesn\u2019t feel right, or you have concerns following treatment, it\u2019s important to contact the practice rather than relying only on written information.\n\nThe documents here are reviewed from time to time, so you may notice updates as guidance changes.\n\n---"
+          "copy": "The documents on this page are provided to support your care with us.\n\nThey may include aftercare guidance, treatment information, and practical notes that are useful before or after an appointment. Not every document will apply to everyone, and some information is only relevant in certain situations.\n\nIf you’ve been given a specific document by the team, you can usually find it here. If you’re unsure which information applies to you, or if something isn’t clear, we’re always happy to help explain.\n\nWritten guidance is helpful, but it can’t replace a proper conversation or clinical assessment. If something doesn’t feel right, or you have concerns following treatment, it’s important to contact the practice rather than relying only on written information.\n\nThe documents here are reviewed from time to time, so you may notice updates as guidance changes.\n\n---"
         },
         {
           "id": "downloads_contact_cta",
@@ -2995,7 +3181,7 @@
           "type": "copy-block",
           "title": "Privacy and your information",
           "label": "Overview",
-          "copy": "This privacy notice explains how St Mary\u2019s House Dental Care uses and protects personal information.\n\nWe are committed to handling personal data responsibly and in line with UK data protection law.\n\nWe may collect personal information when you contact the practice, book an appointment, complete forms, or use this website.\n\nThis can include contact details, appointment information, and technical data such as IP address and browser type when you use the site.\n\nPersonal information is used to provide dental care, manage appointments, communicate with you, and meet our legal and professional obligations.\n\nWe do not sell personal data and only share information where necessary for care, administration, or legal reasons.\n\nWe take appropriate steps to keep personal information secure, including access controls and secure systems.\n\nData is kept only for as long as required by clinical, legal, or regulatory obligations.\n\nYou have rights under UK data protection law, including the right to access your information and request corrections.\n\nIf you have questions about how your data is used, or wish to exercise your rights, please contact the practice.\n\nThis privacy notice may be updated from time to time to reflect changes in law or how we operate.\n\nThe current version will always be available on this website."
+          "copy": "This privacy notice explains how St Mary’s House Dental Care uses and protects personal information.\n\nWe are committed to handling personal data responsibly and in line with UK data protection law.\n\nWe may collect personal information when you contact the practice, book an appointment, complete forms, or use this website.\n\nThis can include contact details, appointment information, and technical data such as IP address and browser type when you use the site.\n\nPersonal information is used to provide dental care, manage appointments, communicate with you, and meet our legal and professional obligations.\n\nWe do not sell personal data and only share information where necessary for care, administration, or legal reasons.\n\nWe take appropriate steps to keep personal information secure, including access controls and secure systems.\n\nData is kept only for as long as required by clinical, legal, or regulatory obligations.\n\nYou have rights under UK data protection law, including the right to access your information and request corrections.\n\nIf you have questions about how your data is used, or wish to exercise your rights, please contact the practice.\n\nThis privacy notice may be updated from time to time to reflect changes in law or how we operate.\n\nThe current version will always be available on this website."
         },
         {
           "id": "legal_terms",
@@ -3011,7 +3197,7 @@
             },
             {
               "title": "Who we share it with",
-              "copy": "We do not sell personal data. We only share information when it\u2019s necessary for care, administration, or legal reasons, and we aim to share the minimum needed."
+              "copy": "We do not sell personal data. We only share information when it’s necessary for care, administration, or legal reasons, and we aim to share the minimum needed."
             },
             {
               "title": "How long we keep it",
@@ -3089,7 +3275,7 @@
           "type": "copy-block",
           "title": "Using this website",
           "label": "Overview",
-          "copy": "These website terms explain how you may use this site and what the information here is (and isn\u2019t) intended for.\n\nThe content on this website is provided for general information only. It is not a substitute for a dental examination, diagnosis, or personalised advice.\n\nIf you have a dental problem, pain, swelling, trauma, or anything you\u2019re worried about, please contact the practice so we can advise you appropriately."
+          "copy": "These website terms explain how you may use this site and what the information here is (and isn’t) intended for.\n\nThe content on this website is provided for general information only. It is not a substitute for a dental examination, diagnosis, or personalised advice.\n\nIf you have a dental problem, pain, swelling, trauma, or anything you’re worried about, please contact the practice so we can advise you appropriately."
         },
         {
           "id": "legal_terms",
@@ -3105,11 +3291,11 @@
             },
             {
               "title": "Your choices and controls",
-              "copy": "You are welcome to print or share pages for personal use, but please don\u2019t copy large parts of the site for commercial use.\n\nIf you\u2019re making decisions about treatment, the safest route is always an appointment where we can assess you properly and explain options, limits, and likely maintenance."
+              "copy": "You are welcome to print or share pages for personal use, but please don’t copy large parts of the site for commercial use.\n\nIf you’re making decisions about treatment, the safest route is always an appointment where we can assess you properly and explain options, limits, and likely maintenance."
             },
             {
               "title": "How to contact us",
-              "copy": "If you have questions about the website content, or you believe something is unclear or out of date, please contact the practice and we\u2019ll do our best to help.\n\nFor clinical concerns (pain, swelling, broken teeth, lost restorations, or anything urgent), please call us so we can guide you to the right next step."
+              "copy": "If you have questions about the website content, or you believe something is unclear or out of date, please contact the practice and we’ll do our best to help.\n\nFor clinical concerns (pain, swelling, broken teeth, lost restorations, or anything urgent), please call us so we can guide you to the right next step."
             },
             {
               "title": "Updates to this page",
@@ -3136,7 +3322,7 @@
           "type": "copy-block",
           "title": "Accessibility on our website",
           "label": "Overview",
-          "copy": "We want our website to be usable for as many people as possible. Accessibility is an ongoing process, and we aim to improve readability, navigation, and compatibility with assistive technologies over time. If you find any part of the site difficult to use \u2014 for example, problems with contrast, text size, forms, or keyboard navigation \u2014 please let us know. Where possible, we can provide information in an alternative format and record feedback for future improvements."
+          "copy": "We want our website to be usable for as many people as possible. Accessibility is an ongoing process, and we aim to improve readability, navigation, and compatibility with assistive technologies over time. If you find any part of the site difficult to use — for example, problems with contrast, text size, forms, or keyboard navigation — please let us know. Where possible, we can provide information in an alternative format and record feedback for future improvements."
         },
         {
           "id": "legal_terms",
@@ -3148,11 +3334,11 @@
             },
             {
               "title": "What you can do on your side",
-              "copy": "Many people improve readability using browser or device settings (text size, zoom, contrast modes, reader modes, and voice control). If you\u2019d like help finding those settings, let us know."
+              "copy": "Many people improve readability using browser or device settings (text size, zoom, contrast modes, reader modes, and voice control). If you’d like help finding those settings, let us know."
             },
             {
               "title": "Known limitations",
-              "copy": "Some third-party tools, embedded media, or older documents may not meet every accessibility standard in every situation. If you find something that isn\u2019t working for you, we want to know so we can look at alternatives."
+              "copy": "Some third-party tools, embedded media, or older documents may not meet every accessibility standard in every situation. If you find something that isn’t working for you, we want to know so we can look at alternatives."
             },
             {
               "title": "Alternative formats",
@@ -3183,7 +3369,7 @@
           "type": "copy-block",
           "title": "Raising concerns",
           "label": "Overview",
-          "copy": "If something hasn\u2019t felt right, we want to know.\n\nWe take complaints seriously and we aim to resolve concerns fairly, calmly, and as quickly as possible.\n\nIf you feel able, please raise the issue with us directly first. Most concerns can be resolved promptly once we understand what has happened and what you\u2019re worried about."
+          "copy": "If something hasn’t felt right, we want to know.\n\nWe take complaints seriously and we aim to resolve concerns fairly, calmly, and as quickly as possible.\n\nIf you feel able, please raise the issue with us directly first. Most concerns can be resolved promptly once we understand what has happened and what you’re worried about."
         },
         {
           "id": "legal_terms",
@@ -3195,7 +3381,7 @@
             },
             {
               "title": "Key points in plain English",
-              "copy": "- Tell us what happened and what outcome you\u2019re hoping for.\n- We will listen, review what we can, and respond clearly.\n- If we need time to investigate properly, we will tell you the expected timescales.\n- You can raise concerns in writing, by email, or by speaking to the team."
+              "copy": "- Tell us what happened and what outcome you’re hoping for.\n- We will listen, review what we can, and respond clearly.\n- If we need time to investigate properly, we will tell you the expected timescales.\n- You can raise concerns in writing, by email, or by speaking to the team."
             },
             {
               "title": "Your choices and controls",
@@ -3229,7 +3415,7 @@
           "id": "blog_intro_copy",
           "type": "copy-block",
           "title": "Practice insights",
-          "copy": "This is where we share practical notes and clinical insights from the practice.\n\nMost posts are written to help you make sense of common dental concerns, what tends to cause them, and what sensible next steps usually look like. From time to time we\u2019ll also explain how planning, scanning and modern materials can make treatment more predictable.\n\nEverything here is general information. It can be a useful starting point, but it can\u2019t replace advice tailored to you after an examination. If something you read here raises questions about your own teeth or gums, we\u2019re happy to talk it through at an appointment.\n\n---",
+          "copy": "This is where we share practical notes and clinical insights from the practice.\n\nMost posts are written to help you make sense of common dental concerns, what tends to cause them, and what sensible next steps usually look like. From time to time we’ll also explain how planning, scanning and modern materials can make treatment more predictable.\n\nEverything here is general information. It can be a useful starting point, but it can’t replace advice tailored to you after an examination. If something you read here raises questions about your own teeth or gums, we’re happy to talk it through at an appointment.\n\n---",
           "label": "Insights"
         },
         {
@@ -3240,7 +3426,7 @@
             "Prevention and looking after teeth and gums between visits",
             "Common problems we see (tooth wear, sensitivity, gum issues) and what they can mean",
             "Treatment planning: what an assessment involves and why stages matter",
-            "Technology and materials \u2014 what they help with, and where the limits are"
+            "Technology and materials — what they help with, and where the limits are"
           ],
           "label": "Topics"
         }
@@ -3329,7 +3515,7 @@
           "id": "video_consultation_intro",
           "type": "copy-block",
           "title": "Remote guidance with a clinician",
-          "copy": "A video consultation can be a calm first step if you\u2019d like clinical guidance before coming into the practice.\n\nIt works well for discussing symptoms, reviewing your history, talking through options, and planning what would be most useful to do in person. If something needs a hands-on examination, X-rays or scans, we\u2019ll be clear about that and help you book the right appointment.\n\nA video consultation is not designed for emergencies, significant swelling, trauma, or situations where you may need urgent clinical care. In those cases, please call us so we can advise promptly.",
+          "copy": "A video consultation can be a calm first step if you’d like clinical guidance before coming into the practice.\n\nIt works well for discussing symptoms, reviewing your history, talking through options, and planning what would be most useful to do in person. If something needs a hands-on examination, X-rays or scans, we’ll be clear about that and help you book the right appointment.\n\nA video consultation is not designed for emergencies, significant swelling, trauma, or situations where you may need urgent clinical care. In those cases, please call us so we can advise promptly.",
           "label": "Overview"
         },
         {
@@ -3429,7 +3615,7 @@
           "id": "finance_intro",
           "type": "copy-block",
           "title": "Finance support without pressure",
-          "copy": "Some patients prefer to spread the cost of dental treatment over time rather than paying for everything at once.\n\nFinance can be a practical option for larger treatment plans, but it isn\u2019t right for everyone and isn\u2019t a requirement for treatment.",
+          "copy": "Some patients prefer to spread the cost of dental treatment over time rather than paying for everything at once.\n\nFinance can be a practical option for larger treatment plans, but it isn’t right for everyone and isn’t a requirement for treatment.",
           "label": "Overview"
         },
         {
@@ -3556,7 +3742,7 @@
             },
             {
               "title": "Digital smile design",
-              "description": "Visual planning to guide decisions\u2014helpful, but never a guarantee.",
+              "description": "Visual planning to guide decisions—helpful, but never a guarantee.",
               "href": "/treatments/digital-smile-design"
             },
             {
@@ -3599,7 +3785,7 @@
             "preset": "primary"
           },
           {
-            "label": "What\u2019s included in a check-up?",
+            "label": "What’s included in a check-up?",
             "href": "/dental-checkups-oral-cancer-screening",
             "preset": "secondary"
           }
@@ -3611,7 +3797,7 @@
             "preset": "primary"
           },
           {
-            "label": "What\u2019s included in a check-up?",
+            "label": "What’s included in a check-up?",
             "href": "/dental-checkups-oral-cancer-screening",
             "preset": "secondary"
           }
@@ -3622,7 +3808,7 @@
           "id": "practice_plan_intro",
           "type": "copy-block",
           "title": "Membership that keeps care consistent",
-          "copy": "A dental practice plan is designed to help patients look after their oral health on an ongoing basis, rather than focusing only on treatment when problems arise.\n\nIt spreads the cost of routine dental care and encourages regular review, prevention, and early intervention where needed.\n\nWe\u2019ll explain what is included, what isn\u2019t, and how often appointments are recommended for you personally. If you\u2019re comparing options, we can also talk through pay-as-you-go fees so you can choose what fits best.",
+          "copy": "A dental practice plan is designed to help patients look after their oral health on an ongoing basis, rather than focusing only on treatment when problems arise.\n\nIt spreads the cost of routine dental care and encourages regular review, prevention, and early intervention where needed.\n\nWe’ll explain what is included, what isn’t, and how often appointments are recommended for you personally. If you’re comparing options, we can also talk through pay-as-you-go fees so you can choose what fits best.",
           "label": "Overview"
         },
         {
@@ -3671,7 +3857,7 @@
               "preset": "primary"
             },
             {
-              "label": "What\u2019s included in a check-up?",
+              "label": "What’s included in a check-up?",
               "href": "/dental-checkups-oral-cancer-screening",
               "preset": "secondary"
             }
@@ -3764,7 +3950,7 @@
               "preset": "secondary"
             },
             {
-              "label": "Children\u2019s dental care",
+              "label": "Children’s dental care",
               "href": "/treatments/childrens-dentistry",
               "preset": "secondary"
             },
@@ -3907,7 +4093,7 @@
               "preset": "secondary"
             },
             {
-              "label": "Children\u2019s dental care",
+              "label": "Children’s dental care",
               "href": "/treatments/childrens-dentistry",
               "preset": "secondary"
             },
@@ -4981,12 +5167,12 @@
           "type": "copy-block",
           "title": "Conservative improvements, well planned",
           "label": "Introduction",
-          "copy": "Composite bonding uses tooth-coloured resin to improve shape, close small gaps, repair chips, or soften uneven edges. It can often be done with minimal drilling, making it a conservative option when the bite and enamel are suitable. We begin with an assessment of wear, staining, gum health and bite forces, because those factors determine how predictable bonding will be over time. For some patients, whitening or aligner straightening first can improve the final result and reduce the amount of composite needed. If bonding is a good fit, we\u2019ll explain what it can achieve, how it\u2019s maintained, and what to expect with polishing and repairs."
+          "copy": "Composite bonding uses tooth-coloured resin to improve shape, close small gaps, repair chips, or soften uneven edges. It can often be done with minimal drilling, making it a conservative option when the bite and enamel are suitable. We begin with an assessment of wear, staining, gum health and bite forces, because those factors determine how predictable bonding will be over time. For some patients, whitening or aligner straightening first can improve the final result and reduce the amount of composite needed. If bonding is a good fit, we’ll explain what it can achieve, how it’s maintained, and what to expect with polishing and repairs."
         },
         {
           "id": "composite_indications",
           "type": "features",
-          "title": "What composite bonding can and can\u2019t do",
+          "title": "What composite bonding can and can’t do",
           "items": [
             "Adds volume to close small gaps, soften edges, and refine proportions without drilling healthy enamel",
             "Repairs chipped or worn incisal edges; larger fractures or weakened teeth may need onlays or crowns",
@@ -5023,7 +5209,7 @@
             "When colour is the main concern, dentist-led whitening is usually recommended before bonding so shades align",
             "If teeth are rotated or crowded, aligners or other orthodontic treatment can set the foundation before cosmetic bonding",
             "For larger shape changes or durability, porcelain veneers or digitally designed 3D veneers may be more appropriate",
-            "Composite bonding often forms part of an Align \u2192 Bleach \u2192 Composite pathway, with veneers reserved for specific needs"
+            "Composite bonding often forms part of an Align → Bleach → Composite pathway, with veneers reserved for specific needs"
           ]
         },
         {
@@ -5040,7 +5226,7 @@
         {
           "id": "composite_not_suited",
           "type": "features",
-          "title": "When bonding isn\u2019t the best choice",
+          "title": "When bonding isn’t the best choice",
           "items": [
             "Heavy bites or active clenching with limited space may need occlusal therapy or guards first",
             "Severe wear or bite collapse often requires orthodontics, onlays, or veneers for stability",
@@ -5337,7 +5523,7 @@
           "type": "copy-block",
           "title": "Strength, function, and maintainability",
           "label": "Introduction",
-          "copy": "A dental crown is a protective restoration that covers and strengthens a tooth that is heavily filled, cracked, worn down, or has had root canal treatment. The goal is to restore function and protect the remaining tooth structure, while keeping the bite comfortable and the margins clean and maintainable. We plan crowns using a full assessment and digital scans so we can check contact points, bite forces and appearance before anything is finalised. Where appropriate, we\u2019ll discuss onlays or adhesive options that preserve more natural tooth. If a crown is recommended, we\u2019ll explain materials, preparation, and how to look after it."
+          "copy": "A dental crown is a protective restoration that covers and strengthens a tooth that is heavily filled, cracked, worn down, or has had root canal treatment. The goal is to restore function and protect the remaining tooth structure, while keeping the bite comfortable and the margins clean and maintainable. We plan crowns using a full assessment and digital scans so we can check contact points, bite forces and appearance before anything is finalised. Where appropriate, we’ll discuss onlays or adhesive options that preserve more natural tooth. If a crown is recommended, we’ll explain materials, preparation, and how to look after it."
         },
         {
           "id": "treatment_overview_copy"
@@ -5380,7 +5566,7 @@
         {
           "id": "restorative_full_inventory",
           "type": "routing_cards",
-          "title": "Restorative Dentistry \u2014 full treatment list",
+          "title": "Restorative Dentistry — full treatment list",
           "label": "Full list",
           "items": [
             {
@@ -5507,7 +5693,7 @@
           "id": "whitening_consult_overview",
           "type": "treatment_overview_rich",
           "title": "A measured plan tailored to your smile",
-          "copy": "We assess enamel, existing restorations, and gum health before prescribing a gel strength and schedule. You\u2019ll see a realistic shade range, understand how whitening supports planned alignment or bonding, and know when we\u2019ll review progress.",
+          "copy": "We assess enamel, existing restorations, and gum health before prescribing a gel strength and schedule. You’ll see a realistic shade range, understand how whitening supports planned alignment or bonding, and know when we’ll review progress.",
           "bullets": [
             "Clinical exam and baseline shade recording",
             "Digital scans for precise tray production",
@@ -5570,7 +5756,7 @@
         {
           "id": "aesthetic_full_inventory",
           "type": "routing_cards",
-          "title": "Aesthetic Dentistry \u2014 full treatment list",
+          "title": "Aesthetic Dentistry — full treatment list",
           "label": "Full list",
           "items": [
             {
@@ -5693,7 +5879,7 @@
           "faqs": [
             {
               "question": "How long will I wear the trays each day?",
-              "answer": "Most patients whiten for a set period each evening based on the prescribed gel. We\u2019ll agree the exact cadence with you."
+              "answer": "Most patients whiten for a set period each evening based on the prescribed gel. We’ll agree the exact cadence with you."
             },
             {
               "question": "What if my teeth feel sensitive?",
@@ -5757,7 +5943,7 @@
           "bullets": [
             "Shade comparison against your baseline",
             "Inspection of trays for seal and comfort",
-            "Discussion of how often you\u2019ll realistically top-up",
+            "Discussion of how often you’ll realistically top-up",
             "Guidance if restorations need refreshing instead of whitening",
             "Written instructions for the latest gel strength"
           ]
@@ -5793,7 +5979,7 @@
             },
             {
               "question": "Can I reuse my old trays?",
-              "answer": "Yes, provided the fit is still secure. We\u2019ll check for wear or gaps before supplying gel."
+              "answer": "Yes, provided the fit is still secure. We’ll check for wear or gaps before supplying gel."
             },
             {
               "question": "Will I need stronger gel each time?",
@@ -5874,7 +6060,7 @@
           "id": "whitening_sensitivity_mid_cta",
           "type": "treatment_mid_cta",
           "title": "Sensitivity-aware whitening options",
-          "strapline": "If sensitivity is the main issue, it can help to address the cause first \u2014 such as gum health, tooth wear, or hygiene care \u2014 then decide whether whitening still makes sense."
+          "strapline": "If sensitivity is the main issue, it can help to address the cause first — such as gum health, tooth wear, or hygiene care — then decide whether whitening still makes sense."
         },
         {
           "id": "whitening_sensitivity_faq",
@@ -5964,11 +6150,11 @@
             },
             {
               "question": "How long does whitening last?",
-              "answer": "Results are maintained with good hygiene and occasional top-ups. We\u2019ll guide you on a safe refresh schedule using your existing trays."
+              "answer": "Results are maintained with good hygiene and occasional top-ups. We’ll guide you on a safe refresh schedule using your existing trays."
             },
             {
               "question": "Is whitening part of a smile makeover?",
-              "answer": "Often yes. Whitening is the \u201cB\u201d in our Align, Bleach, Composite approach so colour is set before aligning teeth or adding bonding."
+              "answer": "Often yes. Whitening is the “B” in our Align, Bleach, Composite approach so colour is set before aligning teeth or adding bonding."
             }
           ]
         },
@@ -6063,7 +6249,7 @@
         {
           "id": "orthodontics_full_inventory",
           "type": "routing_cards",
-          "title": "Orthodontics & Retainers \u2014 full treatment list",
+          "title": "Orthodontics & Retainers — full treatment list",
           "label": "Full list",
           "items": [
             {
@@ -6122,7 +6308,7 @@
           "id": "full_smile_makeover_overview_rich",
           "type": "treatment_overview_rich",
           "title": "Smile makeovers guided by a shared plan",
-          "copy": "A full smile makeover is a way of looking at your teeth together, rather than treating individual problems in isolation. People often come to us with a mix of concerns \u2014 how their teeth look, how they function, or how they\u2019ve changed over time.\n\nRather than jumping straight to treatment, we start by understanding what matters to you and what\u2019s realistically achievable. In many cases, there is more than one way forward. Some options are simpler and more conservative, while others are more involved and take longer.\n\nOur role is to help you understand those options clearly, including their limits, so you can decide what feels right for you.\n\n---",
+          "copy": "A full smile makeover is a way of looking at your teeth together, rather than treating individual problems in isolation. People often come to us with a mix of concerns — how their teeth look, how they function, or how they’ve changed over time.\n\nRather than jumping straight to treatment, we start by understanding what matters to you and what’s realistically achievable. In many cases, there is more than one way forward. Some options are simpler and more conservative, while others are more involved and take longer.\n\nOur role is to help you understand those options clearly, including their limits, so you can decide what feels right for you.\n\n---",
           "bullets": [
             "Plan designed from scans and photos",
             "Sequence options reviewed together",
@@ -6146,7 +6332,7 @@
           "items": [
             {
               "title": "Digital smile design",
-              "description": "We start by understanding your concerns, examining your teeth and bite, and discussing what you\u2019d like to change. This helps identify which problems need addressing first and which can be left alone."
+              "description": "We start by understanding your concerns, examining your teeth and bite, and discussing what you’d like to change. This helps identify which problems need addressing first and which can be left alone."
             },
             {
               "title": "Phase timeline",
@@ -6162,7 +6348,7 @@
           "id": "full_smile_makeover_clinician_insight",
           "type": "clinician_insight",
           "label": "Clinician insight",
-          "quote": "A full smile makeover isn\u2019t a single treatment. It\u2019s a way of planning several treatments together so they work well as a whole.\n\nWhat that involves varies from person to person. For some, it may focus on alignment and tooth position. For others, it may involve whitening, bonding, veneers or restorative work to address wear, damage or long-standing problems.\n\nThe most important part is the assessment and planning stage. We take time to understand what\u2019s bothering you, examine your teeth and bite carefully, and look at what is realistically achievable. In many cases, treatment is staged over time rather than rushed.\n\nNot everyone needs a full smile makeover. Sometimes smaller, simpler steps can make a meaningful difference. Part of our role is helping you understand the options, the limitations, and what makes sense for you in the long term.",
+          "quote": "A full smile makeover isn’t a single treatment. It’s a way of planning several treatments together so they work well as a whole.\n\nWhat that involves varies from person to person. For some, it may focus on alignment and tooth position. For others, it may involve whitening, bonding, veneers or restorative work to address wear, damage or long-standing problems.\n\nThe most important part is the assessment and planning stage. We take time to understand what’s bothering you, examine your teeth and bite carefully, and look at what is realistically achievable. In many cases, treatment is staged over time rather than rushed.\n\nNot everyone needs a full smile makeover. Sometimes smaller, simpler steps can make a meaningful difference. Part of our role is helping you understand the options, the limitations, and what makes sense for you in the long term.",
           "attribution": "Clinical team",
           "role": "Smile design"
         },
@@ -6173,15 +6359,15 @@
           "title": "Makeover journeys",
           "stories": [
             {
-              "summary": "\u201cI wanted to improve how my teeth looked, but I was nervous about doing too much. We talked through different options and took things step by step, which made the whole process feel manageable.\u201d",
+              "summary": "“I wanted to improve how my teeth looked, but I was nervous about doing too much. We talked through different options and took things step by step, which made the whole process feel manageable.”",
               "name": "Case P"
             },
             {
-              "summary": "\u201cMy teeth had worn over time and I wasn\u2019t sure what could realistically be done. The planning stage helped me understand what was possible and what wasn\u2019t, before deciding how far to go.\u201d",
+              "summary": "“My teeth had worn over time and I wasn’t sure what could realistically be done. The planning stage helped me understand what was possible and what wasn’t, before deciding how far to go.”",
               "name": "Case Q"
             },
             {
-              "summary": "\u201cI didn\u2019t want anything rushed. Having time to think things through and spread treatment out made a big difference to how comfortable I felt.\u201d",
+              "summary": "“I didn’t want anything rushed. Having time to think things through and spread treatment out made a big difference to how comfortable I felt.”",
               "name": "Case R"
             }
           ]
@@ -6190,7 +6376,7 @@
           "id": "full_smile_makeover_mid_cta",
           "type": "treatment_mid_cta",
           "title": "Planning a wider smile change",
-          "strapline": "If you\u2019re considering a full smile makeover, the first step is a conversation. An assessment allows us to look at your teeth properly and talk through whether this approach makes sense for you."
+          "strapline": "If you’re considering a full smile makeover, the first step is a conversation. An assessment allows us to look at your teeth properly and talk through whether this approach makes sense for you."
         },
         {
           "id": "full_smile_makeover_faq",
@@ -6200,7 +6386,7 @@
           "faqs": [
             {
               "question": "Who is a full smile makeover for?",
-              "answer": "It may be suitable for people with several concerns they\u2019d like to address together, such as worn, discoloured, misaligned or damaged teeth. An assessment is needed to see whether this approach is appropriate."
+              "answer": "It may be suitable for people with several concerns they’d like to address together, such as worn, discoloured, misaligned or damaged teeth. An assessment is needed to see whether this approach is appropriate."
             },
             {
               "question": "What treatments might be involved?",
@@ -6208,11 +6394,11 @@
             },
             {
               "question": "How long does it take?",
-              "answer": "Timeframes vary. Some treatment plans take a few months, while others are staged over a longer period. We\u2019ll talk this through during planning so you know what to expect."
+              "answer": "Timeframes vary. Some treatment plans take a few months, while others are staged over a longer period. We’ll talk this through during planning so you know what to expect."
             },
             {
               "question": "Are there alternatives?",
-              "answer": "Yes. In many cases, more limited treatment can still improve appearance or function. We\u2019ll discuss alternatives and the likely trade-offs."
+              "answer": "Yes. In many cases, more limited treatment can still improve appearance or function. We’ll discuss alternatives and the likely trade-offs."
             },
             {
               "question": "How long do results last?",
@@ -6311,7 +6497,7 @@
         {
           "id": "digital_full_inventory",
           "type": "routing_cards",
-          "title": "3D & Digital Dentistry \u2014 full treatment list",
+          "title": "3D & Digital Dentistry — full treatment list",
           "label": "Full list",
           "items": [
             {
@@ -6394,9 +6580,9 @@
           "id": "emergency_dentistry_overview",
           "type": "treatment_overview_rich",
           "title": "Emergency dentistry",
-          "copy": "If you\u2019re in pain, have swelling, or you\u2019ve damaged a tooth, the first job is to work out what\u2019s urgent and what\u2019s fixable \u2014 calmly.\n\nEmergency care is usually about stabilising the situation: getting you comfortable, reducing risk, and planning the right longer-term repair.\n\nIf you\u2019re unsure whether you need to be seen quickly, contact us and we\u2019ll guide you.",
+          "copy": "If you’re in pain, have swelling, or you’ve damaged a tooth, the first job is to work out what’s urgent and what’s fixable — calmly.\n\nEmergency care is usually about stabilising the situation: getting you comfortable, reducing risk, and planning the right longer-term repair.\n\nIf you’re unsure whether you need to be seen quickly, contact us and we’ll guide you.",
           "bullets": [
-            "Assess what\u2019s happening and how urgent it is",
+            "Assess what’s happening and how urgent it is",
             "Settle pain and stabilise the problem safely",
             "Explain the next step and the longer-term plan"
           ]
@@ -6406,7 +6592,7 @@
           "type": "copy-block",
           "title": "How we handle dental emergencies",
           "label": "Introduction",
-          "copy": "Dental problems rarely arrive at a convenient time.\n\nWe\u2019ll listen to what\u2019s happening, ask a few focused questions, and advise whether it sounds urgent. If you need to be seen, we\u2019ll aim to book the right type of appointment rather than squeeze you into the wrong slot.\n\nIf there are signs of a serious spreading infection (rapid facial swelling, fever, difficulty swallowing, or breathing problems), seek urgent medical help immediately (A&E / 999) and then let us know as soon as you can."
+          "copy": "Dental problems rarely arrive at a convenient time.\n\nWe’ll listen to what’s happening, ask a few focused questions, and advise whether it sounds urgent. If you need to be seen, we’ll aim to book the right type of appointment rather than squeeze you into the wrong slot.\n\nIf there are signs of a serious spreading infection (rapid facial swelling, fever, difficulty swallowing, or breathing problems), seek urgent medical help immediately (A&E / 999) and then let us know as soon as you can."
         },
         {
           "id": "emergency_dentistry_triage",
@@ -6425,7 +6611,7 @@
           "type": "steps",
           "title": "What to do right now",
           "items": [
-            "Contact us with a short description of what\u2019s happened, where the pain is, and how long it has been going on",
+            "Contact us with a short description of what’s happened, where the pain is, and how long it has been going on",
             "Use normal pain relief if safe for you (follow the packet guidance) and avoid chewing on the painful side",
             "If you develop facial swelling, fever, difficulty swallowing, or breathing problems, seek urgent medical help"
           ]
@@ -6477,14 +6663,14 @@
           "type": "treatment_media_feature",
           "label": "Common emergency situations",
           "title": "What you can expect at an emergency visit",
-          "copy": "We\u2019ll focus on diagnosis and stabilisation.\n\nThat usually means an examination (and X-rays if needed), clear explanation of what we can see, and the least invasive step that reduces pain and risk. Sometimes that\u2019s a temporary measure with a planned follow-up. Sometimes it\u2019s a definitive repair \u2014 it depends on the tooth and the cause.\n\nWe\u2019ll explain costs and options before anything starts, so you can make a clear decision under pressure.",
+          "copy": "We’ll focus on diagnosis and stabilisation.\n\nThat usually means an examination (and X-rays if needed), clear explanation of what we can see, and the least invasive step that reduces pain and risk. Sometimes that’s a temporary measure with a planned follow-up. Sometimes it’s a definitive repair — it depends on the tooth and the cause.\n\nWe’ll explain costs and options before anything starts, so you can make a clear decision under pressure.",
           "mediaHint": "Calm, stepwise care"
         },
         {
           "id": "emergency_dentistry_next_steps",
           "type": "cta",
           "title": "After an emergency visit",
-          "copy": "Following emergency care, further treatment may be recommended to address the underlying cause.\n\nWe\u2019ll explain any findings clearly and discuss whether monitoring, further investigation, or planned treatment is appropriate.\n\nYou\u2019ll have time to consider options once the immediate situation has settled.",
+          "copy": "Following emergency care, further treatment may be recommended to address the underlying cause.\n\nWe’ll explain any findings clearly and discuss whether monitoring, further investigation, or planned treatment is appropriate.\n\nYou’ll have time to consider options once the immediate situation has settled.",
           "ctas": [
             {
               "label": "Book a check-up",
@@ -6506,11 +6692,11 @@
           "faqs": [
             {
               "question": "When urgent care may not be necessary",
-              "answer": "Some issues can wait a short time \u2014 for example, a small chip with no pain, a lost filling that isn\u2019t sensitive, or mild sensitivity that settles quickly.\n\nIf you\u2019re unsure, it\u2019s still worth contacting us. We can help you work out whether it sounds urgent, and what to do while you\u2019re waiting."
+              "answer": "Some issues can wait a short time — for example, a small chip with no pain, a lost filling that isn’t sensitive, or mild sensitivity that settles quickly.\n\nIf you’re unsure, it’s still worth contacting us. We can help you work out whether it sounds urgent, and what to do while you’re waiting."
             },
             {
               "question": "Questions and reassurance",
-              "answer": "If you\u2019re anxious, tell us. We\u2019ll take things step-by-step, explain what we\u2019re doing, and keep the plan simple.\n\nEmergency dentistry isn\u2019t about pressure-selling or starting big treatment on the spot. It\u2019s about getting you safe, comfortable, and clear on the next sensible step."
+              "answer": "If you’re anxious, tell us. We’ll take things step-by-step, explain what we’re doing, and keep the plan simple.\n\nEmergency dentistry isn’t about pressure-selling or starting big treatment on the spot. It’s about getting you safe, comfortable, and clear on the next sensible step."
             }
           ]
         },
@@ -6535,7 +6721,7 @@
         {
           "id": "emergency_full_inventory",
           "type": "routing_cards",
-          "title": "Emergency Dentistry \u2014 full treatment list",
+          "title": "Emergency Dentistry — full treatment list",
           "label": "Full list",
           "items": [
             {
@@ -6627,9 +6813,9 @@
           "id": "emergency_appointments_overview",
           "type": "treatment_overview_rich",
           "title": "Emergency dental appointments",
-          "copy": "If you\u2019re in pain, have swelling, or you\u2019ve damaged a tooth, an emergency appointment is about stabilising the situation.\n\nThat usually means diagnosis, getting you comfortable, reducing risk, and agreeing the next sensible step. Sometimes we can fix the problem on the day. Sometimes the safest care is staged.\n\nWe\u2019ll explain what we can see, what\u2019s realistic, and what you can do next \u2014 without pressure.",
+          "copy": "If you’re in pain, have swelling, or you’ve damaged a tooth, an emergency appointment is about stabilising the situation.\n\nThat usually means diagnosis, getting you comfortable, reducing risk, and agreeing the next sensible step. Sometimes we can fix the problem on the day. Sometimes the safest care is staged.\n\nWe’ll explain what we can see, what’s realistic, and what you can do next — without pressure.",
           "bullets": [
-            "Work out what\u2019s happening and how urgent it is",
+            "Work out what’s happening and how urgent it is",
             "Relieve pain and stabilise the tooth or gum",
             "Reduce risk of infection or worsening symptoms",
             "Plan the next step clearly and realistically"
@@ -6638,7 +6824,7 @@
         {
           "id": "treatment.heroIntro",
           "type": "copy-block",
-          "copy": "Dental problems rarely happen at a convenient time.\n\nIf you\u2019re not sure whether you need to be seen urgently, contact us. We\u2019ll ask a few focused questions and advise timing.\n\nIf you have rapid facial swelling, fever, difficulty swallowing, or breathing problems, seek urgent medical help immediately (A&E / 999) and then let us know as soon as you can."
+          "copy": "Dental problems rarely happen at a convenient time.\n\nIf you’re not sure whether you need to be seen urgently, contact us. We’ll ask a few focused questions and advise timing.\n\nIf you have rapid facial swelling, fever, difficulty swallowing, or breathing problems, seek urgent medical help immediately (A&E / 999) and then let us know as soon as you can."
         },
         {
           "id": "emergency_appointments_symptoms",
@@ -6657,7 +6843,7 @@
           "type": "steps",
           "title": "What to do now",
           "items": [
-            "Contact us and describe what\u2019s happened, where the pain is, and how long it has been going on",
+            "Contact us and describe what’s happened, where the pain is, and how long it has been going on",
             "Use normal pain relief if safe for you (follow the packet guidance)",
             "Avoid chewing on the painful side and stick to softer foods",
             "If swelling, fever, or swallowing/breathing issues develop, seek urgent medical help"
@@ -6667,7 +6853,7 @@
           "id": "emergency_appointments_importance",
           "type": "copy-block",
           "title": "Why assessment matters",
-          "copy": "Emergency care works best when we diagnose the cause properly, not just the symptom.\n\nPain can come from decay, infection, cracks, gum problems, or failed restorations \u2014 and the right solution depends on what we find.\n\nSeeing you early often gives more conservative options, better comfort, and fewer repeat flare-ups.",
+          "copy": "Emergency care works best when we diagnose the cause properly, not just the symptom.\n\nPain can come from decay, infection, cracks, gum problems, or failed restorations — and the right solution depends on what we find.\n\nSeeing you early often gives more conservative options, better comfort, and fewer repeat flare-ups.",
           "label": "Prompt care"
         },
         {
@@ -6675,7 +6861,7 @@
           "type": "treatment_media_feature",
           "label": "What we can do",
           "title": "What an emergency appointment can involve",
-          "copy": "An emergency visit usually includes an examination and, where appropriate, X-rays to understand what\u2019s happening under the surface.\n\nWe\u2019ll explain the likely cause, discuss options and costs, and agree the safest next step. That might be a temporary stabilisation, a simple repair, or a plan for staged treatment.\n\nOur aim is clarity, comfort, and a sensible route forward.",
+          "copy": "An emergency visit usually includes an examination and, where appropriate, X-rays to understand what’s happening under the surface.\n\nWe’ll explain the likely cause, discuss options and costs, and agree the safest next step. That might be a temporary stabilisation, a simple repair, or a plan for staged treatment.\n\nOur aim is clarity, comfort, and a sensible route forward.",
           "mediaHint": "Calm chairside care"
         },
         {
@@ -6691,15 +6877,15 @@
           "faqs": [
             {
               "question": "Can you always fix the problem on the day?",
-              "answer": "Not always \u2014 it depends on the cause and what\u2019s safest for the tooth. Sometimes we can provide a definitive repair. Other times the priority is stabilisation and pain control, followed by a planned appointment for the longer-term fix. We\u2019ll explain this clearly at the visit."
+              "answer": "Not always — it depends on the cause and what’s safest for the tooth. Sometimes we can provide a definitive repair. Other times the priority is stabilisation and pain control, followed by a planned appointment for the longer-term fix. We’ll explain this clearly at the visit."
             },
             {
               "question": "What if I am nervous about urgent treatment?",
-              "answer": "Tell us. We\u2019ll take a calm, step-by-step approach: clear explanation, breaks if you need them, and a plan that feels manageable. Emergency dentistry isn\u2019t about rushing you \u2014 it\u2019s about getting you safe and comfortable."
+              "answer": "Tell us. We’ll take a calm, step-by-step approach: clear explanation, breaks if you need them, and a plan that feels manageable. Emergency dentistry isn’t about rushing you — it’s about getting you safe and comfortable."
             },
             {
               "question": "Do I need a referral for an emergency visit?",
-              "answer": "No. You can contact the practice directly. If we think you need another service urgently (for example, medical assessment after trauma or signs of a serious spreading infection), we\u2019ll tell you clearly and help you choose the safest next step."
+              "answer": "No. You can contact the practice directly. If we think you need another service urgently (for example, medical assessment after trauma or signs of a serious spreading infection), we’ll tell you clearly and help you choose the safest next step."
             }
           ]
         },
@@ -6740,7 +6926,7 @@
           "id": "emergency_pain_overview",
           "type": "treatment_overview_rich",
           "title": "Severe toothache and dental pain",
-          "copy": "Severe toothache can feel urgent, and it\u2019s hard to think about anything else. Here in Shoreham-by-Sea, we see how quickly pain can disrupt sleep, eating, and work.\n\nPain relief can help you cope, but it doesn\u2019t fix the underlying cause. Toothache can come from decay, infection, cracks, gum problems, grinding, or a filling or crown that\u2019s failed.\n\nWe\u2019ll assess what\u2019s going on, explain what we can see, and recommend the most sensible way to settle pain and protect the tooth.",
+          "copy": "Severe toothache can feel urgent, and it’s hard to think about anything else. Here in Shoreham-by-Sea, we see how quickly pain can disrupt sleep, eating, and work.\n\nPain relief can help you cope, but it doesn’t fix the underlying cause. Toothache can come from decay, infection, cracks, gum problems, grinding, or a filling or crown that’s failed.\n\nWe’ll assess what’s going on, explain what we can see, and recommend the most sensible way to settle pain and protect the tooth.",
           "bullets": [
             "Identify the cause of pain",
             "Relieve discomfort safely",
@@ -6751,7 +6937,7 @@
         {
           "id": "treatment.heroIntro",
           "type": "copy-block",
-          "copy": "Toothache can range from mild twinges to severe, throbbing pain that disrupts sleep. If it\u2019s persistent, worsening, or triggered by biting, heat, or cold, it\u2019s worth getting checked even if it comes and goes.\n\nWe can talk through what\u2019s happening and advise timing. If pain is getting worse, you notice swelling, fever, a bad taste, or you cannot open your mouth comfortably, call us promptly.\n\nIf you have rapid facial swelling, fever, difficulty swallowing, or breathing problems, seek urgent medical help immediately (A&E / 999) and then let us know as soon as you can."
+          "copy": "Toothache can range from mild twinges to severe, throbbing pain that disrupts sleep. If it’s persistent, worsening, or triggered by biting, heat, or cold, it’s worth getting checked even if it comes and goes.\n\nWe can talk through what’s happening and advise timing. If pain is getting worse, you notice swelling, fever, a bad taste, or you cannot open your mouth comfortably, call us promptly.\n\nIf you have rapid facial swelling, fever, difficulty swallowing, or breathing problems, seek urgent medical help immediately (A&E / 999) and then let us know as soon as you can."
         },
         {
           "id": "emergency_pain_symptoms",
@@ -6789,7 +6975,7 @@
           "type": "treatment_media_feature",
           "label": "What we can do",
           "title": "Possible treatments",
-          "copy": "At an emergency appointment we start with an assessment, look for the cause, and confirm a diagnosis with any checks or X-rays needed.\n\nWhere appropriate we provide immediate stabilisation to relieve pain and protect the tooth. Not all treatment is completed in one visit, so we\u2019ll outline the next stages and timing.\n\nOptions may include replacing or repairing a filling, root canal treatment to treat infection inside the tooth, gum treatment, adjusting the bite, or in some cases removing a tooth that can\u2019t be predictably saved.\n\nWe\u2019ll explain the findings and the pros and cons of each option before anything is done.",
+          "copy": "At an emergency appointment we start with an assessment, look for the cause, and confirm a diagnosis with any checks or X-rays needed.\n\nWhere appropriate we provide immediate stabilisation to relieve pain and protect the tooth. Not all treatment is completed in one visit, so we’ll outline the next stages and timing.\n\nOptions may include replacing or repairing a filling, root canal treatment to treat infection inside the tooth, gum treatment, adjusting the bite, or in some cases removing a tooth that can’t be predictably saved.\n\nWe’ll explain the findings and the pros and cons of each option before anything is done.",
           "mediaHint": "Comfort-first care"
         },
         {
@@ -6805,15 +6991,15 @@
           "faqs": [
             {
               "question": "Can I wait to see if the pain settles?",
-              "answer": "Sometimes pain eases for a while, but the cause may still be there. If pain is severe, waking you, lingering, or getting worse, it\u2019s best to get advice promptly. Contact us and we\u2019ll guide you on timing."
+              "answer": "Sometimes pain eases for a while, but the cause may still be there. If pain is severe, waking you, lingering, or getting worse, it’s best to get advice promptly. Contact us and we’ll guide you on timing."
             },
             {
               "question": "Will treatment be painful?",
-              "answer": "Our aim is to get you comfortable first. We use effective local anaesthetic and we work in a calm, step-by-step way. If you\u2019re anxious, tell us \u2014 pacing, breaks, and clear explanation make a big difference."
+              "answer": "Our aim is to get you comfortable first. We use effective local anaesthetic and we work in a calm, step-by-step way. If you’re anxious, tell us — pacing, breaks, and clear explanation make a big difference."
             },
             {
               "question": "What if the pain starts overnight?",
-              "answer": "Use normal pain relief if safe for you (follow the packet guidance), keep the area clean, and avoid chewing on that side. If you develop swelling, fever, or difficulty swallowing/breathing, seek urgent medical help. Contact us as soon as we\u2019re open and we\u2019ll advise next steps."
+              "answer": "Use normal pain relief if safe for you (follow the packet guidance), keep the area clean, and avoid chewing on that side. If you develop swelling, fever, or difficulty swallowing/breathing, seek urgent medical help. Contact us as soon as we’re open and we’ll advise next steps."
             }
           ]
         },
@@ -6865,7 +7051,7 @@
         {
           "id": "treatment.heroIntro",
           "type": "copy-block",
-          "copy": "Infections can start quietly \u2014 sometimes as a dull ache, sometimes as sensitivity, and sometimes with no pain until swelling appears.\n\nAn abscess can come from the tooth nerve, from gum disease, or from a crack or deep decay letting bacteria in.\n\nIf you\u2019re unsure whether it\u2019s an emergency, call us. We can advise on urgency and what to do while you\u2019re waiting to be seen."
+          "copy": "Infections can start quietly — sometimes as a dull ache, sometimes as sensitivity, and sometimes with no pain until swelling appears.\n\nAn abscess can come from the tooth nerve, from gum disease, or from a crack or deep decay letting bacteria in.\n\nIf you’re unsure whether it’s an emergency, call us. We can advise on urgency and what to do while you’re waiting to be seen."
         },
         {
           "id": "emergency_abscess_symptoms",
@@ -6895,7 +7081,7 @@
           "id": "emergency_abscess_importance",
           "type": "copy-block",
           "title": "Why it needs proper assessment",
-          "copy": "Infections are not always solved by antibiotics alone. Antibiotics may be appropriate in certain situations, but the source of the infection usually needs treating.\n\nThat might mean draining the infection, cleaning and sealing the tooth with root canal treatment, treating gum infection, or removing a tooth that cannot be saved.\n\nOur job is to assess the cause, explain the realistic options, and help you get stable quickly \u2014 then plan longer-term care calmly.",
+          "copy": "Infections are not always solved by antibiotics alone. Antibiotics may be appropriate in certain situations, but the source of the infection usually needs treating.\n\nThat might mean draining the infection, cleaning and sealing the tooth with root canal treatment, treating gum infection, or removing a tooth that cannot be saved.\n\nOur job is to assess the cause, explain the realistic options, and help you get stable quickly — then plan longer-term care calmly.",
           "label": "Act early"
         },
         {
@@ -6903,7 +7089,7 @@
           "type": "treatment_media_feature",
           "label": "What we can do",
           "title": "Possible treatments",
-          "copy": "Treatment depends on where the infection is coming from and how advanced it is.\n\nOptions may include local measures to relieve pressure, root canal treatment to save a tooth, periodontal (gum) treatment, or extraction where the tooth cannot be predictably restored.\n\nIf antibiotics are needed, we\u2019ll explain why, what they can and can\u2019t do, and what follow-up is required.",
+          "copy": "Treatment depends on where the infection is coming from and how advanced it is.\n\nOptions may include local measures to relieve pressure, root canal treatment to save a tooth, periodontal (gum) treatment, or extraction where the tooth cannot be predictably restored.\n\nIf antibiotics are needed, we’ll explain why, what they can and can’t do, and what follow-up is required.",
           "mediaHint": "Gentle relief"
         },
         {
@@ -6919,11 +7105,11 @@
           "faqs": [
             {
               "question": "Do I always need antibiotics?",
-              "answer": "Sometimes antibiotics are necessary, especially if there is spreading swelling or you are unwell. But an abscess usually needs the source treated as well \u2014 for example drainage, root canal treatment, gum treatment, or extraction. We\u2019ll advise what\u2019s appropriate after assessment."
+              "answer": "Sometimes antibiotics are necessary, especially if there is spreading swelling or you are unwell. But an abscess usually needs the source treated as well — for example drainage, root canal treatment, gum treatment, or extraction. We’ll advise what’s appropriate after assessment."
             },
             {
               "question": "Will the swelling go away on its own?",
-              "answer": "Symptoms can ease if an abscess drains, but the infection often remains and can flare again. Leaving it can increase risk of spread and reduce the chance of saving the tooth. It\u2019s safest to get it assessed."
+              "answer": "Symptoms can ease if an abscess drains, but the infection often remains and can flare again. Leaving it can increase risk of spread and reduce the chance of saving the tooth. It’s safest to get it assessed."
             },
             {
               "question": "Can I work or travel after treatment?",
@@ -6968,7 +7154,7 @@
           "id": "emergency_chipped_overview",
           "type": "treatment_overview_rich",
           "title": "Broken, chipped or cracked teeth",
-          "copy": "If you\u2019ve chipped a tooth, cracked a corner, or something feels sharp or painful, it\u2019s worth getting it checked promptly.\n\nSome problems look small but involve deeper cracks or exposed dentine, which can lead to sensitivity, infection, or a larger fracture.\n\nWe\u2019ll assess what\u2019s happened, explain what we can see, and recommend the least invasive repair that keeps the tooth stable.",
+          "copy": "If you’ve chipped a tooth, cracked a corner, or something feels sharp or painful, it’s worth getting it checked promptly.\n\nSome problems look small but involve deeper cracks or exposed dentine, which can lead to sensitivity, infection, or a larger fracture.\n\nWe’ll assess what’s happened, explain what we can see, and recommend the least invasive repair that keeps the tooth stable.",
           "bullets": [
             "Quick smoothing to prevent cuts to cheeks or tongue",
             "Temporary coverings where needed",
@@ -6979,7 +7165,7 @@
         {
           "id": "treatment.heroIntro",
           "type": "copy-block",
-          "copy": "Teeth can chip or crack for lots of reasons \u2014 biting something hard, an old filling giving way, grinding, or an accident.\n\nSometimes it\u2019s mainly cosmetic. Sometimes it\u2019s an early warning that the tooth is under stress.\n\nIf you\u2019re unsure, we\u2019d rather you call and ask. We can advise whether it sounds urgent and what to do in the meantime."
+          "copy": "Teeth can chip or crack for lots of reasons — biting something hard, an old filling giving way, grinding, or an accident.\n\nSometimes it’s mainly cosmetic. Sometimes it’s an early warning that the tooth is under stress.\n\nIf you’re unsure, we’d rather you call and ask. We can advise whether it sounds urgent and what to do in the meantime."
         },
         {
           "id": "emergency_chipped_symptoms",
@@ -7008,8 +7194,8 @@
         {
           "id": "emergency_chipped_importance",
           "type": "copy-block",
-          "title": "Why it\u2019s worth checking",
-          "copy": "A chip or crack isn\u2019t always an emergency, but it can change quickly.\n\nSmall fractures can spread, and exposed dentine can become very sensitive. In some cases, cracks allow bacteria to reach the nerve, leading to infection.\n\nSeeing you early gives us more conservative options \u2014 and helps prevent the problem turning into a bigger repair.",
+          "title": "Why it’s worth checking",
+          "copy": "A chip or crack isn’t always an emergency, but it can change quickly.\n\nSmall fractures can spread, and exposed dentine can become very sensitive. In some cases, cracks allow bacteria to reach the nerve, leading to infection.\n\nSeeing you early gives us more conservative options — and helps prevent the problem turning into a bigger repair.",
           "label": "Protect the tooth"
         },
         {
@@ -7017,7 +7203,7 @@
           "type": "treatment_media_feature",
           "label": "What we can do",
           "title": "Possible treatments",
-          "copy": "Treatment depends on where the crack is, how deep it goes, and how much tooth is missing.\n\nOptions may include smoothing a sharp edge, a bonded repair (composite), replacing or reshaping an old filling, or protecting the tooth with an onlay or crown.\n\nIf the nerve is involved, root canal treatment may be needed \u2014 but we only recommend that when it\u2019s clearly indicated.",
+          "copy": "Treatment depends on where the crack is, how deep it goes, and how much tooth is missing.\n\nOptions may include smoothing a sharp edge, a bonded repair (composite), replacing or reshaping an old filling, or protecting the tooth with an onlay or crown.\n\nIf the nerve is involved, root canal treatment may be needed — but we only recommend that when it’s clearly indicated.",
           "mediaHint": "Restorative options"
         },
         {
@@ -7033,7 +7219,7 @@
           "faqs": [
             {
               "question": "Can a chipped tooth wait?",
-              "answer": "Sometimes a small chip can wait a short time, but it\u2019s best to get advice. Chips can expose dentine, increase sensitivity, or develop into a larger fracture. Call us and we\u2019ll guide you on timing."
+              "answer": "Sometimes a small chip can wait a short time, but it’s best to get advice. Chips can expose dentine, increase sensitivity, or develop into a larger fracture. Call us and we’ll guide you on timing."
             },
             {
               "question": "Will I need a crown straight away?",
@@ -7041,7 +7227,7 @@
             },
             {
               "question": "Is it safe to keep eating?",
-              "answer": "Try to avoid chewing on the affected side until we\u2019ve assessed the tooth. Softer foods and careful cleaning help. If biting triggers sharp pain, stop and contact us as that can suggest a deeper crack."
+              "answer": "Try to avoid chewing on the affected side until we’ve assessed the tooth. Softer foods and careful cleaning help. If biting triggers sharp pain, stop and contact us as that can suggest a deeper crack."
             }
           ]
         },
@@ -7082,9 +7268,9 @@
           "id": "emergency_avulsion_overview",
           "type": "treatment_overview_rich",
           "title": "Knocked-out tooth",
-          "copy": "A knocked-out adult tooth can sometimes be saved, but timing and handling matter.\n\nIf you can get advice immediately, bring the tooth with you and avoid touching the root. If it\u2019s safe to do so, gentle first aid can improve the chances of a good outcome \u2014 but it isn\u2019t always possible in real life, especially after an accident.\n\nCall us straight away so we can guide you on what to do next and how urgently you need to be seen.",
+          "copy": "A knocked-out adult tooth can sometimes be saved, but timing and handling matter.\n\nIf you can get advice immediately, bring the tooth with you and avoid touching the root. If it’s safe to do so, gentle first aid can improve the chances of a good outcome — but it isn’t always possible in real life, especially after an accident.\n\nCall us straight away so we can guide you on what to do next and how urgently you need to be seen.",
           "bullets": [
-            "Act quickly \u2014 time matters",
+            "Act quickly — time matters",
             "Handle the tooth carefully (avoid the root)",
             "Keep it moist and protected",
             "Get assessed promptly for the best chance of stabilisation"
@@ -7093,7 +7279,7 @@
         {
           "id": "treatment.heroIntro",
           "type": "copy-block",
-          "copy": "Having a tooth knocked out is frightening \u2014 and it often happens alongside a fall, collision, or sports injury.\n\nIf the tooth is an adult tooth, there may be a chance of replantation depending on timing and what\u2019s happened to the tooth and socket.\n\nIf you\u2019re unsure whether it\u2019s a baby tooth or an adult tooth, or there are other injuries, call us and we\u2019ll guide you to the safest next step."
+          "copy": "Having a tooth knocked out is frightening — and it often happens alongside a fall, collision, or sports injury.\n\nIf the tooth is an adult tooth, there may be a chance of replantation depending on timing and what’s happened to the tooth and socket.\n\nIf you’re unsure whether it’s a baby tooth or an adult tooth, or there are other injuries, call us and we’ll guide you to the safest next step."
         },
         {
           "id": "emergency_avulsion_symptoms",
@@ -7113,7 +7299,7 @@
           "items": [
             "Check for head injury, heavy bleeding, or breathing problems and seek urgent medical help if needed",
             "Find the tooth, pick it up by the crown (not the root), and avoid scrubbing it",
-            "If it\u2019s dirty, rinse gently for a few seconds with milk or saline (avoid disinfectants)",
+            "If it’s dirty, rinse gently for a few seconds with milk or saline (avoid disinfectants)",
             "Keep it moist: ideally in milk, saline, or inside the cheek if safe (not in water)",
             "Call us immediately so we can advise urgency and prepare for assessment"
           ]
@@ -7122,7 +7308,7 @@
           "id": "emergency_avulsion_importance",
           "type": "copy-block",
           "title": "Why speed matters",
-          "copy": "The tissues that help an adult tooth reattach can be damaged quickly if the tooth dries out or is handled roughly.\n\nEven with prompt care, replantation isn\u2019t always possible or successful \u2014 but early assessment usually gives the best chance of stabilising the situation and planning next steps.\n\nWe\u2019ll also check for associated injuries, fractures, and whether nearby teeth have been damaged or loosened.",
+          "copy": "The tissues that help an adult tooth reattach can be damaged quickly if the tooth dries out or is handled roughly.\n\nEven with prompt care, replantation isn’t always possible or successful — but early assessment usually gives the best chance of stabilising the situation and planning next steps.\n\nWe’ll also check for associated injuries, fractures, and whether nearby teeth have been damaged or loosened.",
           "label": "Act quickly"
         },
         {
@@ -7130,7 +7316,7 @@
           "type": "treatment_media_feature",
           "label": "What we can do",
           "title": "Possible treatments",
-          "copy": "Treatment depends on whether the tooth is an adult tooth, how long it has been out, how it has been stored, and the condition of the socket and surrounding bone.\n\nOptions may include careful replantation and stabilisation (splinting) where appropriate, monitoring healing, and follow-up assessment. In some situations, replacement options are discussed if replantation isn\u2019t possible.\n\nWe\u2019ll explain the likely risks, the aftercare required, and what long-term maintenance might involve.",
+          "copy": "Treatment depends on whether the tooth is an adult tooth, how long it has been out, how it has been stored, and the condition of the socket and surrounding bone.\n\nOptions may include careful replantation and stabilisation (splinting) where appropriate, monitoring healing, and follow-up assessment. In some situations, replacement options are discussed if replantation isn’t possible.\n\nWe’ll explain the likely risks, the aftercare required, and what long-term maintenance might involve.",
           "mediaHint": "Stabilisation and healing"
         },
         {
@@ -7146,15 +7332,15 @@
           "faqs": [
             {
               "question": "Can a baby tooth be replanted?",
-              "answer": "Usually no. Baby (primary) teeth are not normally replanted because doing so can damage the developing adult tooth underneath. If you\u2019re unsure whether it\u2019s a baby or adult tooth, call us and we\u2019ll advise quickly."
+              "answer": "Usually no. Baby (primary) teeth are not normally replanted because doing so can damage the developing adult tooth underneath. If you’re unsure whether it’s a baby or adult tooth, call us and we’ll advise quickly."
             },
             {
               "question": "What if the tooth looks damaged?",
-              "answer": "If the tooth is broken, cracked, or has obvious contamination, replantation may be less suitable \u2014 but it depends on the situation. Keep the tooth safe and moist, avoid touching the root, and contact us so we can assess what\u2019s realistic."
+              "answer": "If the tooth is broken, cracked, or has obvious contamination, replantation may be less suitable — but it depends on the situation. Keep the tooth safe and moist, avoid touching the root, and contact us so we can assess what’s realistic."
             },
             {
               "question": "Do I need a tetanus check?",
-              "answer": "If the injury involved a dirty wound, soil, or a cut that may have been contaminated, a tetanus check may be sensible. If you\u2019re unsure, contact your GP, NHS 111, or urgent care for advice \u2014 and still contact us so we can deal with the dental side promptly."
+              "answer": "If the injury involved a dirty wound, soil, or a cut that may have been contaminated, a tetanus check may be sensible. If you’re unsure, contact your GP, NHS 111, or urgent care for advice — and still contact us so we can deal with the dental side promptly."
             }
           ]
         },
@@ -7195,7 +7381,7 @@
           "id": "emergency_crown_overview",
           "type": "treatment_overview_rich",
           "title": "Lost crowns, veneers or fillings",
-          "copy": "If a crown, veneer or filling has come out, it can feel urgent \u2014 especially if the tooth is sensitive or looks unfinished.\n\nIn many cases the tooth can be protected and repaired conservatively, but timing matters. A lost restoration can leave sharp edges, exposed dentine, or a tooth that is more likely to fracture.\n\nWe\u2019ll assess what\u2019s happened, explain the options clearly, and help you stabilise the tooth as simply as possible.",
+          "copy": "If a crown, veneer or filling has come out, it can feel urgent — especially if the tooth is sensitive or looks unfinished.\n\nIn many cases the tooth can be protected and repaired conservatively, but timing matters. A lost restoration can leave sharp edges, exposed dentine, or a tooth that is more likely to fracture.\n\nWe’ll assess what’s happened, explain the options clearly, and help you stabilise the tooth as simply as possible.",
           "bullets": [
             "Protect the tooth and reduce sensitivity",
             "Check for decay, cracks, or a cause for the failure",
@@ -7206,7 +7392,7 @@
         {
           "id": "treatment.heroIntro",
           "type": "copy-block",
-          "copy": "Restorations can come loose for lots of reasons \u2014 wear over time, biting something hard, decay underneath, or the tooth changing shape.\n\nSometimes it\u2019s a straightforward re-cement. Sometimes it\u2019s a sign the tooth needs a different kind of protection.\n\nIf you still have the crown or veneer, keep it safe and bring it with you. We can often learn a lot from seeing it."
+          "copy": "Restorations can come loose for lots of reasons — wear over time, biting something hard, decay underneath, or the tooth changing shape.\n\nSometimes it’s a straightforward re-cement. Sometimes it’s a sign the tooth needs a different kind of protection.\n\nIf you still have the crown or veneer, keep it safe and bring it with you. We can often learn a lot from seeing it."
         },
         {
           "id": "emergency_crown_symptoms",
@@ -7228,15 +7414,15 @@
             "Keep the area clean with gentle brushing and warm salt-water rinses",
             "Avoid chewing on that side and stick to softer foods",
             "If the tooth is sharp, cover it temporarily with sugar-free gum or dental wax",
-            "Keep the crown/veneer if you have it and bring it with you (don\u2019t force it back on)",
+            "Keep the crown/veneer if you have it and bring it with you (don’t force it back on)",
             "Call us so we can advise urgency and book the right appointment"
           ]
         },
         {
           "id": "emergency_crown_importance",
           "type": "copy-block",
-          "title": "Why it\u2019s worth seeing us promptly",
-          "copy": "When a restoration comes out, the underlying tooth is often more vulnerable than it looks.\n\nExposed dentine can be very sensitive, and the tooth can fracture more easily \u2014 especially if it\u2019s already heavily filled. If there is decay or a crack underneath, delaying can reduce the options.\n\nSeeing you early helps us protect the tooth, manage discomfort, and plan a repair that lasts.",
+          "title": "Why it’s worth seeing us promptly",
+          "copy": "When a restoration comes out, the underlying tooth is often more vulnerable than it looks.\n\nExposed dentine can be very sensitive, and the tooth can fracture more easily — especially if it’s already heavily filled. If there is decay or a crack underneath, delaying can reduce the options.\n\nSeeing you early helps us protect the tooth, manage discomfort, and plan a repair that lasts.",
           "label": "Protect exposed teeth"
         },
         {
@@ -7244,7 +7430,7 @@
           "type": "treatment_media_feature",
           "label": "What we can do",
           "title": "Possible treatments",
-          "copy": "The right solution depends on why the restoration came out and what the tooth looks like underneath.\n\nOptions may include re-cementing the existing crown or veneer (if it\u2019s intact and the fit is still appropriate), replacing a filling, or making a new restoration if the tooth needs better protection.\n\nIf decay or a crack is present, we\u2019ll explain the findings and the most sensible way to stabilise the tooth long-term.",
+          "copy": "The right solution depends on why the restoration came out and what the tooth looks like underneath.\n\nOptions may include re-cementing the existing crown or veneer (if it’s intact and the fit is still appropriate), replacing a filling, or making a new restoration if the tooth needs better protection.\n\nIf decay or a crack is present, we’ll explain the findings and the most sensible way to stabilise the tooth long-term.",
           "mediaHint": "Restoration check"
         },
         {
@@ -7320,7 +7506,7 @@
         {
           "id": "treatment.heroIntro",
           "type": "copy-block",
-          "copy": "Dental trauma can range from chipped enamel to displaced or loosened teeth, fractures, and injuries to gums or supporting bone. What matters most is prompt assessment: we check tooth stability, nerve response, bite changes and soft tissue injury, and take X-rays to rule out hidden fractures. Treatment might include smoothing or repairing a chip, splinting a tooth, dressing an exposed nerve, or planning follow-up care if the tooth\u2019s nerve is at risk. We\u2019ll also advise on pain control and what to avoid while the area heals. If a tooth has been knocked out, time is critical \u2014 see that page for immediate steps."
+          "copy": "Dental trauma can range from chipped enamel to displaced or loosened teeth, fractures, and injuries to gums or supporting bone. What matters most is prompt assessment: we check tooth stability, nerve response, bite changes and soft tissue injury, and take X-rays to rule out hidden fractures. Treatment might include smoothing or repairing a chip, splinting a tooth, dressing an exposed nerve, or planning follow-up care if the tooth’s nerve is at risk. We’ll also advise on pain control and what to avoid while the area heals. If a tooth has been knocked out, time is critical — see that page for immediate steps."
         },
         {
           "id": "emergency_trauma_symptoms",
@@ -8193,7 +8379,7 @@
           "id": "night_guards_occlusal_splints_mid_cta",
           "type": "treatment_mid_cta",
           "title": "Protection options to compare",
-          "strapline": "Compare connected options for clenching, jaw joint symptoms, and tooth wear \u2014 and choose the calm next step."
+          "strapline": "Compare connected options for clenching, jaw joint symptoms, and tooth wear — and choose the calm next step."
         },
         {
           "id": "treatment.faq"
@@ -8205,7 +8391,7 @@
           "id": "night_guards_occlusal_splints_closing_cta",
           "type": "treatment_closing_cta",
           "title": "Night guards for grinding and jaw tension",
-          "strapline": "A custom occlusal splint can reduce wear, ease muscle strain, and protect heavily filled or worn teeth \u2014 without over-treating.",
+          "strapline": "A custom occlusal splint can reduce wear, ease muscle strain, and protect heavily filled or worn teeth — without over-treating.",
           "ctas": [
             {
               "label": "Book a night guard assessment",
@@ -8227,7 +8413,7 @@
         {
           "id": "night_guards_full_inventory",
           "type": "routing_cards",
-          "title": "Night guards & occlusal therapy \u2014 related treatments",
+          "title": "Night guards & occlusal therapy — related treatments",
           "label": "Explore the full list",
           "items": [
             {
@@ -8423,7 +8609,7 @@
           "bullets": [
             "Gentle, unhurried check-ups with the same clinical team",
             "Prevention plans tailored to your enamel, gums, and lifestyle",
-            "Clear guidance if you\u2019re anxious or prefer slower appointments"
+            "Clear guidance if you’re anxious or prefer slower appointments"
           ],
           "ctas": [
             {
@@ -8486,7 +8672,7 @@
             "Polishing and airflow-style finishing where suitable for stain control",
             "Tips to improve brushing and interdental cleaning at home",
             "Why visits matter even if you brush well: hidden build-up and hard-to-reach areas",
-            "Preventing gum disease and bad breath with tailored intervals\u2014see periodontal care (/treatments/periodontal-gum-care)"
+            "Preventing gum disease and bad breath with tailored intervals—see periodontal care (/treatments/periodontal-gum-care)"
           ],
           "strapline": "Regular hygiene keeps gums healthy and helps fillings, crowns, and implants last longer."
         },
@@ -8501,7 +8687,7 @@
           "title": "Simple, science-led guidance you can follow",
           "body": "We create a plan that fits your daily routine so small adjustments have a big impact.",
           "bullets": [
-            "Fluoride advice matched to your risk level\u2014no pushy sales",
+            "Fluoride advice matched to your risk level—no pushy sales",
             "Diet and sugar-frequency guidance with practical swaps",
             "Support for sensitive teeth, including gentle techniques and desensitising care",
             "Custom lab-made sports mouthguards for contact or ball sports (/treatments/sports-mouthguards)"
@@ -8538,7 +8724,7 @@
             "Teens and young adults: monitoring wisdom teeth, orthodontic retainers, and sports protection",
             "Young-at-heart retirees: focus on comfort, function, and maintaining existing restorations",
             "Medical changes considered so your plan stays safe and effective",
-            "Appointment pacing adjusted if you\u2019re nervous or prefer slower visits"
+            "Appointment pacing adjusted if you’re nervous or prefer slower visits"
           ]
         },
         {
@@ -8581,11 +8767,11 @@
             },
             {
               "question": "Do you check for mouth cancer?",
-              "answer": "Yes. Oral cancer screening is part of every exam. We review soft tissues, lymph areas, and any changes you\u2019ve noticed."
+              "answer": "Yes. Oral cancer screening is part of every exam. We review soft tissues, lymph areas, and any changes you’ve noticed."
             },
             {
-              "question": "I\u2019m nervous \u2014 can you go slowly?",
-              "answer": "Absolutely. Tell us ahead of time and we\u2019ll pace the visit, explain each step, and link you to our nervous patient support if helpful (/treatments/nervous-patients)."
+              "question": "I’m nervous — can you go slowly?",
+              "answer": "Absolutely. Tell us ahead of time and we’ll pace the visit, explain each step, and link you to our nervous patient support if helpful (/treatments/nervous-patients)."
             },
             {
               "question": "Is home whitening better?",
@@ -8602,7 +8788,7 @@
           "seoRole": "cta",
           "eyebrow": "Next steps",
           "title": "Book your comprehensive dental exam",
-          "body": "Speak to us about a prevention-first plan. If you\u2019re anxious, tell us \u2014 we\u2019ll tailor the visit and pace it carefully.",
+          "body": "Speak to us about a prevention-first plan. If you’re anxious, tell us — we’ll tailor the visit and pace it carefully.",
           "ctas": [
             {
               "label": "Dental check-ups & oral cancer screening",
@@ -8619,7 +8805,7 @@
         {
           "id": "general_full_inventory",
           "type": "routing_cards",
-          "title": "General Dentistry \u2014 full treatment list",
+          "title": "General Dentistry — full treatment list",
           "label": "Full list",
           "items": [
             {
@@ -8636,7 +8822,7 @@
               "href": "/treatments/periodontal-gum-care"
             },
             {
-              "title": "Children\u2019s dentistry",
+              "title": "Children’s dentistry",
               "href": "/treatments/childrens-dentistry"
             },
             {
@@ -8669,7 +8855,7 @@
                 "href": "/treatments/periodontal-gum-care"
               },
               {
-                "title": "Children\u2019s dentistry",
+                "title": "Children’s dentistry",
                 "href": "/treatments/childrens-dentistry"
               },
               {
@@ -8693,7 +8879,7 @@
     },
     "childrens_dentistry": {
       "id": "childrens_dentistry",
-      "label": "Children\u2019s dentistry",
+      "label": "Children’s dentistry",
       "path": "/treatments/childrens-dentistry",
       "category": "treatment",
       "hero": "treatment_neutral_hero_v1",
@@ -8709,7 +8895,7 @@
           "variantId": "smh_childrens_dentistry_hero",
           "order": 10,
           "seoRole": "hero",
-          "eyebrow": "Children\u2019s dentistry",
+          "eyebrow": "Children’s dentistry",
           "title": "Gentle check-ups that build lifelong habits",
           "body": "We keep appointments short, positive, and age-appropriate so children feel relaxed while we protect their growing smiles.",
           "bullets": [
@@ -8719,7 +8905,7 @@
           ],
           "ctas": [
             {
-              "label": "Book a children\u2019s check-up",
+              "label": "Book a children’s check-up",
               "href": "/contact?topic=children",
               "preset": "primary"
             },
@@ -8754,7 +8940,7 @@
           "variantId": "smh_childrens_dentistry_checkup",
           "order": 30,
           "seoRole": "primaryContent",
-          "eyebrow": "What a children\u2019s check-up includes",
+          "eyebrow": "What a children’s check-up includes",
           "title": "Gentle exams with practical guidance",
           "body": "Each visit is paced slowly so children stay comfortable while we check teeth, gums, and bite development.",
           "bullets": [
@@ -8819,7 +9005,7 @@
           "seoRole": "supporting",
           "eyebrow": "When we suggest an orthodontic chat",
           "title": "Early guidance keeps options open",
-          "body": "If we spot crowding, bite discrepancies, or habits affecting jaw growth, we\u2019ll recommend an orthodontic assessment. We collaborate with orthodontic colleagues for fixed or removable options when the time is right\u2014always explained clearly to families.",
+          "body": "If we spot crowding, bite discrepancies, or habits affecting jaw growth, we’ll recommend an orthodontic assessment. We collaborate with orthodontic colleagues for fixed or removable options when the time is right—always explained clearly to families.",
           "mediaHint": "Monitoring bite, spacing, and eruption patterns"
         },
         {
@@ -8829,12 +9015,12 @@
           "variantId": "smh_childrens_dentistry_faq",
           "order": 80,
           "seoRole": "faq",
-          "eyebrow": "Children\u2019s dentistry FAQs",
+          "eyebrow": "Children’s dentistry FAQs",
           "title": "Answers for parents",
           "faqs": [
             {
               "question": "When should my child first visit?",
-              "answer": "We\u2019re happy to see children as soon as their first teeth appear or by their first birthday. Early visits help them get used to the chair and let us spot any early issues."
+              "answer": "We’re happy to see children as soon as their first teeth appear or by their first birthday. Early visits help them get used to the chair and let us spot any early issues."
             },
             {
               "question": "How often should they come?",
@@ -8846,7 +9032,7 @@
             },
             {
               "question": "What if my child is scared?",
-              "answer": "Tell us ahead of time and we\u2019ll keep visits short, use tell-show-do, and let them stay in control. We can build up gradually with positive language and plenty of breaks."
+              "answer": "Tell us ahead of time and we’ll keep visits short, use tell-show-do, and let them stay in control. We can build up gradually with positive language and plenty of breaks."
             }
           ]
         },
@@ -8865,10 +9051,10 @@
           "seoRole": "cta",
           "eyebrow": "Next steps",
           "title": "Book a gentle check-up for your child",
-          "body": "We\u2019ll keep things calm, answer your questions, and map out a prevention plan that fits family life.",
+          "body": "We’ll keep things calm, answer your questions, and map out a prevention plan that fits family life.",
           "ctas": [
             {
-              "label": "Book a children\u2019s appointment",
+              "label": "Book a children’s appointment",
               "href": "/contact?topic=children",
               "variant": "primary"
             },
@@ -8922,11 +9108,11 @@
           "seoRole": "hero",
           "eyebrow": "Periodontal & gum care",
           "title": "Gum disease",
-          "body": "Gum disease is a common condition that affects the tissues supporting the teeth.\n\nIt often develops gradually and may not cause pain in its early stages, which means it can progress unnoticed for some time.\n\nAt St Mary\u2019s House Dental Care, gum disease is managed with a long-term view, focusing on understanding causes, stabilising the condition, and supporting ongoing oral health.",
+          "body": "Gum disease is a common condition that affects the tissues supporting the teeth.\n\nIt often develops gradually and may not cause pain in its early stages, which means it can progress unnoticed for some time.\n\nAt St Mary’s House Dental Care, gum disease is managed with a long-term view, focusing on understanding causes, stabilising the condition, and supporting ongoing oral health.",
           "bullets": [
             "Gum disease is a common condition that affects the tissues supporting the teeth.",
             "It often develops gradually and may not cause pain in its early stages, which means it can progress unnoticed for some time.",
-            "At St Mary\u2019s House Dental Care, gum disease is managed with a long-term view, focusing on understanding causes, stabilising the condition, and supporting ongoing oral health."
+            "At St Mary’s House Dental Care, gum disease is managed with a long-term view, focusing on understanding causes, stabilising the condition, and supporting ongoing oral health."
           ],
           "ctas": [
             {
@@ -9047,7 +9233,7 @@
           "faqs": [
             {
               "question": "Does deep cleaning hurt?",
-              "answer": "Treatment is planned gently with numbing gels or local anaesthetic where needed. You\u2019ll be guided on what to expect and how to keep things comfortable afterwards."
+              "answer": "Treatment is planned gently with numbing gels or local anaesthetic where needed. You’ll be guided on what to expect and how to keep things comfortable afterwards."
             },
             {
               "question": "How long does it take to see improvement?",
@@ -9055,11 +9241,11 @@
             },
             {
               "question": "Can gum tissue grow back?",
-              "answer": "Inflammation can reduce and pockets can tighten with good care. Recession usually needs protective maintenance rather than regrowth, and we\u2019ll discuss options if grafting or referral is appropriate."
+              "answer": "Inflammation can reduce and pockets can tighten with good care. Recession usually needs protective maintenance rather than regrowth, and we’ll discuss options if grafting or referral is appropriate."
             },
             {
               "question": "What about implants with gum inflammation?",
-              "answer": "Peri-implant tissues can often be stabilised with careful cleaning, airflow-style stain removal, and close reviews. If advanced peri-implantitis is present, we\u2019ll outline referral options calmly."
+              "answer": "Peri-implant tissues can often be stabilised with careful cleaning, airflow-style stain removal, and close reviews. If advanced peri-implantitis is present, we’ll outline referral options calmly."
             }
           ]
         },
@@ -9109,10 +9295,10 @@
           "seoRole": "hero",
           "eyebrow": "Endodontics & root canal care",
           "title": "Root canal treatment",
-          "body": "Root canal treatment is used when the nerve inside a tooth has become inflamed or infected.\n\nThe aim is to remove infection, seal the tooth, and keep it stable long-term \u2014 often avoiding the need for extraction.\n\nWe\u2019ll assess the tooth carefully, explain what we can see (and what we can\u2019t), and recommend the most predictable option for your situation.",
+          "body": "Root canal treatment is used when the nerve inside a tooth has become inflamed or infected.\n\nThe aim is to remove infection, seal the tooth, and keep it stable long-term — often avoiding the need for extraction.\n\nWe’ll assess the tooth carefully, explain what we can see (and what we can’t), and recommend the most predictable option for your situation.",
           "bullets": [
             "Relieve pain and settle infection",
-            "Preserve the tooth where it\u2019s sensible to do so",
+            "Preserve the tooth where it’s sensible to do so",
             "Restore strength with the right protection afterwards"
           ],
           "ctas": [
@@ -9141,7 +9327,7 @@
             "Pain that lingers after hot or cold",
             "Throbbing pain or pain that wakes you",
             "Pain on biting or when you release the bite",
-            "Swelling, a gum \u2018spot\u2019, or a bad taste",
+            "Swelling, a gum ‘spot’, or a bad taste",
             "A tooth that has darkened after previous trauma"
           ],
           "strapline": "In some cases, there may be little or no pain, and the problem is identified during examination."
@@ -9172,7 +9358,7 @@
           "seoRole": "supporting",
           "eyebrow": "Why root canal treatment may be needed",
           "title": "Why planning and precision matter",
-          "body": "Root canal treatment is detail work.\n\nGood outcomes depend on seeing the anatomy clearly, cleaning thoroughly, and sealing the tooth well. Sometimes canals are narrow, curved, or hard to locate \u2014 and that\u2019s where careful technique and appropriate imaging help.\n\nWe\u2019ll explain what we can see on the day and whether the tooth looks straightforward, complex, or uncertain \u2014 before we commit you to a plan.",
+          "body": "Root canal treatment is detail work.\n\nGood outcomes depend on seeing the anatomy clearly, cleaning thoroughly, and sealing the tooth well. Sometimes canals are narrow, curved, or hard to locate — and that’s where careful technique and appropriate imaging help.\n\nWe’ll explain what we can see on the day and whether the tooth looks straightforward, complex, or uncertain — before we commit you to a plan.",
           "mediaHint": "CBCT mapping, rotary instruments, and apex location"
         },
         {
@@ -9185,10 +9371,10 @@
           "eyebrow": "Comfort and what to expect",
           "title": "Comfort, pacing, and anxiety",
           "items": [
-            "We take time to get you properly numb \u2014 pain control is not rushed",
+            "We take time to get you properly numb — pain control is not rushed",
             "We can work in shorter stages if you find long appointments difficult",
-            "We explain each step before we do it and agree a clear \u2018stop\u2019 signal",
-            "If you\u2019re nervous, tell us \u2014 we\u2019ll adapt the pace and the plan"
+            "We explain each step before we do it and agree a clear ‘stop’ signal",
+            "If you’re nervous, tell us — we’ll adapt the pace and the plan"
           ]
         },
         {
@@ -9200,7 +9386,7 @@
           "seoRole": "supporting",
           "eyebrow": "Alternatives and limitations",
           "title": "Limitations and risks",
-          "body": "Root canal treatment is usually very successful, but it isn\u2019t magic.\n\nSometimes anatomy is complex, infection has been present for a long time, or cracks mean the tooth cannot be predictably saved. Occasionally a tooth needs further treatment later, even after an apparently good initial result.\n\nWe\u2019ll talk through the realistic risks for your tooth specifically, and what the alternatives would be.",
+          "body": "Root canal treatment is usually very successful, but it isn’t magic.\n\nSometimes anatomy is complex, infection has been present for a long time, or cracks mean the tooth cannot be predictably saved. Occasionally a tooth needs further treatment later, even after an apparently good initial result.\n\nWe’ll talk through the realistic risks for your tooth specifically, and what the alternatives would be.",
           "bullets": [
             "Success depends on anatomy, infection level, and tooth structure",
             "Some teeth need follow-up treatment or referral if complexity is high",
@@ -9216,7 +9402,7 @@
           "seoRole": "supporting",
           "eyebrow": "After root canal treatment",
           "title": "Aftercare and long-term outlook",
-          "body": "Once the nerve is treated, the tooth still needs to be protected.\n\nBack teeth in particular often need an onlay or crown afterwards because they\u2019re more likely to fracture. A well-sealed, well-protected tooth can last many years, but maintenance matters.\n\nWe\u2019ll recommend the simplest protection that gives the tooth the best chance of staying stable.",
+          "body": "Once the nerve is treated, the tooth still needs to be protected.\n\nBack teeth in particular often need an onlay or crown afterwards because they’re more likely to fracture. A well-sealed, well-protected tooth can last many years, but maintenance matters.\n\nWe’ll recommend the simplest protection that gives the tooth the best chance of staying stable.",
           "bullets": [
             "Follow-up checks are part of good endodontic care",
             "Protecting the tooth afterwards is often the key to longevity",
@@ -9234,8 +9420,8 @@
           "title": "Questions people ask",
           "faqs": [
             {
-              "question": "What if I\u2019m unsure whether I need root canal treatment?",
-              "answer": "Root canal treatment should not be painful \u2014 the tooth is numbed thoroughly and we work carefully.\n\nPeople often come in expecting the worst because they\u2019re already in pain. In reality, the aim is to remove the source of that pain and make the tooth comfortable again.\n\nIf you\u2019re anxious, tell us. We can pace the appointment, take breaks, and keep the plan simple."
+              "question": "What if I’m unsure whether I need root canal treatment?",
+              "answer": "Root canal treatment should not be painful — the tooth is numbed thoroughly and we work carefully.\n\nPeople often come in expecting the worst because they’re already in pain. In reality, the aim is to remove the source of that pain and make the tooth comfortable again.\n\nIf you’re anxious, tell us. We can pace the appointment, take breaks, and keep the plan simple."
             }
           ]
         },
@@ -9254,7 +9440,7 @@
           "seoRole": "cta",
           "eyebrow": "Next steps",
           "title": "Talk to us about root canal treatment",
-          "body": "If you have toothache, lingering sensitivity, or swelling, it\u2019s worth getting the tooth assessed.\n\nWe\u2019ll explain what\u2019s going on, whether the tooth is realistically savable, and what the next step should be \u2014 without pressure.",
+          "body": "If you have toothache, lingering sensitivity, or swelling, it’s worth getting the tooth assessed.\n\nWe’ll explain what’s going on, whether the tooth is realistically savable, and what the next step should be — without pressure.",
           "ctas": [
             {
               "label": "Book a root canal consult",
@@ -9291,7 +9477,7 @@
           "seoRole": "hero",
           "eyebrow": "Extractions & oral surgery",
           "title": "Dental extractions",
-          "body": "A dental extraction involves the removal of a tooth that cannot be maintained comfortably or predictably over the long term.\n\nExtractions are usually considered only when other options are unlikely to succeed or would not offer a stable long-term outcome.\n\nAt St Mary\u2019s House Dental Care, the focus is always on preserving teeth where possible and recommending extraction only when it\u2019s genuinely in a patient\u2019s best interest.",
+          "body": "A dental extraction involves the removal of a tooth that cannot be maintained comfortably or predictably over the long term.\n\nExtractions are usually considered only when other options are unlikely to succeed or would not offer a stable long-term outcome.\n\nAt St Mary’s House Dental Care, the focus is always on preserving teeth where possible and recommending extraction only when it’s genuinely in a patient’s best interest.",
           "bullets": [
             "Calm assessments that explain when extraction is the safest route",
             "Minimally invasive techniques to protect bone and gum",
@@ -9322,7 +9508,7 @@
           "items": [
             "An extraction may be advised if a tooth is severely damaged by decay, infection, fracture, or advanced gum disease.",
             "It may also be considered where a tooth is causing ongoing pain, repeated infection, or is affecting the health of surrounding teeth.",
-            "We\u2019ll always explain why removal is being suggested and what alternatives have been considered."
+            "We’ll always explain why removal is being suggested and what alternatives have been considered."
           ],
           "strapline": "If you experience rapid swelling, spreading infection, or difficulty swallowing, treat it as urgent and contact us for emergency dentistry advice."
         },
@@ -9364,8 +9550,8 @@
           "title": "Comfort and what to expect",
           "items": [
             "Many patients worry about discomfort during or after an extraction.",
-            "The procedure is carried out once the area is numb, and we\u2019ll talk you through what sensations to expect. Some soreness afterwards is normal and usually settles over time.",
-            "We\u2019ll provide clear aftercare advice to support healing."
+            "The procedure is carried out once the area is numb, and we’ll talk you through what sensations to expect. Some soreness afterwards is normal and usually settles over time.",
+            "We’ll provide clear aftercare advice to support healing."
           ]
         },
         {
@@ -9377,7 +9563,7 @@
           "seoRole": "supporting",
           "eyebrow": "Risks, limits & alternatives",
           "title": "Aftercare and healing",
-          "body": "After an extraction, it\u2019s important to allow the area to heal properly.\n\nThis may involve avoiding certain foods, keeping the area clean, and following specific instructions to reduce the risk of complications.\n\nWe\u2019ll explain what\u2019s normal during healing and when to get in touch if concerns arise.",
+          "body": "After an extraction, it’s important to allow the area to heal properly.\n\nThis may involve avoiding certain foods, keeping the area clean, and following specific instructions to reduce the risk of complications.\n\nWe’ll explain what’s normal during healing and when to get in touch if concerns arise.",
           "bullets": [
             "Discussion of saving versus removing a tooth with restorative or endodontic care",
             "Clear consent for complex roots, impacted teeth, or medical considerations",
@@ -9414,11 +9600,11 @@
           "faqs": [
             {
               "question": "Questions and reassurance",
-              "answer": "Being told a tooth needs to be removed can feel daunting.\n\nIf you\u2019re unsure why an extraction has been suggested or what it means for you, we encourage you to ask. Clear explanations help support confident, informed decisions."
+              "answer": "Being told a tooth needs to be removed can feel daunting.\n\nIf you’re unsure why an extraction has been suggested or what it means for you, we encourage you to ask. Clear explanations help support confident, informed decisions."
             },
             {
               "question": "How long is recovery?",
-              "answer": "Most people are comfortable after a few days with steady improvement over 1\u20132 weeks. We give written instructions to support smooth healing."
+              "answer": "Most people are comfortable after a few days with steady improvement over 1–2 weeks. We give written instructions to support smooth healing."
             },
             {
               "question": "Can the tooth be replaced?",
@@ -9426,7 +9612,7 @@
             },
             {
               "question": "What if the tooth could be saved?",
-              "answer": "If a filling, crown, or root canal could provide a predictable result, we\u2019ll explain that option first so you can make an informed choice."
+              "answer": "If a filling, crown, or root canal could provide a predictable result, we’ll explain that option first so you can make an informed choice."
             }
           ]
         },
@@ -9465,7 +9651,7 @@
     "senior_mature_smile_care": {
       "id": "senior_mature_smile_care",
       "label": "Senior and mature smile care",
-      "description": "Comfort-first dentistry for later life, focusing on gum health, dry mouth, worn or heavily filled teeth, and realistic tooth replacement options.\n\nWe\u2019ll look at what\u2019s changing, what\u2019s stable, and what would genuinely improve day-to-day comfort and confidence \u2014 without over-treating.",
+      "description": "Comfort-first dentistry for later life, focusing on gum health, dry mouth, worn or heavily filled teeth, and realistic tooth replacement options.\n\nWe’ll look at what’s changing, what’s stable, and what would genuinely improve day-to-day comfort and confidence — without over-treating.",
       "path": "/treatments/senior-mature-smile-care",
       "category": "treatment",
       "hero": "treatment_neutral_hero_v1",
@@ -9493,7 +9679,7 @@
           "id": "senior_mature_smile_care_closing_cta",
           "type": "treatment_closing_cta",
           "title": "Plan mature smile care",
-          "strapline": "Balance comfort, function, and appearance with a tailored plan \u2014 paced to suit you.",
+          "strapline": "Balance comfort, function, and appearance with a tailored plan — paced to suit you.",
           "ctas": [
             {
               "label": "Book a mature smile review",
@@ -9560,7 +9746,7 @@
           "id": "tmj_jaw_comfort_closing_cta",
           "type": "treatment_closing_cta",
           "title": "Get help with jaw joint (TMJ) discomfort",
-          "strapline": "Understand what\u2019s driving the symptoms, reduce strain, and build a practical plan \u2014 without hype.",
+          "strapline": "Understand what’s driving the symptoms, reduce strain, and build a practical plan — without hype.",
           "ctas": [
             {
               "label": "Book a jaw (TMJ) comfort review",
@@ -9597,7 +9783,7 @@
           "id": "treatment.heroIntro",
           "type": "copy-block",
           "title": "Nervous patients",
-          "copy": "If you feel anxious about dentistry, you\u2019re not alone \u2014 and you don\u2019t need to \u2018push through it\u2019 to get help.\n\nWe take a calm, practical approach: clear explanations, gentle pacing, and treatment planned in stages when that makes things easier.\n\nSometimes the best first appointment is simply a conversation and an examination. We\u2019ll agree a plan together \u2014 with comfort and control built in from the start."
+          "copy": "If you feel anxious about dentistry, you’re not alone — and you don’t need to ‘push through it’ to get help.\n\nWe take a calm, practical approach: clear explanations, gentle pacing, and treatment planned in stages when that makes things easier.\n\nSometimes the best first appointment is simply a conversation and an examination. We’ll agree a plan together — with comfort and control built in from the start."
         },
         {
           "id": "treatment.whoIsItFor",
@@ -9622,13 +9808,13 @@
             "Fear of judgement or embarrassment",
             "Concern about costs, pressure, or unexpected treatment"
           ],
-          "strapline": "These are normal concerns \u2014 and we plan around them."
+          "strapline": "These are normal concerns — and we plan around them."
         },
         {
           "id": "treatment.consultationOverview",
           "type": "treatment_overview_rich",
           "title": "What to expect",
-          "body": "We\u2019ll start by understanding what makes dentistry difficult for you. That might be a specific fear (needles, numbness, drilling), sensory overload, a past experience, or simply not knowing what\u2019s going to happen.\n\nDepending on your needs, we can:\n- go at a slower pace, with breaks\n- agree a clear \u2018stop\u2019 signal so you stay in control\n- explain each step before we do it\n- stage care so it feels manageable rather than overwhelming\n\nIf sedation is relevant, we can explain when it may be appropriate and what it involves. Not everyone needs it \u2014 for many people, pacing and predictability are the biggest difference.",
+          "body": "We’ll start by understanding what makes dentistry difficult for you. That might be a specific fear (needles, numbness, drilling), sensory overload, a past experience, or simply not knowing what’s going to happen.\n\nDepending on your needs, we can:\n- go at a slower pace, with breaks\n- agree a clear ‘stop’ signal so you stay in control\n- explain each step before we do it\n- stage care so it feels manageable rather than overwhelming\n\nIf sedation is relevant, we can explain when it may be appropriate and what it involves. Not everyone needs it — for many people, pacing and predictability are the biggest difference.",
           "bullets": [
             "A calm, non-judgemental conversation first",
             "An examination (and X-rays only if needed)",
@@ -9836,11 +10022,11 @@
           "id": "tooth_wear_overview",
           "type": "treatment_overview_rich",
           "title": "Tooth wear and erosion",
-          "copy": "Tooth wear refers to the gradual loss of tooth structure over time.\n\nIt\u2019s a common issue and often develops slowly, meaning many people don\u2019t notice it until changes in shape, sensitivity, or appearance become more obvious.\n\nAt St Mary\u2019s House Dental Care, tooth wear is managed thoughtfully, with an emphasis on understanding why it\u2019s happening before deciding how to treat it.",
+          "copy": "Tooth wear refers to the gradual loss of tooth structure over time.\n\nIt’s a common issue and often develops slowly, meaning many people don’t notice it until changes in shape, sensitivity, or appearance become more obvious.\n\nAt St Mary’s House Dental Care, tooth wear is managed thoughtfully, with an emphasis on understanding why it’s happening before deciding how to treat it.",
           "bullets": [
             "Tooth wear refers to the gradual loss of tooth structure over time",
             "It often develops slowly before changes become more obvious",
-            "Care focuses on understanding why it\u2019s happening before deciding how to treat it"
+            "Care focuses on understanding why it’s happening before deciding how to treat it"
           ]
         },
         {
@@ -9914,8 +10100,8 @@
           "title": "Questions and reassurance",
           "faqs": [
             {
-              "question": "What if I\u2019m unsure about what tooth wear means for me?",
-              "answer": "Learning that your teeth are wearing can be concerning.\n\nIf you\u2019re unsure what it means for you, we encourage you to ask. Understanding the situation clearly helps avoid unnecessary treatment and supports sensible long-term decisions."
+              "question": "What if I’m unsure about what tooth wear means for me?",
+              "answer": "Learning that your teeth are wearing can be concerning.\n\nIf you’re unsure what it means for you, we encourage you to ask. Understanding the situation clearly helps avoid unnecessary treatment and supports sensible long-term decisions."
             }
           ]
         },
@@ -10126,7 +10312,7 @@
           "id": "bruxism_jaw_clenching_mid_cta",
           "type": "treatment_mid_cta",
           "title": "Jaw strain and tooth wear options",
-          "strapline": "Protect worn teeth, reduce jaw strain, and understand the triggers \u2014 with a practical plan."
+          "strapline": "Protect worn teeth, reduce jaw strain, and understand the triggers — with a practical plan."
         },
         {
           "id": "treatment.faq"
@@ -10138,7 +10324,7 @@
           "id": "bruxism_and_jaw_clenching_closing_cta",
           "type": "treatment_closing_cta",
           "title": "Help for grinding and clenching",
-          "strapline": "Grinding and clenching can wear teeth, crack fillings, and overload the jaw muscles. We\u2019ll assess the pattern, explain what it suggests, and help you protect your teeth sensibly.",
+          "strapline": "Grinding and clenching can wear teeth, crack fillings, and overload the jaw muscles. We’ll assess the pattern, explain what it suggests, and help you protect your teeth sensibly.",
           "ctas": [
             {
               "label": "Book a bruxism assessment",
@@ -10266,7 +10452,7 @@
           "id": "tmj_disorder_treatment_mid_cta",
           "type": "treatment_mid_cta",
           "title": "TMJ and jaw-pain options",
-          "strapline": "Jaw pain, clicking, headaches, and clenching often overlap \u2014 compare options and choose the calm next step."
+          "strapline": "Jaw pain, clicking, headaches, and clenching often overlap — compare options and choose the calm next step."
         },
         {
           "id": "treatment.faq"
@@ -10278,7 +10464,7 @@
           "id": "tmj_disorder_treatment_closing_cta",
           "type": "treatment_closing_cta",
           "title": "TMJ disorder assessment and treatment",
-          "strapline": "TMJ symptoms are rarely one simple thing. We\u2019ll assess the joints, muscles, bite factors, and clenching patterns \u2014 then build a practical, staged plan aimed at reducing strain and improving comfort.",
+          "strapline": "TMJ symptoms are rarely one simple thing. We’ll assess the joints, muscles, bite factors, and clenching patterns — then build a practical, staged plan aimed at reducing strain and improving comfort.",
           "ctas": [
             {
               "label": "Book a TMJ assessment",
@@ -10339,7 +10525,7 @@
           "id": "therapeutic_facial_injectables_mid_cta",
           "type": "treatment_mid_cta",
           "title": "Therapeutic facial options",
-          "strapline": "Jaw tension, clenching, facial pain and headaches can overlap \u2014 compare options and choose a calm next step."
+          "strapline": "Jaw tension, clenching, facial pain and headaches can overlap — compare options and choose a calm next step."
         },
         {
           "id": "treatment.faq"
@@ -10351,7 +10537,7 @@
           "id": "therapeutic_facial_injectables_closing_cta",
           "type": "treatment_closing_cta",
           "title": "Therapeutic injectables for jaw tension and facial pain",
-          "strapline": "Some muscle-related symptoms can respond well to carefully planned injectables. We\u2019ll assess what\u2019s driving the problem, explain what\u2019s realistic, and only recommend treatment where it\u2019s appropriate.",
+          "strapline": "Some muscle-related symptoms can respond well to carefully planned injectables. We’ll assess what’s driving the problem, explain what’s realistic, and only recommend treatment where it’s appropriate.",
           "ctas": [
             {
               "label": "Book a therapeutic injectables review",
@@ -10406,7 +10592,7 @@
           "id": "facial_aesthetics_mid_cta",
           "type": "treatment_mid_cta",
           "title": "Explore facial aesthetics options",
-          "strapline": "Choose a natural, clinician-led approach \u2014 with clear advice on what\u2019s appropriate and what\u2019s not."
+          "strapline": "Choose a natural, clinician-led approach — with clear advice on what’s appropriate and what’s not."
         },
         {
           "id": "treatment.faq"
@@ -10418,7 +10604,7 @@
           "id": "facial_aesthetics_closing_cta",
           "type": "treatment_closing_cta",
           "title": "Facial aesthetics consultation",
-          "strapline": "If you\u2019re considering facial aesthetics, we\u2019ll help you make a calm, informed decision.\n\nWe\u2019ll talk through your goals, what\u2019s realistic, and what would suit your facial balance \u2014 with an emphasis on subtle, natural results and safety.",
+          "strapline": "If you’re considering facial aesthetics, we’ll help you make a calm, informed decision.\n\nWe’ll talk through your goals, what’s realistic, and what would suit your facial balance — with an emphasis on subtle, natural results and safety.",
           "ctas": [
             {
               "label": "Book a facial aesthetics consultation",
@@ -10612,7 +10798,7 @@
           "id": "anti_wrinkle_treatments_mid_cta",
           "type": "treatment_mid_cta",
           "title": "Related facial aesthetics",
-          "strapline": "Subtle, clinician-led treatment \u2014 with clear guidance on suitability, safety, and natural results."
+          "strapline": "Subtle, clinician-led treatment — with clear guidance on suitability, safety, and natural results."
         },
         {
           "id": "treatment.faq"
@@ -10624,7 +10810,7 @@
           "id": "anti_wrinkle_treatments_closing_cta",
           "type": "treatment_closing_cta",
           "title": "Anti-wrinkle treatment consultation",
-          "strapline": "If you\u2019re considering anti-wrinkle treatments, we\u2019ll help you decide calmly and realistically.\n\nWe\u2019ll talk through your goals, facial balance, and what would look natural \u2014 and we\u2019ll only recommend treatment where it\u2019s appropriate and safe.",
+          "strapline": "If you’re considering anti-wrinkle treatments, we’ll help you decide calmly and realistically.\n\nWe’ll talk through your goals, facial balance, and what would look natural — and we’ll only recommend treatment where it’s appropriate and safe.",
           "ctas": [
             {
               "label": "Book an anti-wrinkle consultation",
@@ -10682,7 +10868,7 @@
           "id": "dermal_fillers_mid_cta",
           "type": "treatment_mid_cta",
           "title": "Related facial aesthetics",
-          "strapline": "A careful, proportion-led approach \u2014 focused on balance, structure, and natural movement."
+          "strapline": "A careful, proportion-led approach — focused on balance, structure, and natural movement."
         },
         {
           "id": "treatment.faq"
@@ -10694,7 +10880,7 @@
           "id": "dermal_fillers_closing_cta",
           "type": "treatment_closing_cta",
           "title": "Dermal filler consultation",
-          "strapline": "Dermal fillers can be used to restore balance, support facial structure, and soften changes that develop over time.\n\nWe\u2019ll assess facial proportions, skin quality, and movement, explain what\u2019s realistic, and only recommend treatment where it\u2019s appropriate, subtle, and safe.",
+          "strapline": "Dermal fillers can be used to restore balance, support facial structure, and soften changes that develop over time.\n\nWe’ll assess facial proportions, skin quality, and movement, explain what’s realistic, and only recommend treatment where it’s appropriate, subtle, and safe.",
           "ctas": [
             {
               "label": "Book a dermal filler consultation",
@@ -10764,7 +10950,7 @@
           "id": "skin_boosters_closing_cta",
           "type": "treatment_closing_cta",
           "title": "Skin booster consultation",
-          "strapline": "Skin boosters are designed to improve hydration, texture, and elasticity with subtle, natural-looking change over time.\n\nWe\u2019ll talk through your goals, skin quality, and what\u2019s realistic, then recommend a plan only if it\u2019s appropriate and safe for you.",
+          "strapline": "Skin boosters are designed to improve hydration, texture, and elasticity with subtle, natural-looking change over time.\n\nWe’ll talk through your goals, skin quality, and what’s realistic, then recommend a plan only if it’s appropriate and safe for you.",
           "ctas": [
             {
               "label": "Book a skin booster consultation",
@@ -10822,7 +11008,7 @@
           "id": "polynucleotides_mid_cta",
           "type": "treatment_mid_cta",
           "title": "Related facial therapeutics",
-          "strapline": "Compare options that support hydration, texture, and natural-looking skin quality \u2014 with clear advice on suitability."
+          "strapline": "Compare options that support hydration, texture, and natural-looking skin quality — with clear advice on suitability."
         },
         {
           "id": "treatment.faq"
@@ -10834,7 +11020,7 @@
           "id": "polynucleotides_closing_cta",
           "type": "treatment_closing_cta",
           "title": "Polynucleotides consultation",
-          "strapline": "Polynucleotides are used to support skin quality over time \u2014 often focusing on texture, hydration, and a healthier-looking finish rather than dramatic \u2018instant\u2019 change.\n\nWe\u2019ll talk through your goals, assess what\u2019s realistic, and recommend a plan only if it\u2019s appropriate, subtle, and safe.",
+          "strapline": "Polynucleotides are used to support skin quality over time — often focusing on texture, hydration, and a healthier-looking finish rather than dramatic ‘instant’ change.\n\nWe’ll talk through your goals, assess what’s realistic, and recommend a plan only if it’s appropriate, subtle, and safe.",
           "ctas": [
             {
               "label": "Book a polynucleotides consultation",
@@ -10886,7 +11072,7 @@
           "id": "mouthguards_and_retainers_mid_cta",
           "type": "treatment_mid_cta",
           "title": "Protection options to compare",
-          "strapline": "Retainers, sports guards, and night guards do different jobs \u2014 we\u2019ll help you choose what\u2019s appropriate."
+          "strapline": "Retainers, sports guards, and night guards do different jobs — we’ll help you choose what’s appropriate."
         },
         {
           "id": "treatment.faq"
@@ -10898,7 +11084,7 @@
           "id": "mouthguards_and_retainers_closing_cta",
           "type": "treatment_closing_cta",
           "title": "Protect teeth, restorations, and orthodontic results",
-          "strapline": "Mouthguards and retainers can protect teeth during sport, help maintain orthodontic results, and reduce wear from clenching in the right situations.\n\nWe\u2019ll assess your bite and risks, then recommend the simplest option that genuinely helps \u2014 without over-treating.",
+          "strapline": "Mouthguards and retainers can protect teeth during sport, help maintain orthodontic results, and reduce wear from clenching in the right situations.\n\nWe’ll assess your bite and risks, then recommend the simplest option that genuinely helps — without over-treating.",
           "ctas": [
             {
               "label": "Book a mouthguard / retainer review",

--- a/packages/champagne-manifests/src/__tests__/answerSurface.test.ts
+++ b/packages/champagne-manifests/src/__tests__/answerSurface.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import {
+  TREATMENT_ANSWER_SURFACE_REQUIRED_SECTION_IDS,
+  validateTreatmentAnswerSurface,
+  type TreatmentAnswerSurface,
+} from "../answerSurface";
+
+const completeSurface = (): TreatmentAnswerSurface => ({
+  version: "TREATMENT_ANSWER_SURFACE_V1",
+  status: "example_seed",
+  exampleSeed: true,
+  primaryGeography: "Shoreham-by-Sea",
+  sections: TREATMENT_ANSWER_SURFACE_REQUIRED_SECTION_IDS.map((id) => ({
+    id,
+    heading: id,
+    body: `Answer content for ${id}.`,
+  })),
+});
+
+describe("treatment answer-surface model", () => {
+  it("validates all required sections when present", () => {
+    const result = validateTreatmentAnswerSurface(completeSurface());
+
+    expect(result.valid).toBe(true);
+    expect(result.frameworkPresent).toBe(true);
+    expect(result.missingSectionIds).toEqual([]);
+    expect(result.presentSectionIds).toHaveLength(TREATMENT_ANSWER_SURFACE_REQUIRED_SECTION_IDS.length);
+  });
+
+  it("detects missing sections", () => {
+    const surface = completeSurface();
+    surface.sections = surface.sections.filter((section) => section.id !== "aftercare");
+
+    const result = validateTreatmentAnswerSurface(surface);
+
+    expect(result.valid).toBe(false);
+    expect(result.missingSectionIds).toContain("aftercare");
+    expect(result.errors.join(" ")).toContain("aftercare");
+  });
+
+  it("reports secondary geography stuffing without making Shoreham secondary", () => {
+    const surface = completeSurface();
+    surface.sections[0] = {
+      id: "direct_answer",
+      heading: "Direct answer",
+      body: "Brighton Brighton Brighton Worthing Lancing Southwick should be reported as stuffing while Shoreham-by-Sea remains primary.",
+    };
+
+    const result = validateTreatmentAnswerSurface(surface);
+
+    expect(result.secondaryGeographyStuffing).toBe(true);
+    expect(result.secondaryGeographyMentions.Brighton).toBe(3);
+    expect(result.warnings.join(" ")).toContain("Secondary geography");
+  });
+});

--- a/packages/champagne-manifests/src/answerSurface.ts
+++ b/packages/champagne-manifests/src/answerSurface.ts
@@ -1,0 +1,179 @@
+export const TREATMENT_ANSWER_SURFACE_REQUIRED_SECTION_IDS = [
+  "direct_answer",
+  "what_this_treatment_is",
+  "who_it_is_for",
+  "who_it_may_not_be_suitable_for",
+  "benefits",
+  "risks_and_limitations",
+  "alternatives",
+  "process",
+  "timeline",
+  "aftercare",
+  "cost_fee_logic",
+  "local_shoreham_context",
+  "clinician_expertise",
+  "technology_used",
+  "faq",
+  "related_treatments_internal_links",
+  "last_reviewed_clinical_review",
+  "cta",
+] as const;
+
+export type TreatmentAnswerSurfaceSectionId =
+  (typeof TREATMENT_ANSWER_SURFACE_REQUIRED_SECTION_IDS)[number];
+
+export type TreatmentAnswerSurfaceStatus = "example_seed" | "draft" | "ready_for_clinical_review" | "clinically_reviewed";
+
+export interface TreatmentAnswerSurfaceLink {
+  label: string;
+  href: string;
+  relationship?: "alternative" | "related" | "next_step" | "prerequisite" | "maintenance" | string;
+}
+
+export interface TreatmentAnswerSurfaceFaq {
+  question: string;
+  answer: string;
+}
+
+export interface TreatmentAnswerSurfaceSection {
+  id: TreatmentAnswerSurfaceSectionId | string;
+  heading: string;
+  body?: string;
+  items?: string[];
+  faqs?: TreatmentAnswerSurfaceFaq[];
+  links?: TreatmentAnswerSurfaceLink[];
+  ctas?: TreatmentAnswerSurfaceLink[];
+  review?: {
+    lastReviewed?: string;
+    clinicalReviewer?: string;
+    nextReviewDue?: string;
+  };
+}
+
+export interface TreatmentAnswerSurface {
+  version: string;
+  status: TreatmentAnswerSurfaceStatus | string;
+  frameworkOnly?: boolean;
+  exampleSeed?: boolean;
+  primaryGeography: string;
+  secondaryGeographies?: string[];
+  sections: TreatmentAnswerSurfaceSection[];
+}
+
+export interface TreatmentAnswerSurfaceValidationResult {
+  valid: boolean;
+  frameworkPresent: boolean;
+  presentSectionIds: string[];
+  missingSectionIds: string[];
+  duplicateSectionIds: string[];
+  unknownSectionIds: string[];
+  emptySectionIds: string[];
+  secondaryGeographyMentions: Record<string, number>;
+  secondaryGeographyStuffing: boolean;
+  errors: string[];
+  warnings: string[];
+}
+
+const REQUIRED_SECTION_SET = new Set<string>(TREATMENT_ANSWER_SURFACE_REQUIRED_SECTION_IDS);
+const DEFAULT_SECONDARY_GEOGRAPHIES = ["Brighton", "Worthing", "Lancing", "Southwick"];
+
+function textFromValue(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (Array.isArray(value)) return value.map(textFromValue).join(" ");
+  if (value && typeof value === "object") return Object.values(value).map(textFromValue).join(" ");
+  return "";
+}
+
+function countNeedle(haystack: string, needle: string): number {
+  const escaped = needle.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return (haystack.match(new RegExp(`\\b${escaped}\\b`, "gi")) ?? []).length;
+}
+
+export function validateTreatmentAnswerSurface(
+  answerSurface: TreatmentAnswerSurface | null | undefined,
+): TreatmentAnswerSurfaceValidationResult {
+  const errors: string[] = [];
+  const warnings: string[] = [];
+
+  if (!answerSurface || typeof answerSurface !== "object") {
+    return {
+      valid: false,
+      frameworkPresent: false,
+      presentSectionIds: [],
+      missingSectionIds: [...TREATMENT_ANSWER_SURFACE_REQUIRED_SECTION_IDS],
+      duplicateSectionIds: [],
+      unknownSectionIds: [],
+      emptySectionIds: [],
+      secondaryGeographyMentions: {},
+      secondaryGeographyStuffing: false,
+      errors: ["answerSurface is missing"],
+      warnings,
+    };
+  }
+
+  if (answerSurface.version !== "TREATMENT_ANSWER_SURFACE_V1") {
+    errors.push("answerSurface.version must be TREATMENT_ANSWER_SURFACE_V1");
+  }
+  if (answerSurface.primaryGeography !== "Shoreham-by-Sea") {
+    errors.push("answerSurface.primaryGeography must remain Shoreham-by-Sea");
+  }
+
+  const sections = Array.isArray(answerSurface.sections) ? answerSurface.sections : [];
+  if (sections.length === 0) errors.push("answerSurface.sections must be a non-empty array");
+
+  const seen = new Set<string>();
+  const duplicateSectionIds = new Set<string>();
+  const unknownSectionIds = new Set<string>();
+  const emptySectionIds = new Set<string>();
+
+  for (const section of sections) {
+    const sectionId = section?.id;
+    if (!sectionId || !REQUIRED_SECTION_SET.has(sectionId)) {
+      unknownSectionIds.add(String(sectionId ?? "(missing)"));
+      continue;
+    }
+    if (seen.has(sectionId)) duplicateSectionIds.add(sectionId);
+    seen.add(sectionId);
+    const hasBody = typeof section.body === "string" && section.body.trim().length > 0;
+    const hasItems = Array.isArray(section.items) && section.items.some((item) => item.trim().length > 0);
+    const hasFaqs = Array.isArray(section.faqs) && section.faqs.length > 0;
+    const hasLinks = Array.isArray(section.links) && section.links.length > 0;
+    const hasCtas = Array.isArray(section.ctas) && section.ctas.length > 0;
+    const hasReview = Boolean(section.review?.lastReviewed || section.review?.clinicalReviewer || section.review?.nextReviewDue);
+    if (!section.heading || !(hasBody || hasItems || hasFaqs || hasLinks || hasCtas || hasReview)) {
+      emptySectionIds.add(sectionId);
+    }
+  }
+
+  const presentSectionIds = TREATMENT_ANSWER_SURFACE_REQUIRED_SECTION_IDS.filter((sectionId) => seen.has(sectionId));
+  const missingSectionIds = TREATMENT_ANSWER_SURFACE_REQUIRED_SECTION_IDS.filter((sectionId) => !seen.has(sectionId));
+  const secondaryGeographies = answerSurface.secondaryGeographies?.length
+    ? answerSurface.secondaryGeographies
+    : DEFAULT_SECONDARY_GEOGRAPHIES;
+  const allText = textFromValue(answerSurface.sections);
+  const secondaryGeographyMentions = Object.fromEntries(
+    secondaryGeographies.map((geography) => [geography, countNeedle(allText, geography)]),
+  );
+  const totalSecondaryMentions = Object.values(secondaryGeographyMentions).reduce((total, count) => total + count, 0);
+  const secondaryGeographyStuffing = totalSecondaryMentions > 4 || Object.values(secondaryGeographyMentions).some((count) => count > 2);
+
+  if (missingSectionIds.length > 0) errors.push(`Missing answerSurface sections: ${missingSectionIds.join(", ")}`);
+  if (duplicateSectionIds.size > 0) errors.push(`Duplicate answerSurface sections: ${[...duplicateSectionIds].join(", ")}`);
+  if (unknownSectionIds.size > 0) errors.push(`Unknown answerSurface sections: ${[...unknownSectionIds].join(", ")}`);
+  if (emptySectionIds.size > 0) errors.push(`Empty answerSurface sections: ${[...emptySectionIds].join(", ")}`);
+  if (secondaryGeographyStuffing) warnings.push("Secondary geography mentions exceed answer-surface stuffing threshold");
+
+  return {
+    valid: errors.length === 0,
+    frameworkPresent: true,
+    presentSectionIds,
+    missingSectionIds,
+    duplicateSectionIds: [...duplicateSectionIds],
+    unknownSectionIds: [...unknownSectionIds],
+    emptySectionIds: [...emptySectionIds],
+    secondaryGeographyMentions,
+    secondaryGeographyStuffing,
+    errors,
+    warnings,
+  };
+}

--- a/packages/champagne-manifests/src/core.ts
+++ b/packages/champagne-manifests/src/core.ts
@@ -9,6 +9,7 @@ import sectionPageDefaults from "../data/sections/page-type.defaults.json";
 import sectionFxDefaults from "../data/sections/section-fx.defaults.json";
 import sectionPrmDefaults from "../data/sections/section-prm.defaults.json";
 import sectionLibraryData from "../data/sections/section-library.json";
+import type { TreatmentAnswerSurface } from "./answerSurface";
 import sectionLayoutAligners from "../data/sections/smh/treatments.aligners.json";
 import sectionLayoutClearAligners from "../data/sections/smh/treatments.clear-aligners.json";
 import sectionLayoutSparkAligners from "../data/sections/smh/treatments.clear-aligners-spark.json";
@@ -139,6 +140,7 @@ export interface ChampagnePageManifest {
   category?: string;
   label?: string;
   ctas?: ChampagnePageCTAConfig;
+  answerSurface?: TreatmentAnswerSurface;
   [key: string]: unknown;
 }
 

--- a/packages/champagne-manifests/src/helpers.ts
+++ b/packages/champagne-manifests/src/helpers.ts
@@ -14,6 +14,7 @@ import type {
   ChampagneStylesManifest,
   ChampagneHeroBinding,
 } from "./core";
+import type { TreatmentAnswerSurface } from "./answerSurface";
 import {
   champagneMachineManifest,
   champagneMediaDeckManifests,
@@ -169,6 +170,10 @@ function collectTreatmentEntries(): ChampagneTreatmentPage[] {
 
 export function getTreatmentPages(): ChampagneTreatmentPage[] {
   return collectTreatmentEntries();
+}
+
+export function getTreatmentAnswerSurface(slugOrPath: string): TreatmentAnswerSurface | undefined {
+  return getTreatmentManifest(slugOrPath)?.answerSurface;
 }
 
 export function getTreatmentManifest(slugOrPath: string): ChampagneTreatmentPage | undefined {

--- a/packages/champagne-manifests/src/index.ts
+++ b/packages/champagne-manifests/src/index.ts
@@ -63,6 +63,7 @@ export {
   getMediaDecks,
   getMediaDeck,
   getTreatmentManifest,
+  getTreatmentAnswerSurface,
   resolveTreatmentPathAlias,
   getTreatmentPages,
   getCTAIntentConfigForRoute,
@@ -75,5 +76,16 @@ export {
   type ChampagneTreatmentPage,
   type ChampagneCTAIntentConfig,
 } from "./helpers";
+export {
+  TREATMENT_ANSWER_SURFACE_REQUIRED_SECTION_IDS,
+  validateTreatmentAnswerSurface,
+  type TreatmentAnswerSurface,
+  type TreatmentAnswerSurfaceFaq,
+  type TreatmentAnswerSurfaceLink,
+  type TreatmentAnswerSurfaceSection,
+  type TreatmentAnswerSurfaceSectionId,
+  type TreatmentAnswerSurfaceStatus,
+  type TreatmentAnswerSurfaceValidationResult,
+} from "./answerSurface";
 export { useValidatedManifest } from "./useValidatedManifest";
 export type { ChampagneManifest, ChampagneSectionEntry } from "./types";

--- a/packages/champagne-sections/src/ChampagneSectionRenderer.tsx
+++ b/packages/champagne-sections/src/ChampagneSectionRenderer.tsx
@@ -18,6 +18,7 @@ import { Section_TreatmentToolsTrio } from "./Section_TreatmentToolsTrio";
 import { getSectionStack } from "./SectionRegistry";
 import type { SectionRegistryEntry } from "./SectionRegistry";
 import { Section_GoogleReviews } from "./Section_GoogleReviews";
+import { Section_TreatmentAnswerSurface } from "./Section_TreatmentAnswerSurface";
 import { arbitrateCtaSurfaces } from "./ctaSurfaceArbitrator";
 import { normalizeSectionsForMidCTA } from "./ctaPlacement";
 
@@ -54,6 +55,7 @@ const typeMap: Record<string, SectionComponent> = {
   treatment_faq_block: (props) => <Section_FAQ {...props} />,
   treatment_closing_cta: (props) => <Section_TreatmentClosingCTA {...props} />,
   reviews: (props) => <Section_GoogleReviews {...props} />,
+  treatment_answer_surface: (props) => <Section_TreatmentAnswerSurface {...props} />,
 };
 
 function enforceSingleClosingCTA(sections: SectionRegistryEntry[]) {

--- a/packages/champagne-sections/src/SectionRegistry.ts
+++ b/packages/champagne-sections/src/SectionRegistry.ts
@@ -20,7 +20,8 @@ export interface SectionRegistryEntry {
     | "treatment_mid_cta"
     | "treatment_faq_block"
     | "treatment_closing_cta"
-    | "reviews";
+    | "reviews"
+    | "treatment_answer_surface";
   title?: string;
   body?: string;
   eyebrow?: string;
@@ -84,6 +85,7 @@ const specializedKinds: Record<string, SectionRegistryEntry["kind"]> = {
   treatment_faq_block: "treatment_faq_block",
   faq: "treatment_faq_block",
   treatment_closing_cta: "treatment_closing_cta",
+  treatment_answer_surface: "treatment_answer_surface",
   cta: "treatment_closing_cta",
   google_reviews: "reviews",
   routing_cards: "routing_cards",

--- a/packages/champagne-sections/src/Section_TreatmentAnswerSurface.tsx
+++ b/packages/champagne-sections/src/Section_TreatmentAnswerSurface.tsx
@@ -1,0 +1,152 @@
+import type { CSSProperties } from "react";
+import type { TreatmentAnswerSurface, TreatmentAnswerSurfaceSection } from "@champagne/manifests";
+import { TREATMENT_ANSWER_SURFACE_REQUIRED_SECTION_IDS } from "@champagne/manifests";
+import type { SectionRegistryEntry } from "./SectionRegistry";
+
+interface SectionTreatmentAnswerSurfaceProps {
+  section: SectionRegistryEntry;
+}
+
+const shellStyle: CSSProperties = {
+  display: "grid",
+  gap: "clamp(1rem, 2vw, 1.5rem)",
+  padding: "clamp(1.25rem, 3vw, 2rem)",
+  border: "1px solid var(--border-subtle)",
+  background: "var(--surface-0)",
+  color: "var(--text-high)",
+  boxShadow: "var(--shadow-soft)",
+};
+
+const gridStyle: CSSProperties = {
+  display: "grid",
+  gridTemplateColumns: "repeat(auto-fit, minmax(min(100%, 18rem), 1fr))",
+  gap: "clamp(0.8rem, 1.8vw, 1.2rem)",
+};
+
+const cardStyle: CSSProperties = {
+  display: "grid",
+  gap: "0.65rem",
+  padding: "1rem",
+  border: "1px solid var(--border-subtle)",
+  background: "var(--surface-1)",
+  color: "var(--text-medium)",
+};
+
+const headingStyle: CSSProperties = {
+  margin: 0,
+  color: "var(--text-high)",
+  fontSize: "clamp(1rem, 1.5vw, 1.2rem)",
+};
+
+const bodyStyle: CSSProperties = {
+  margin: 0,
+  color: "var(--text-medium)",
+  lineHeight: 1.65,
+};
+
+const eyebrowStyle: CSSProperties = {
+  margin: 0,
+  color: "var(--text-low)",
+  textTransform: "uppercase",
+  letterSpacing: "0.08em",
+  fontSize: "0.78rem",
+};
+
+function isAnswerSurface(value: unknown): value is TreatmentAnswerSurface {
+  return Boolean(value && typeof value === "object" && Array.isArray((value as TreatmentAnswerSurface).sections));
+}
+
+function extractAnswerSurface(section: SectionRegistryEntry): TreatmentAnswerSurface | undefined {
+  const definition = section.definition && typeof section.definition === "object" ? section.definition : undefined;
+  const fromDefinition = (definition as { answerSurface?: unknown } | undefined)?.answerSurface;
+  if (isAnswerSurface(fromDefinition)) return fromDefinition;
+  if (isAnswerSurface(definition)) return definition;
+  return undefined;
+}
+
+function renderSectionContent(answerSection: TreatmentAnswerSurfaceSection) {
+  if (answerSection.faqs?.length) {
+    return answerSection.faqs.map((faq) => (
+      <p key={faq.question} style={bodyStyle}>
+        <strong>{faq.question}</strong> {faq.answer}
+      </p>
+    ));
+  }
+
+  if (answerSection.links?.length) {
+    return (
+      <ul style={{ margin: 0, paddingInlineStart: "1.1rem" }}>
+        {answerSection.links.map((link) => (
+          <li key={`${link.href}-${link.label}`}>
+            <a href={link.href}>{link.label}</a>
+          </li>
+        ))}
+      </ul>
+    );
+  }
+
+  if (answerSection.ctas?.length) {
+    return (
+      <ul style={{ margin: 0, paddingInlineStart: "1.1rem" }}>
+        {answerSection.ctas.map((cta) => (
+          <li key={`${cta.href}-${cta.label}`}>
+            <a href={cta.href}>{cta.label}</a>
+          </li>
+        ))}
+      </ul>
+    );
+  }
+
+  if (answerSection.items?.length) {
+    return (
+      <ul style={{ margin: 0, paddingInlineStart: "1.1rem" }}>
+        {answerSection.items.map((item) => (
+          <li key={item}>{item}</li>
+        ))}
+      </ul>
+    );
+  }
+
+  if (answerSection.review) {
+    return (
+      <p style={bodyStyle}>
+        Last reviewed: {answerSection.review.lastReviewed ?? "To be confirmed"}. Clinical reviewer: {answerSection.review.clinicalReviewer ?? "To be confirmed"}.
+      </p>
+    );
+  }
+
+  return null;
+}
+
+export function Section_TreatmentAnswerSurface({ section }: SectionTreatmentAnswerSurfaceProps) {
+  const answerSurface = extractAnswerSurface(section);
+  if (!answerSurface) return null;
+
+  const sectionsById = new Map(answerSurface.sections.map((answerSection) => [answerSection.id, answerSection]));
+  const orderedSections = TREATMENT_ANSWER_SURFACE_REQUIRED_SECTION_IDS
+    .map((sectionId) => sectionsById.get(sectionId))
+    .filter((answerSection): answerSection is TreatmentAnswerSurfaceSection => Boolean(answerSection));
+
+  return (
+    <section style={shellStyle} aria-labelledby={`${section.id}-heading`} data-answer-surface-status={answerSurface.status}>
+      <div style={{ display: "grid", gap: "0.45rem" }}>
+        <p style={eyebrowStyle}>Treatment answers</p>
+        <h2 id={`${section.id}-heading`} style={{ ...headingStyle, fontSize: "clamp(1.35rem, 2.5vw, 2rem)" }}>
+          {section.title ?? "Treatment answer surface"}
+        </h2>
+        {answerSurface.exampleSeed && (
+          <p style={bodyStyle}>Example seed only. Future content rewrites can replace this structured data without changing the route or hero.</p>
+        )}
+      </div>
+      <div style={gridStyle}>
+        {orderedSections.map((answerSection) => (
+          <article key={answerSection.id} style={cardStyle}>
+            <h3 style={headingStyle}>{answerSection.heading}</h3>
+            {answerSection.body && <p style={bodyStyle}>{answerSection.body}</p>}
+            {renderSectionContent(answerSection)}
+          </article>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/packages/champagne-sections/src/index.ts
+++ b/packages/champagne-sections/src/index.ts
@@ -15,3 +15,4 @@ export { Section_PatientStoriesRail } from "./Section_PatientStoriesRail";
 export { Section_FAQ } from "./Section_FAQ";
 export { Section_TreatmentClosingCTA } from "./Section_TreatmentClosingCTA";
 export { Section_GoogleReviews } from "./Section_GoogleReviews";
+export { Section_TreatmentAnswerSurface } from "./Section_TreatmentAnswerSurface";

--- a/reports/WEBSITE_TRUTH_EXPORT_REPORT_V1.json
+++ b/reports/WEBSITE_TRUTH_EXPORT_REPORT_V1.json
@@ -1,6 +1,6 @@
 {
   "version": "WEBSITE_TRUTH_EXPORT_REPORT_V1",
-  "generatedAt": "2026-05-28T19:10:45.734Z",
+  "generatedAt": "2026-05-29T13:45:44.821Z",
   "contract": {
     "file": "ops/contracts/WEBSITE_TRUTH_EXPORT_CONTRACT_V1.json",
     "version": "CHAMPAGNE_WEBSITE_TRUTH_EXPORT_CONTRACT_V1"
@@ -6324,7 +6324,8 @@
         "variantId": "hero.variant.group.02_v1"
       },
       "sectionCount": 10,
-      "surface": "champagne/surface/base"
+      "surface": "champagne/surface/base",
+      "answerSurface": null
     },
     {
       "route": "/treatments/implants",
@@ -6337,7 +6338,21 @@
         "variantId": "treatment.implants"
       },
       "sectionCount": 13,
-      "surface": "champagne/surface/treatment"
+      "surface": "champagne/surface/treatment",
+      "answerSurface": {
+        "frameworkPresent": true,
+        "valid": true,
+        "status": "example_seed",
+        "presentSectionCount": 18,
+        "missingSectionIds": [],
+        "secondaryGeographyMentions": {
+          "Brighton": 0,
+          "Worthing": 0,
+          "Lancing": 0,
+          "Southwick": 0
+        },
+        "secondaryGeographyStuffing": false
+      }
     },
     {
       "route": "/treatments/veneers",
@@ -6350,7 +6365,35 @@
         "variantId": "hero.variant.group.05_v1"
       },
       "sectionCount": 13,
-      "surface": "champagne/surface/treatment"
+      "surface": "champagne/surface/treatment",
+      "answerSurface": {
+        "frameworkPresent": false,
+        "valid": false,
+        "status": null,
+        "presentSectionCount": 0,
+        "missingSectionIds": [
+          "direct_answer",
+          "what_this_treatment_is",
+          "who_it_is_for",
+          "who_it_may_not_be_suitable_for",
+          "benefits",
+          "risks_and_limitations",
+          "alternatives",
+          "process",
+          "timeline",
+          "aftercare",
+          "cost_fee_logic",
+          "local_shoreham_context",
+          "clinician_expertise",
+          "technology_used",
+          "faq",
+          "related_treatments_internal_links",
+          "last_reviewed_clinical_review",
+          "cta"
+        ],
+        "secondaryGeographyMentions": {},
+        "secondaryGeographyStuffing": false
+      }
     },
     {
       "route": "/treatments/clear-aligners",
@@ -6363,7 +6406,35 @@
         "variantId": "hero.variant.group.04_v1"
       },
       "sectionCount": 12,
-      "surface": "champagne/surface/treatment"
+      "surface": "champagne/surface/treatment",
+      "answerSurface": {
+        "frameworkPresent": false,
+        "valid": false,
+        "status": null,
+        "presentSectionCount": 0,
+        "missingSectionIds": [
+          "direct_answer",
+          "what_this_treatment_is",
+          "who_it_is_for",
+          "who_it_may_not_be_suitable_for",
+          "benefits",
+          "risks_and_limitations",
+          "alternatives",
+          "process",
+          "timeline",
+          "aftercare",
+          "cost_fee_logic",
+          "local_shoreham_context",
+          "clinician_expertise",
+          "technology_used",
+          "faq",
+          "related_treatments_internal_links",
+          "last_reviewed_clinical_review",
+          "cta"
+        ],
+        "secondaryGeographyMentions": {},
+        "secondaryGeographyStuffing": false
+      }
     },
     {
       "route": "/treatments/clear-aligners-spark",
@@ -6376,7 +6447,35 @@
         "variantId": "hero.variant.group.07_v1"
       },
       "sectionCount": 11,
-      "surface": "champagne/surface/treatment"
+      "surface": "champagne/surface/treatment",
+      "answerSurface": {
+        "frameworkPresent": false,
+        "valid": false,
+        "status": null,
+        "presentSectionCount": 0,
+        "missingSectionIds": [
+          "direct_answer",
+          "what_this_treatment_is",
+          "who_it_is_for",
+          "who_it_may_not_be_suitable_for",
+          "benefits",
+          "risks_and_limitations",
+          "alternatives",
+          "process",
+          "timeline",
+          "aftercare",
+          "cost_fee_logic",
+          "local_shoreham_context",
+          "clinician_expertise",
+          "technology_used",
+          "faq",
+          "related_treatments_internal_links",
+          "last_reviewed_clinical_review",
+          "cta"
+        ],
+        "secondaryGeographyMentions": {},
+        "secondaryGeographyStuffing": false
+      }
     },
     {
       "route": "/treatments/fixed-braces",
@@ -6389,7 +6488,35 @@
         "variantId": "hero.variant.group.06_v1"
       },
       "sectionCount": 10,
-      "surface": "champagne/surface/treatment"
+      "surface": "champagne/surface/treatment",
+      "answerSurface": {
+        "frameworkPresent": false,
+        "valid": false,
+        "status": null,
+        "presentSectionCount": 0,
+        "missingSectionIds": [
+          "direct_answer",
+          "what_this_treatment_is",
+          "who_it_is_for",
+          "who_it_may_not_be_suitable_for",
+          "benefits",
+          "risks_and_limitations",
+          "alternatives",
+          "process",
+          "timeline",
+          "aftercare",
+          "cost_fee_logic",
+          "local_shoreham_context",
+          "clinician_expertise",
+          "technology_used",
+          "faq",
+          "related_treatments_internal_links",
+          "last_reviewed_clinical_review",
+          "cta"
+        ],
+        "secondaryGeographyMentions": {},
+        "secondaryGeographyStuffing": false
+      }
     },
     {
       "route": "/treatments/dental-checkups-oral-cancer-screening",
@@ -6402,7 +6529,35 @@
         "variantId": "hero.variant.group.01_v1"
       },
       "sectionCount": 9,
-      "surface": "champagne/surface/hub"
+      "surface": "champagne/surface/hub",
+      "answerSurface": {
+        "frameworkPresent": false,
+        "valid": false,
+        "status": null,
+        "presentSectionCount": 0,
+        "missingSectionIds": [
+          "direct_answer",
+          "what_this_treatment_is",
+          "who_it_is_for",
+          "who_it_may_not_be_suitable_for",
+          "benefits",
+          "risks_and_limitations",
+          "alternatives",
+          "process",
+          "timeline",
+          "aftercare",
+          "cost_fee_logic",
+          "local_shoreham_context",
+          "clinician_expertise",
+          "technology_used",
+          "faq",
+          "related_treatments_internal_links",
+          "last_reviewed_clinical_review",
+          "cta"
+        ],
+        "secondaryGeographyMentions": {},
+        "secondaryGeographyStuffing": false
+      }
     },
     {
       "route": "/treatments/implants-single-tooth",
@@ -6415,7 +6570,35 @@
         "variantId": "hero.variant.group.09_v1"
       },
       "sectionCount": 11,
-      "surface": "champagne/surface/treatment"
+      "surface": "champagne/surface/treatment",
+      "answerSurface": {
+        "frameworkPresent": false,
+        "valid": false,
+        "status": null,
+        "presentSectionCount": 0,
+        "missingSectionIds": [
+          "direct_answer",
+          "what_this_treatment_is",
+          "who_it_is_for",
+          "who_it_may_not_be_suitable_for",
+          "benefits",
+          "risks_and_limitations",
+          "alternatives",
+          "process",
+          "timeline",
+          "aftercare",
+          "cost_fee_logic",
+          "local_shoreham_context",
+          "clinician_expertise",
+          "technology_used",
+          "faq",
+          "related_treatments_internal_links",
+          "last_reviewed_clinical_review",
+          "cta"
+        ],
+        "secondaryGeographyMentions": {},
+        "secondaryGeographyStuffing": false
+      }
     },
     {
       "route": "/treatments/implants-multiple-teeth",
@@ -6428,7 +6611,35 @@
         "variantId": "hero.variant.treatment_v1"
       },
       "sectionCount": 11,
-      "surface": "champagne/surface/treatment"
+      "surface": "champagne/surface/treatment",
+      "answerSurface": {
+        "frameworkPresent": false,
+        "valid": false,
+        "status": null,
+        "presentSectionCount": 0,
+        "missingSectionIds": [
+          "direct_answer",
+          "what_this_treatment_is",
+          "who_it_is_for",
+          "who_it_may_not_be_suitable_for",
+          "benefits",
+          "risks_and_limitations",
+          "alternatives",
+          "process",
+          "timeline",
+          "aftercare",
+          "cost_fee_logic",
+          "local_shoreham_context",
+          "clinician_expertise",
+          "technology_used",
+          "faq",
+          "related_treatments_internal_links",
+          "last_reviewed_clinical_review",
+          "cta"
+        ],
+        "secondaryGeographyMentions": {},
+        "secondaryGeographyStuffing": false
+      }
     },
     {
       "route": "/treatments/implants-full-arch",
@@ -6441,7 +6652,35 @@
         "variantId": "hero.variant.treatment_v1"
       },
       "sectionCount": 11,
-      "surface": "champagne/surface/treatment"
+      "surface": "champagne/surface/treatment",
+      "answerSurface": {
+        "frameworkPresent": false,
+        "valid": false,
+        "status": null,
+        "presentSectionCount": 0,
+        "missingSectionIds": [
+          "direct_answer",
+          "what_this_treatment_is",
+          "who_it_is_for",
+          "who_it_may_not_be_suitable_for",
+          "benefits",
+          "risks_and_limitations",
+          "alternatives",
+          "process",
+          "timeline",
+          "aftercare",
+          "cost_fee_logic",
+          "local_shoreham_context",
+          "clinician_expertise",
+          "technology_used",
+          "faq",
+          "related_treatments_internal_links",
+          "last_reviewed_clinical_review",
+          "cta"
+        ],
+        "secondaryGeographyMentions": {},
+        "secondaryGeographyStuffing": false
+      }
     },
     {
       "route": "/treatments/implant-retained-dentures",
@@ -6454,7 +6693,35 @@
         "variantId": "hero.variant.treatment_v1"
       },
       "sectionCount": 11,
-      "surface": "champagne/surface/treatment"
+      "surface": "champagne/surface/treatment",
+      "answerSurface": {
+        "frameworkPresent": false,
+        "valid": false,
+        "status": null,
+        "presentSectionCount": 0,
+        "missingSectionIds": [
+          "direct_answer",
+          "what_this_treatment_is",
+          "who_it_is_for",
+          "who_it_may_not_be_suitable_for",
+          "benefits",
+          "risks_and_limitations",
+          "alternatives",
+          "process",
+          "timeline",
+          "aftercare",
+          "cost_fee_logic",
+          "local_shoreham_context",
+          "clinician_expertise",
+          "technology_used",
+          "faq",
+          "related_treatments_internal_links",
+          "last_reviewed_clinical_review",
+          "cta"
+        ],
+        "secondaryGeographyMentions": {},
+        "secondaryGeographyStuffing": false
+      }
     },
     {
       "route": "/treatments/implant-consultation",
@@ -6467,7 +6734,35 @@
         "variantId": "hero.variant.treatment_v1"
       },
       "sectionCount": 11,
-      "surface": "champagne/surface/treatment"
+      "surface": "champagne/surface/treatment",
+      "answerSurface": {
+        "frameworkPresent": false,
+        "valid": false,
+        "status": null,
+        "presentSectionCount": 0,
+        "missingSectionIds": [
+          "direct_answer",
+          "what_this_treatment_is",
+          "who_it_is_for",
+          "who_it_may_not_be_suitable_for",
+          "benefits",
+          "risks_and_limitations",
+          "alternatives",
+          "process",
+          "timeline",
+          "aftercare",
+          "cost_fee_logic",
+          "local_shoreham_context",
+          "clinician_expertise",
+          "technology_used",
+          "faq",
+          "related_treatments_internal_links",
+          "last_reviewed_clinical_review",
+          "cta"
+        ],
+        "secondaryGeographyMentions": {},
+        "secondaryGeographyStuffing": false
+      }
     },
     {
       "route": "/treatments/implants-bone-grafting",
@@ -6480,7 +6775,35 @@
         "variantId": "hero.variant.treatment_v1"
       },
       "sectionCount": 11,
-      "surface": "champagne/surface/treatment"
+      "surface": "champagne/surface/treatment",
+      "answerSurface": {
+        "frameworkPresent": false,
+        "valid": false,
+        "status": null,
+        "presentSectionCount": 0,
+        "missingSectionIds": [
+          "direct_answer",
+          "what_this_treatment_is",
+          "who_it_is_for",
+          "who_it_may_not_be_suitable_for",
+          "benefits",
+          "risks_and_limitations",
+          "alternatives",
+          "process",
+          "timeline",
+          "aftercare",
+          "cost_fee_logic",
+          "local_shoreham_context",
+          "clinician_expertise",
+          "technology_used",
+          "faq",
+          "related_treatments_internal_links",
+          "last_reviewed_clinical_review",
+          "cta"
+        ],
+        "secondaryGeographyMentions": {},
+        "secondaryGeographyStuffing": false
+      }
     },
     {
       "route": "/treatments/sinus-lift",
@@ -6493,7 +6816,35 @@
         "variantId": "hero.variant.treatment_v1"
       },
       "sectionCount": 11,
-      "surface": "champagne/surface/treatment"
+      "surface": "champagne/surface/treatment",
+      "answerSurface": {
+        "frameworkPresent": false,
+        "valid": false,
+        "status": null,
+        "presentSectionCount": 0,
+        "missingSectionIds": [
+          "direct_answer",
+          "what_this_treatment_is",
+          "who_it_is_for",
+          "who_it_may_not_be_suitable_for",
+          "benefits",
+          "risks_and_limitations",
+          "alternatives",
+          "process",
+          "timeline",
+          "aftercare",
+          "cost_fee_logic",
+          "local_shoreham_context",
+          "clinician_expertise",
+          "technology_used",
+          "faq",
+          "related_treatments_internal_links",
+          "last_reviewed_clinical_review",
+          "cta"
+        ],
+        "secondaryGeographyMentions": {},
+        "secondaryGeographyStuffing": false
+      }
     },
     {
       "route": "/treatments/teeth-in-a-day",
@@ -6506,7 +6857,35 @@
         "variantId": "hero.variant.treatment_v1"
       },
       "sectionCount": 11,
-      "surface": "champagne/surface/treatment"
+      "surface": "champagne/surface/treatment",
+      "answerSurface": {
+        "frameworkPresent": false,
+        "valid": false,
+        "status": null,
+        "presentSectionCount": 0,
+        "missingSectionIds": [
+          "direct_answer",
+          "what_this_treatment_is",
+          "who_it_is_for",
+          "who_it_may_not_be_suitable_for",
+          "benefits",
+          "risks_and_limitations",
+          "alternatives",
+          "process",
+          "timeline",
+          "aftercare",
+          "cost_fee_logic",
+          "local_shoreham_context",
+          "clinician_expertise",
+          "technology_used",
+          "faq",
+          "related_treatments_internal_links",
+          "last_reviewed_clinical_review",
+          "cta"
+        ],
+        "secondaryGeographyMentions": {},
+        "secondaryGeographyStuffing": false
+      }
     },
     {
       "route": "/treatments/sedation-for-implants",
@@ -6519,7 +6898,35 @@
         "variantId": "hero.variant.treatment_v1"
       },
       "sectionCount": 11,
-      "surface": "champagne/surface/treatment"
+      "surface": "champagne/surface/treatment",
+      "answerSurface": {
+        "frameworkPresent": false,
+        "valid": false,
+        "status": null,
+        "presentSectionCount": 0,
+        "missingSectionIds": [
+          "direct_answer",
+          "what_this_treatment_is",
+          "who_it_is_for",
+          "who_it_may_not_be_suitable_for",
+          "benefits",
+          "risks_and_limitations",
+          "alternatives",
+          "process",
+          "timeline",
+          "aftercare",
+          "cost_fee_logic",
+          "local_shoreham_context",
+          "clinician_expertise",
+          "technology_used",
+          "faq",
+          "related_treatments_internal_links",
+          "last_reviewed_clinical_review",
+          "cta"
+        ],
+        "secondaryGeographyMentions": {},
+        "secondaryGeographyStuffing": false
+      }
     },
     {
       "route": "/treatments/failed-implant-replacement",
@@ -6532,7 +6939,35 @@
         "variantId": "hero.variant.treatment_v1"
       },
       "sectionCount": 11,
-      "surface": "champagne/surface/treatment"
+      "surface": "champagne/surface/treatment",
+      "answerSurface": {
+        "frameworkPresent": false,
+        "valid": false,
+        "status": null,
+        "presentSectionCount": 0,
+        "missingSectionIds": [
+          "direct_answer",
+          "what_this_treatment_is",
+          "who_it_is_for",
+          "who_it_may_not_be_suitable_for",
+          "benefits",
+          "risks_and_limitations",
+          "alternatives",
+          "process",
+          "timeline",
+          "aftercare",
+          "cost_fee_logic",
+          "local_shoreham_context",
+          "clinician_expertise",
+          "technology_used",
+          "faq",
+          "related_treatments_internal_links",
+          "last_reviewed_clinical_review",
+          "cta"
+        ],
+        "secondaryGeographyMentions": {},
+        "secondaryGeographyStuffing": false
+      }
     },
     {
       "route": "/treatments/implant-aftercare",
@@ -6545,7 +6980,35 @@
         "variantId": "hero.variant.treatment_v1"
       },
       "sectionCount": 11,
-      "surface": "champagne/surface/treatment"
+      "surface": "champagne/surface/treatment",
+      "answerSurface": {
+        "frameworkPresent": false,
+        "valid": false,
+        "status": null,
+        "presentSectionCount": 0,
+        "missingSectionIds": [
+          "direct_answer",
+          "what_this_treatment_is",
+          "who_it_is_for",
+          "who_it_may_not_be_suitable_for",
+          "benefits",
+          "risks_and_limitations",
+          "alternatives",
+          "process",
+          "timeline",
+          "aftercare",
+          "cost_fee_logic",
+          "local_shoreham_context",
+          "clinician_expertise",
+          "technology_used",
+          "faq",
+          "related_treatments_internal_links",
+          "last_reviewed_clinical_review",
+          "cta"
+        ],
+        "secondaryGeographyMentions": {},
+        "secondaryGeographyStuffing": false
+      }
     },
     {
       "route": "/treatments/surgically-guided-implants",
@@ -6558,7 +7021,35 @@
         "variantId": "hero.variant.treatment_v1"
       },
       "sectionCount": 11,
-      "surface": "champagne/surface/treatment"
+      "surface": "champagne/surface/treatment",
+      "answerSurface": {
+        "frameworkPresent": false,
+        "valid": false,
+        "status": null,
+        "presentSectionCount": 0,
+        "missingSectionIds": [
+          "direct_answer",
+          "what_this_treatment_is",
+          "who_it_is_for",
+          "who_it_may_not_be_suitable_for",
+          "benefits",
+          "risks_and_limitations",
+          "alternatives",
+          "process",
+          "timeline",
+          "aftercare",
+          "cost_fee_logic",
+          "local_shoreham_context",
+          "clinician_expertise",
+          "technology_used",
+          "faq",
+          "related_treatments_internal_links",
+          "last_reviewed_clinical_review",
+          "cta"
+        ],
+        "secondaryGeographyMentions": {},
+        "secondaryGeographyStuffing": false
+      }
     },
     {
       "route": "/treatments/3d-implant-restorations",
@@ -6571,7 +7062,35 @@
         "variantId": "hero.variant.treatment_v1"
       },
       "sectionCount": 11,
-      "surface": "champagne/surface/treatment"
+      "surface": "champagne/surface/treatment",
+      "answerSurface": {
+        "frameworkPresent": false,
+        "valid": false,
+        "status": null,
+        "presentSectionCount": 0,
+        "missingSectionIds": [
+          "direct_answer",
+          "what_this_treatment_is",
+          "who_it_is_for",
+          "who_it_may_not_be_suitable_for",
+          "benefits",
+          "risks_and_limitations",
+          "alternatives",
+          "process",
+          "timeline",
+          "aftercare",
+          "cost_fee_logic",
+          "local_shoreham_context",
+          "clinician_expertise",
+          "technology_used",
+          "faq",
+          "related_treatments_internal_links",
+          "last_reviewed_clinical_review",
+          "cta"
+        ],
+        "secondaryGeographyMentions": {},
+        "secondaryGeographyStuffing": false
+      }
     },
     {
       "route": "/treatments/3d-printed-veneers",
@@ -6584,7 +7103,35 @@
         "variantId": "hero.variant.treatment_v1"
       },
       "sectionCount": 11,
-      "surface": "champagne/surface/treatment"
+      "surface": "champagne/surface/treatment",
+      "answerSurface": {
+        "frameworkPresent": false,
+        "valid": false,
+        "status": null,
+        "presentSectionCount": 0,
+        "missingSectionIds": [
+          "direct_answer",
+          "what_this_treatment_is",
+          "who_it_is_for",
+          "who_it_may_not_be_suitable_for",
+          "benefits",
+          "risks_and_limitations",
+          "alternatives",
+          "process",
+          "timeline",
+          "aftercare",
+          "cost_fee_logic",
+          "local_shoreham_context",
+          "clinician_expertise",
+          "technology_used",
+          "faq",
+          "related_treatments_internal_links",
+          "last_reviewed_clinical_review",
+          "cta"
+        ],
+        "secondaryGeographyMentions": {},
+        "secondaryGeographyStuffing": false
+      }
     },
     {
       "route": "/treatments/composite-bonding",
@@ -6597,7 +7144,35 @@
         "variantId": "hero.variant.treatment_v1"
       },
       "sectionCount": 12,
-      "surface": "champagne/surface/treatment"
+      "surface": "champagne/surface/treatment",
+      "answerSurface": {
+        "frameworkPresent": false,
+        "valid": false,
+        "status": null,
+        "presentSectionCount": 0,
+        "missingSectionIds": [
+          "direct_answer",
+          "what_this_treatment_is",
+          "who_it_is_for",
+          "who_it_may_not_be_suitable_for",
+          "benefits",
+          "risks_and_limitations",
+          "alternatives",
+          "process",
+          "timeline",
+          "aftercare",
+          "cost_fee_logic",
+          "local_shoreham_context",
+          "clinician_expertise",
+          "technology_used",
+          "faq",
+          "related_treatments_internal_links",
+          "last_reviewed_clinical_review",
+          "cta"
+        ],
+        "secondaryGeographyMentions": {},
+        "secondaryGeographyStuffing": false
+      }
     },
     {
       "route": "/treatments/injection-moulded-composite",
@@ -6610,7 +7185,35 @@
         "variantId": "hero.variant.treatment_v1"
       },
       "sectionCount": 9,
-      "surface": "champagne/surface/treatment"
+      "surface": "champagne/surface/treatment",
+      "answerSurface": {
+        "frameworkPresent": false,
+        "valid": false,
+        "status": null,
+        "presentSectionCount": 0,
+        "missingSectionIds": [
+          "direct_answer",
+          "what_this_treatment_is",
+          "who_it_is_for",
+          "who_it_may_not_be_suitable_for",
+          "benefits",
+          "risks_and_limitations",
+          "alternatives",
+          "process",
+          "timeline",
+          "aftercare",
+          "cost_fee_logic",
+          "local_shoreham_context",
+          "clinician_expertise",
+          "technology_used",
+          "faq",
+          "related_treatments_internal_links",
+          "last_reviewed_clinical_review",
+          "cta"
+        ],
+        "secondaryGeographyMentions": {},
+        "secondaryGeographyStuffing": false
+      }
     },
     {
       "route": "/treatments/dental-bridges",
@@ -6623,7 +7226,35 @@
         "variantId": "hero.variant.treatment_v1"
       },
       "sectionCount": 12,
-      "surface": "champagne/surface/treatment"
+      "surface": "champagne/surface/treatment",
+      "answerSurface": {
+        "frameworkPresent": false,
+        "valid": false,
+        "status": null,
+        "presentSectionCount": 0,
+        "missingSectionIds": [
+          "direct_answer",
+          "what_this_treatment_is",
+          "who_it_is_for",
+          "who_it_may_not_be_suitable_for",
+          "benefits",
+          "risks_and_limitations",
+          "alternatives",
+          "process",
+          "timeline",
+          "aftercare",
+          "cost_fee_logic",
+          "local_shoreham_context",
+          "clinician_expertise",
+          "technology_used",
+          "faq",
+          "related_treatments_internal_links",
+          "last_reviewed_clinical_review",
+          "cta"
+        ],
+        "secondaryGeographyMentions": {},
+        "secondaryGeographyStuffing": false
+      }
     },
     {
       "route": "/treatments/dental-crowns",
@@ -6636,7 +7267,35 @@
         "variantId": "hero.variant.group.02_v1"
       },
       "sectionCount": 7,
-      "surface": "champagne/surface/treatment"
+      "surface": "champagne/surface/treatment",
+      "answerSurface": {
+        "frameworkPresent": false,
+        "valid": false,
+        "status": null,
+        "presentSectionCount": 0,
+        "missingSectionIds": [
+          "direct_answer",
+          "what_this_treatment_is",
+          "who_it_is_for",
+          "who_it_may_not_be_suitable_for",
+          "benefits",
+          "risks_and_limitations",
+          "alternatives",
+          "process",
+          "timeline",
+          "aftercare",
+          "cost_fee_logic",
+          "local_shoreham_context",
+          "clinician_expertise",
+          "technology_used",
+          "faq",
+          "related_treatments_internal_links",
+          "last_reviewed_clinical_review",
+          "cta"
+        ],
+        "secondaryGeographyMentions": {},
+        "secondaryGeographyStuffing": false
+      }
     },
     {
       "route": "/treatments/teeth-whitening",
@@ -6649,7 +7308,35 @@
         "variantId": "hero.variant.group.05_v1"
       },
       "sectionCount": 8,
-      "surface": "champagne/surface/treatment"
+      "surface": "champagne/surface/treatment",
+      "answerSurface": {
+        "frameworkPresent": false,
+        "valid": false,
+        "status": null,
+        "presentSectionCount": 0,
+        "missingSectionIds": [
+          "direct_answer",
+          "what_this_treatment_is",
+          "who_it_is_for",
+          "who_it_may_not_be_suitable_for",
+          "benefits",
+          "risks_and_limitations",
+          "alternatives",
+          "process",
+          "timeline",
+          "aftercare",
+          "cost_fee_logic",
+          "local_shoreham_context",
+          "clinician_expertise",
+          "technology_used",
+          "faq",
+          "related_treatments_internal_links",
+          "last_reviewed_clinical_review",
+          "cta"
+        ],
+        "secondaryGeographyMentions": {},
+        "secondaryGeographyStuffing": false
+      }
     },
     {
       "route": "/treatments/home-teeth-whitening",
@@ -6662,7 +7349,35 @@
         "variantId": "hero.variant.treatment_v1"
       },
       "sectionCount": 8,
-      "surface": "champagne/surface/treatment"
+      "surface": "champagne/surface/treatment",
+      "answerSurface": {
+        "frameworkPresent": false,
+        "valid": false,
+        "status": null,
+        "presentSectionCount": 0,
+        "missingSectionIds": [
+          "direct_answer",
+          "what_this_treatment_is",
+          "who_it_is_for",
+          "who_it_may_not_be_suitable_for",
+          "benefits",
+          "risks_and_limitations",
+          "alternatives",
+          "process",
+          "timeline",
+          "aftercare",
+          "cost_fee_logic",
+          "local_shoreham_context",
+          "clinician_expertise",
+          "technology_used",
+          "faq",
+          "related_treatments_internal_links",
+          "last_reviewed_clinical_review",
+          "cta"
+        ],
+        "secondaryGeographyMentions": {},
+        "secondaryGeographyStuffing": false
+      }
     },
     {
       "route": "/treatments/whitening-top-ups",
@@ -6675,7 +7390,35 @@
         "variantId": "hero.variant.treatment_v1"
       },
       "sectionCount": 6,
-      "surface": "champagne/surface/treatment"
+      "surface": "champagne/surface/treatment",
+      "answerSurface": {
+        "frameworkPresent": false,
+        "valid": false,
+        "status": null,
+        "presentSectionCount": 0,
+        "missingSectionIds": [
+          "direct_answer",
+          "what_this_treatment_is",
+          "who_it_is_for",
+          "who_it_may_not_be_suitable_for",
+          "benefits",
+          "risks_and_limitations",
+          "alternatives",
+          "process",
+          "timeline",
+          "aftercare",
+          "cost_fee_logic",
+          "local_shoreham_context",
+          "clinician_expertise",
+          "technology_used",
+          "faq",
+          "related_treatments_internal_links",
+          "last_reviewed_clinical_review",
+          "cta"
+        ],
+        "secondaryGeographyMentions": {},
+        "secondaryGeographyStuffing": false
+      }
     },
     {
       "route": "/treatments/whitening-sensitive-teeth",
@@ -6688,7 +7431,35 @@
         "variantId": "hero.variant.treatment_v1"
       },
       "sectionCount": 6,
-      "surface": "champagne/surface/treatment"
+      "surface": "champagne/surface/treatment",
+      "answerSurface": {
+        "frameworkPresent": false,
+        "valid": false,
+        "status": null,
+        "presentSectionCount": 0,
+        "missingSectionIds": [
+          "direct_answer",
+          "what_this_treatment_is",
+          "who_it_is_for",
+          "who_it_may_not_be_suitable_for",
+          "benefits",
+          "risks_and_limitations",
+          "alternatives",
+          "process",
+          "timeline",
+          "aftercare",
+          "cost_fee_logic",
+          "local_shoreham_context",
+          "clinician_expertise",
+          "technology_used",
+          "faq",
+          "related_treatments_internal_links",
+          "last_reviewed_clinical_review",
+          "cta"
+        ],
+        "secondaryGeographyMentions": {},
+        "secondaryGeographyStuffing": false
+      }
     },
     {
       "route": "/treatments/teeth-whitening-faqs",
@@ -6701,7 +7472,35 @@
         "variantId": "hero.variant.treatment_v1"
       },
       "sectionCount": 4,
-      "surface": "champagne/surface/treatment"
+      "surface": "champagne/surface/treatment",
+      "answerSurface": {
+        "frameworkPresent": false,
+        "valid": false,
+        "status": null,
+        "presentSectionCount": 0,
+        "missingSectionIds": [
+          "direct_answer",
+          "what_this_treatment_is",
+          "who_it_is_for",
+          "who_it_may_not_be_suitable_for",
+          "benefits",
+          "risks_and_limitations",
+          "alternatives",
+          "process",
+          "timeline",
+          "aftercare",
+          "cost_fee_logic",
+          "local_shoreham_context",
+          "clinician_expertise",
+          "technology_used",
+          "faq",
+          "related_treatments_internal_links",
+          "last_reviewed_clinical_review",
+          "cta"
+        ],
+        "secondaryGeographyMentions": {},
+        "secondaryGeographyStuffing": false
+      }
     },
     {
       "route": "/treatments/orthodontics",
@@ -6714,7 +7513,35 @@
         "variantId": "hero.variant.group.04_v1"
       },
       "sectionCount": 12,
-      "surface": "champagne/surface/treatment"
+      "surface": "champagne/surface/treatment",
+      "answerSurface": {
+        "frameworkPresent": false,
+        "valid": false,
+        "status": null,
+        "presentSectionCount": 0,
+        "missingSectionIds": [
+          "direct_answer",
+          "what_this_treatment_is",
+          "who_it_is_for",
+          "who_it_may_not_be_suitable_for",
+          "benefits",
+          "risks_and_limitations",
+          "alternatives",
+          "process",
+          "timeline",
+          "aftercare",
+          "cost_fee_logic",
+          "local_shoreham_context",
+          "clinician_expertise",
+          "technology_used",
+          "faq",
+          "related_treatments_internal_links",
+          "last_reviewed_clinical_review",
+          "cta"
+        ],
+        "secondaryGeographyMentions": {},
+        "secondaryGeographyStuffing": false
+      }
     },
     {
       "route": "/treatments/full-smile-makeover",
@@ -6727,7 +7554,35 @@
         "variantId": "hero.variant.treatment_v1"
       },
       "sectionCount": 8,
-      "surface": "champagne/surface/treatment"
+      "surface": "champagne/surface/treatment",
+      "answerSurface": {
+        "frameworkPresent": false,
+        "valid": false,
+        "status": null,
+        "presentSectionCount": 0,
+        "missingSectionIds": [
+          "direct_answer",
+          "what_this_treatment_is",
+          "who_it_is_for",
+          "who_it_may_not_be_suitable_for",
+          "benefits",
+          "risks_and_limitations",
+          "alternatives",
+          "process",
+          "timeline",
+          "aftercare",
+          "cost_fee_logic",
+          "local_shoreham_context",
+          "clinician_expertise",
+          "technology_used",
+          "faq",
+          "related_treatments_internal_links",
+          "last_reviewed_clinical_review",
+          "cta"
+        ],
+        "secondaryGeographyMentions": {},
+        "secondaryGeographyStuffing": false
+      }
     },
     {
       "route": "/treatments/3d-digital-dentistry",
@@ -6740,7 +7595,35 @@
         "variantId": "hero.variant.group.07_v1"
       },
       "sectionCount": 12,
-      "surface": "champagne/surface/treatment"
+      "surface": "champagne/surface/treatment",
+      "answerSurface": {
+        "frameworkPresent": false,
+        "valid": false,
+        "status": null,
+        "presentSectionCount": 0,
+        "missingSectionIds": [
+          "direct_answer",
+          "what_this_treatment_is",
+          "who_it_is_for",
+          "who_it_may_not_be_suitable_for",
+          "benefits",
+          "risks_and_limitations",
+          "alternatives",
+          "process",
+          "timeline",
+          "aftercare",
+          "cost_fee_logic",
+          "local_shoreham_context",
+          "clinician_expertise",
+          "technology_used",
+          "faq",
+          "related_treatments_internal_links",
+          "last_reviewed_clinical_review",
+          "cta"
+        ],
+        "secondaryGeographyMentions": {},
+        "secondaryGeographyStuffing": false
+      }
     },
     {
       "route": "/treatments/emergency-dentistry",
@@ -6753,7 +7636,35 @@
         "variantId": "treatment.emergency"
       },
       "sectionCount": 11,
-      "surface": "champagne/surface/treatment"
+      "surface": "champagne/surface/treatment",
+      "answerSurface": {
+        "frameworkPresent": false,
+        "valid": false,
+        "status": null,
+        "presentSectionCount": 0,
+        "missingSectionIds": [
+          "direct_answer",
+          "what_this_treatment_is",
+          "who_it_is_for",
+          "who_it_may_not_be_suitable_for",
+          "benefits",
+          "risks_and_limitations",
+          "alternatives",
+          "process",
+          "timeline",
+          "aftercare",
+          "cost_fee_logic",
+          "local_shoreham_context",
+          "clinician_expertise",
+          "technology_used",
+          "faq",
+          "related_treatments_internal_links",
+          "last_reviewed_clinical_review",
+          "cta"
+        ],
+        "secondaryGeographyMentions": {},
+        "secondaryGeographyStuffing": false
+      }
     },
     {
       "route": "/treatments/emergency-dental-appointments",
@@ -6766,7 +7677,35 @@
         "variantId": "hero.variant.treatment_v1"
       },
       "sectionCount": 9,
-      "surface": "champagne/surface/treatment"
+      "surface": "champagne/surface/treatment",
+      "answerSurface": {
+        "frameworkPresent": false,
+        "valid": false,
+        "status": null,
+        "presentSectionCount": 0,
+        "missingSectionIds": [
+          "direct_answer",
+          "what_this_treatment_is",
+          "who_it_is_for",
+          "who_it_may_not_be_suitable_for",
+          "benefits",
+          "risks_and_limitations",
+          "alternatives",
+          "process",
+          "timeline",
+          "aftercare",
+          "cost_fee_logic",
+          "local_shoreham_context",
+          "clinician_expertise",
+          "technology_used",
+          "faq",
+          "related_treatments_internal_links",
+          "last_reviewed_clinical_review",
+          "cta"
+        ],
+        "secondaryGeographyMentions": {},
+        "secondaryGeographyStuffing": false
+      }
     },
     {
       "route": "/treatments/severe-toothache-dental-pain",
@@ -6779,7 +7718,35 @@
         "variantId": "hero.variant.treatment_v1"
       },
       "sectionCount": 9,
-      "surface": "champagne/surface/treatment"
+      "surface": "champagne/surface/treatment",
+      "answerSurface": {
+        "frameworkPresent": false,
+        "valid": false,
+        "status": null,
+        "presentSectionCount": 0,
+        "missingSectionIds": [
+          "direct_answer",
+          "what_this_treatment_is",
+          "who_it_is_for",
+          "who_it_may_not_be_suitable_for",
+          "benefits",
+          "risks_and_limitations",
+          "alternatives",
+          "process",
+          "timeline",
+          "aftercare",
+          "cost_fee_logic",
+          "local_shoreham_context",
+          "clinician_expertise",
+          "technology_used",
+          "faq",
+          "related_treatments_internal_links",
+          "last_reviewed_clinical_review",
+          "cta"
+        ],
+        "secondaryGeographyMentions": {},
+        "secondaryGeographyStuffing": false
+      }
     },
     {
       "route": "/treatments/dental-abscess-infection",
@@ -6792,7 +7759,35 @@
         "variantId": "hero.variant.treatment_v1"
       },
       "sectionCount": 9,
-      "surface": "champagne/surface/treatment"
+      "surface": "champagne/surface/treatment",
+      "answerSurface": {
+        "frameworkPresent": false,
+        "valid": false,
+        "status": null,
+        "presentSectionCount": 0,
+        "missingSectionIds": [
+          "direct_answer",
+          "what_this_treatment_is",
+          "who_it_is_for",
+          "who_it_may_not_be_suitable_for",
+          "benefits",
+          "risks_and_limitations",
+          "alternatives",
+          "process",
+          "timeline",
+          "aftercare",
+          "cost_fee_logic",
+          "local_shoreham_context",
+          "clinician_expertise",
+          "technology_used",
+          "faq",
+          "related_treatments_internal_links",
+          "last_reviewed_clinical_review",
+          "cta"
+        ],
+        "secondaryGeographyMentions": {},
+        "secondaryGeographyStuffing": false
+      }
     },
     {
       "route": "/treatments/broken-chipped-cracked-teeth",
@@ -6805,7 +7800,35 @@
         "variantId": "hero.variant.treatment_v1"
       },
       "sectionCount": 9,
-      "surface": "champagne/surface/treatment"
+      "surface": "champagne/surface/treatment",
+      "answerSurface": {
+        "frameworkPresent": false,
+        "valid": false,
+        "status": null,
+        "presentSectionCount": 0,
+        "missingSectionIds": [
+          "direct_answer",
+          "what_this_treatment_is",
+          "who_it_is_for",
+          "who_it_may_not_be_suitable_for",
+          "benefits",
+          "risks_and_limitations",
+          "alternatives",
+          "process",
+          "timeline",
+          "aftercare",
+          "cost_fee_logic",
+          "local_shoreham_context",
+          "clinician_expertise",
+          "technology_used",
+          "faq",
+          "related_treatments_internal_links",
+          "last_reviewed_clinical_review",
+          "cta"
+        ],
+        "secondaryGeographyMentions": {},
+        "secondaryGeographyStuffing": false
+      }
     },
     {
       "route": "/treatments/knocked-out-tooth",
@@ -6818,7 +7841,35 @@
         "variantId": "hero.variant.treatment_v1"
       },
       "sectionCount": 9,
-      "surface": "champagne/surface/treatment"
+      "surface": "champagne/surface/treatment",
+      "answerSurface": {
+        "frameworkPresent": false,
+        "valid": false,
+        "status": null,
+        "presentSectionCount": 0,
+        "missingSectionIds": [
+          "direct_answer",
+          "what_this_treatment_is",
+          "who_it_is_for",
+          "who_it_may_not_be_suitable_for",
+          "benefits",
+          "risks_and_limitations",
+          "alternatives",
+          "process",
+          "timeline",
+          "aftercare",
+          "cost_fee_logic",
+          "local_shoreham_context",
+          "clinician_expertise",
+          "technology_used",
+          "faq",
+          "related_treatments_internal_links",
+          "last_reviewed_clinical_review",
+          "cta"
+        ],
+        "secondaryGeographyMentions": {},
+        "secondaryGeographyStuffing": false
+      }
     },
     {
       "route": "/treatments/lost-crowns-veneers-fillings",
@@ -6831,7 +7882,35 @@
         "variantId": "hero.variant.treatment_v1"
       },
       "sectionCount": 9,
-      "surface": "champagne/surface/treatment"
+      "surface": "champagne/surface/treatment",
+      "answerSurface": {
+        "frameworkPresent": false,
+        "valid": false,
+        "status": null,
+        "presentSectionCount": 0,
+        "missingSectionIds": [
+          "direct_answer",
+          "what_this_treatment_is",
+          "who_it_is_for",
+          "who_it_may_not_be_suitable_for",
+          "benefits",
+          "risks_and_limitations",
+          "alternatives",
+          "process",
+          "timeline",
+          "aftercare",
+          "cost_fee_logic",
+          "local_shoreham_context",
+          "clinician_expertise",
+          "technology_used",
+          "faq",
+          "related_treatments_internal_links",
+          "last_reviewed_clinical_review",
+          "cta"
+        ],
+        "secondaryGeographyMentions": {},
+        "secondaryGeographyStuffing": false
+      }
     },
     {
       "route": "/treatments/dental-trauma-accidents",
@@ -6844,7 +7923,35 @@
         "variantId": "hero.variant.treatment_v1"
       },
       "sectionCount": 9,
-      "surface": "champagne/surface/treatment"
+      "surface": "champagne/surface/treatment",
+      "answerSurface": {
+        "frameworkPresent": false,
+        "valid": false,
+        "status": null,
+        "presentSectionCount": 0,
+        "missingSectionIds": [
+          "direct_answer",
+          "what_this_treatment_is",
+          "who_it_is_for",
+          "who_it_may_not_be_suitable_for",
+          "benefits",
+          "risks_and_limitations",
+          "alternatives",
+          "process",
+          "timeline",
+          "aftercare",
+          "cost_fee_logic",
+          "local_shoreham_context",
+          "clinician_expertise",
+          "technology_used",
+          "faq",
+          "related_treatments_internal_links",
+          "last_reviewed_clinical_review",
+          "cta"
+        ],
+        "secondaryGeographyMentions": {},
+        "secondaryGeographyStuffing": false
+      }
     },
     {
       "route": "/treatments/3d-dentistry-and-technology",
@@ -6857,7 +7964,35 @@
         "variantId": "hero.variant.treatment_v1"
       },
       "sectionCount": 5,
-      "surface": "champagne/surface/treatment"
+      "surface": "champagne/surface/treatment",
+      "answerSurface": {
+        "frameworkPresent": false,
+        "valid": false,
+        "status": null,
+        "presentSectionCount": 0,
+        "missingSectionIds": [
+          "direct_answer",
+          "what_this_treatment_is",
+          "who_it_is_for",
+          "who_it_may_not_be_suitable_for",
+          "benefits",
+          "risks_and_limitations",
+          "alternatives",
+          "process",
+          "timeline",
+          "aftercare",
+          "cost_fee_logic",
+          "local_shoreham_context",
+          "clinician_expertise",
+          "technology_used",
+          "faq",
+          "related_treatments_internal_links",
+          "last_reviewed_clinical_review",
+          "cta"
+        ],
+        "secondaryGeographyMentions": {},
+        "secondaryGeographyStuffing": false
+      }
     },
     {
       "route": "/treatments/cbct-3d-scanning",
@@ -6870,7 +8005,35 @@
         "variantId": "hero.variant.treatment_v1"
       },
       "sectionCount": 11,
-      "surface": "champagne/surface/treatment"
+      "surface": "champagne/surface/treatment",
+      "answerSurface": {
+        "frameworkPresent": false,
+        "valid": false,
+        "status": null,
+        "presentSectionCount": 0,
+        "missingSectionIds": [
+          "direct_answer",
+          "what_this_treatment_is",
+          "who_it_is_for",
+          "who_it_may_not_be_suitable_for",
+          "benefits",
+          "risks_and_limitations",
+          "alternatives",
+          "process",
+          "timeline",
+          "aftercare",
+          "cost_fee_logic",
+          "local_shoreham_context",
+          "clinician_expertise",
+          "technology_used",
+          "faq",
+          "related_treatments_internal_links",
+          "last_reviewed_clinical_review",
+          "cta"
+        ],
+        "secondaryGeographyMentions": {},
+        "secondaryGeographyStuffing": false
+      }
     },
     {
       "route": "/treatments/digital-smile-design",
@@ -6883,7 +8046,35 @@
         "variantId": "hero.variant.treatment_v1"
       },
       "sectionCount": 11,
-      "surface": "champagne/surface/treatment"
+      "surface": "champagne/surface/treatment",
+      "answerSurface": {
+        "frameworkPresent": false,
+        "valid": false,
+        "status": null,
+        "presentSectionCount": 0,
+        "missingSectionIds": [
+          "direct_answer",
+          "what_this_treatment_is",
+          "who_it_is_for",
+          "who_it_may_not_be_suitable_for",
+          "benefits",
+          "risks_and_limitations",
+          "alternatives",
+          "process",
+          "timeline",
+          "aftercare",
+          "cost_fee_logic",
+          "local_shoreham_context",
+          "clinician_expertise",
+          "technology_used",
+          "faq",
+          "related_treatments_internal_links",
+          "last_reviewed_clinical_review",
+          "cta"
+        ],
+        "secondaryGeographyMentions": {},
+        "secondaryGeographyStuffing": false
+      }
     },
     {
       "route": "/treatments/3d-printing-lab",
@@ -6896,7 +8087,35 @@
         "variantId": "hero.variant.treatment_v1"
       },
       "sectionCount": 11,
-      "surface": "champagne/surface/treatment"
+      "surface": "champagne/surface/treatment",
+      "answerSurface": {
+        "frameworkPresent": false,
+        "valid": false,
+        "status": null,
+        "presentSectionCount": 0,
+        "missingSectionIds": [
+          "direct_answer",
+          "what_this_treatment_is",
+          "who_it_is_for",
+          "who_it_may_not_be_suitable_for",
+          "benefits",
+          "risks_and_limitations",
+          "alternatives",
+          "process",
+          "timeline",
+          "aftercare",
+          "cost_fee_logic",
+          "local_shoreham_context",
+          "clinician_expertise",
+          "technology_used",
+          "faq",
+          "related_treatments_internal_links",
+          "last_reviewed_clinical_review",
+          "cta"
+        ],
+        "secondaryGeographyMentions": {},
+        "secondaryGeographyStuffing": false
+      }
     },
     {
       "route": "/treatments/inlays-onlays",
@@ -6909,7 +8128,35 @@
         "variantId": "hero.variant.treatment_v1"
       },
       "sectionCount": 11,
-      "surface": "champagne/surface/treatment"
+      "surface": "champagne/surface/treatment",
+      "answerSurface": {
+        "frameworkPresent": false,
+        "valid": false,
+        "status": null,
+        "presentSectionCount": 0,
+        "missingSectionIds": [
+          "direct_answer",
+          "what_this_treatment_is",
+          "who_it_is_for",
+          "who_it_may_not_be_suitable_for",
+          "benefits",
+          "risks_and_limitations",
+          "alternatives",
+          "process",
+          "timeline",
+          "aftercare",
+          "cost_fee_logic",
+          "local_shoreham_context",
+          "clinician_expertise",
+          "technology_used",
+          "faq",
+          "related_treatments_internal_links",
+          "last_reviewed_clinical_review",
+          "cta"
+        ],
+        "secondaryGeographyMentions": {},
+        "secondaryGeographyStuffing": false
+      }
     },
     {
       "route": "/treatments/dental-fillings",
@@ -6922,7 +8169,35 @@
         "variantId": "hero.variant.treatment_v1"
       },
       "sectionCount": 11,
-      "surface": "champagne/surface/treatment"
+      "surface": "champagne/surface/treatment",
+      "answerSurface": {
+        "frameworkPresent": false,
+        "valid": false,
+        "status": null,
+        "presentSectionCount": 0,
+        "missingSectionIds": [
+          "direct_answer",
+          "what_this_treatment_is",
+          "who_it_is_for",
+          "who_it_may_not_be_suitable_for",
+          "benefits",
+          "risks_and_limitations",
+          "alternatives",
+          "process",
+          "timeline",
+          "aftercare",
+          "cost_fee_logic",
+          "local_shoreham_context",
+          "clinician_expertise",
+          "technology_used",
+          "faq",
+          "related_treatments_internal_links",
+          "last_reviewed_clinical_review",
+          "cta"
+        ],
+        "secondaryGeographyMentions": {},
+        "secondaryGeographyStuffing": false
+      }
     },
     {
       "route": "/treatments/dentures",
@@ -6935,7 +8210,35 @@
         "variantId": "hero.variant.treatment_v1"
       },
       "sectionCount": 11,
-      "surface": "champagne/surface/treatment"
+      "surface": "champagne/surface/treatment",
+      "answerSurface": {
+        "frameworkPresent": false,
+        "valid": false,
+        "status": null,
+        "presentSectionCount": 0,
+        "missingSectionIds": [
+          "direct_answer",
+          "what_this_treatment_is",
+          "who_it_is_for",
+          "who_it_may_not_be_suitable_for",
+          "benefits",
+          "risks_and_limitations",
+          "alternatives",
+          "process",
+          "timeline",
+          "aftercare",
+          "cost_fee_logic",
+          "local_shoreham_context",
+          "clinician_expertise",
+          "technology_used",
+          "faq",
+          "related_treatments_internal_links",
+          "last_reviewed_clinical_review",
+          "cta"
+        ],
+        "secondaryGeographyMentions": {},
+        "secondaryGeographyStuffing": false
+      }
     },
     {
       "route": "/treatments/acrylic-dentures",
@@ -6948,7 +8251,35 @@
         "variantId": "hero.variant.treatment_v1"
       },
       "sectionCount": 11,
-      "surface": "champagne/surface/treatment"
+      "surface": "champagne/surface/treatment",
+      "answerSurface": {
+        "frameworkPresent": false,
+        "valid": false,
+        "status": null,
+        "presentSectionCount": 0,
+        "missingSectionIds": [
+          "direct_answer",
+          "what_this_treatment_is",
+          "who_it_is_for",
+          "who_it_may_not_be_suitable_for",
+          "benefits",
+          "risks_and_limitations",
+          "alternatives",
+          "process",
+          "timeline",
+          "aftercare",
+          "cost_fee_logic",
+          "local_shoreham_context",
+          "clinician_expertise",
+          "technology_used",
+          "faq",
+          "related_treatments_internal_links",
+          "last_reviewed_clinical_review",
+          "cta"
+        ],
+        "secondaryGeographyMentions": {},
+        "secondaryGeographyStuffing": false
+      }
     },
     {
       "route": "/treatments/chrome-dentures",
@@ -6961,7 +8292,35 @@
         "variantId": "hero.variant.treatment_v1"
       },
       "sectionCount": 11,
-      "surface": "champagne/surface/treatment"
+      "surface": "champagne/surface/treatment",
+      "answerSurface": {
+        "frameworkPresent": false,
+        "valid": false,
+        "status": null,
+        "presentSectionCount": 0,
+        "missingSectionIds": [
+          "direct_answer",
+          "what_this_treatment_is",
+          "who_it_is_for",
+          "who_it_may_not_be_suitable_for",
+          "benefits",
+          "risks_and_limitations",
+          "alternatives",
+          "process",
+          "timeline",
+          "aftercare",
+          "cost_fee_logic",
+          "local_shoreham_context",
+          "clinician_expertise",
+          "technology_used",
+          "faq",
+          "related_treatments_internal_links",
+          "last_reviewed_clinical_review",
+          "cta"
+        ],
+        "secondaryGeographyMentions": {},
+        "secondaryGeographyStuffing": false
+      }
     },
     {
       "route": "/treatments/peek-partial-dentures",
@@ -6974,7 +8333,35 @@
         "variantId": "hero.variant.treatment_v1"
       },
       "sectionCount": 11,
-      "surface": "champagne/surface/treatment"
+      "surface": "champagne/surface/treatment",
+      "answerSurface": {
+        "frameworkPresent": false,
+        "valid": false,
+        "status": null,
+        "presentSectionCount": 0,
+        "missingSectionIds": [
+          "direct_answer",
+          "what_this_treatment_is",
+          "who_it_is_for",
+          "who_it_may_not_be_suitable_for",
+          "benefits",
+          "risks_and_limitations",
+          "alternatives",
+          "process",
+          "timeline",
+          "aftercare",
+          "cost_fee_logic",
+          "local_shoreham_context",
+          "clinician_expertise",
+          "technology_used",
+          "faq",
+          "related_treatments_internal_links",
+          "last_reviewed_clinical_review",
+          "cta"
+        ],
+        "secondaryGeographyMentions": {},
+        "secondaryGeographyStuffing": false
+      }
     },
     {
       "route": "/treatments/3d-printed-dentures",
@@ -6987,7 +8374,35 @@
         "variantId": "hero.variant.treatment_v1"
       },
       "sectionCount": 11,
-      "surface": "champagne/surface/treatment"
+      "surface": "champagne/surface/treatment",
+      "answerSurface": {
+        "frameworkPresent": false,
+        "valid": false,
+        "status": null,
+        "presentSectionCount": 0,
+        "missingSectionIds": [
+          "direct_answer",
+          "what_this_treatment_is",
+          "who_it_is_for",
+          "who_it_may_not_be_suitable_for",
+          "benefits",
+          "risks_and_limitations",
+          "alternatives",
+          "process",
+          "timeline",
+          "aftercare",
+          "cost_fee_logic",
+          "local_shoreham_context",
+          "clinician_expertise",
+          "technology_used",
+          "faq",
+          "related_treatments_internal_links",
+          "last_reviewed_clinical_review",
+          "cta"
+        ],
+        "secondaryGeographyMentions": {},
+        "secondaryGeographyStuffing": false
+      }
     },
     {
       "route": "/treatments/night-guards-occlusal-splints",
@@ -7000,7 +8415,35 @@
         "variantId": "hero.variant.group.06_v1"
       },
       "sectionCount": 11,
-      "surface": "champagne/surface/treatment"
+      "surface": "champagne/surface/treatment",
+      "answerSurface": {
+        "frameworkPresent": false,
+        "valid": false,
+        "status": null,
+        "presentSectionCount": 0,
+        "missingSectionIds": [
+          "direct_answer",
+          "what_this_treatment_is",
+          "who_it_is_for",
+          "who_it_may_not_be_suitable_for",
+          "benefits",
+          "risks_and_limitations",
+          "alternatives",
+          "process",
+          "timeline",
+          "aftercare",
+          "cost_fee_logic",
+          "local_shoreham_context",
+          "clinician_expertise",
+          "technology_used",
+          "faq",
+          "related_treatments_internal_links",
+          "last_reviewed_clinical_review",
+          "cta"
+        ],
+        "secondaryGeographyMentions": {},
+        "secondaryGeographyStuffing": false
+      }
     },
     {
       "route": "/treatments/sports-mouthguards",
@@ -7013,7 +8456,35 @@
         "variantId": "hero.variant.treatment_v1"
       },
       "sectionCount": 9,
-      "surface": "champagne/surface/treatment"
+      "surface": "champagne/surface/treatment",
+      "answerSurface": {
+        "frameworkPresent": false,
+        "valid": false,
+        "status": null,
+        "presentSectionCount": 0,
+        "missingSectionIds": [
+          "direct_answer",
+          "what_this_treatment_is",
+          "who_it_is_for",
+          "who_it_may_not_be_suitable_for",
+          "benefits",
+          "risks_and_limitations",
+          "alternatives",
+          "process",
+          "timeline",
+          "aftercare",
+          "cost_fee_logic",
+          "local_shoreham_context",
+          "clinician_expertise",
+          "technology_used",
+          "faq",
+          "related_treatments_internal_links",
+          "last_reviewed_clinical_review",
+          "cta"
+        ],
+        "secondaryGeographyMentions": {},
+        "secondaryGeographyStuffing": false
+      }
     },
     {
       "route": "/treatments/dental-retainers",
@@ -7026,7 +8497,35 @@
         "variantId": "hero.variant.treatment_v1"
       },
       "sectionCount": 9,
-      "surface": "champagne/surface/treatment"
+      "surface": "champagne/surface/treatment",
+      "answerSurface": {
+        "frameworkPresent": false,
+        "valid": false,
+        "status": null,
+        "presentSectionCount": 0,
+        "missingSectionIds": [
+          "direct_answer",
+          "what_this_treatment_is",
+          "who_it_is_for",
+          "who_it_may_not_be_suitable_for",
+          "benefits",
+          "risks_and_limitations",
+          "alternatives",
+          "process",
+          "timeline",
+          "aftercare",
+          "cost_fee_logic",
+          "local_shoreham_context",
+          "clinician_expertise",
+          "technology_used",
+          "faq",
+          "related_treatments_internal_links",
+          "last_reviewed_clinical_review",
+          "cta"
+        ],
+        "secondaryGeographyMentions": {},
+        "secondaryGeographyStuffing": false
+      }
     },
     {
       "route": "/treatments/preventative-and-general-dentistry",
@@ -7039,7 +8538,35 @@
         "variantId": "hero.variant.group.01_v1"
       },
       "sectionCount": 12,
-      "surface": "champagne/surface/treatment"
+      "surface": "champagne/surface/treatment",
+      "answerSurface": {
+        "frameworkPresent": false,
+        "valid": false,
+        "status": null,
+        "presentSectionCount": 0,
+        "missingSectionIds": [
+          "direct_answer",
+          "what_this_treatment_is",
+          "who_it_is_for",
+          "who_it_may_not_be_suitable_for",
+          "benefits",
+          "risks_and_limitations",
+          "alternatives",
+          "process",
+          "timeline",
+          "aftercare",
+          "cost_fee_logic",
+          "local_shoreham_context",
+          "clinician_expertise",
+          "technology_used",
+          "faq",
+          "related_treatments_internal_links",
+          "last_reviewed_clinical_review",
+          "cta"
+        ],
+        "secondaryGeographyMentions": {},
+        "secondaryGeographyStuffing": false
+      }
     },
     {
       "route": "/treatments/childrens-dentistry",
@@ -7052,7 +8579,35 @@
         "variantId": "hero.variant.treatment_v1"
       },
       "sectionCount": 10,
-      "surface": "champagne/surface/treatment"
+      "surface": "champagne/surface/treatment",
+      "answerSurface": {
+        "frameworkPresent": false,
+        "valid": false,
+        "status": null,
+        "presentSectionCount": 0,
+        "missingSectionIds": [
+          "direct_answer",
+          "what_this_treatment_is",
+          "who_it_is_for",
+          "who_it_may_not_be_suitable_for",
+          "benefits",
+          "risks_and_limitations",
+          "alternatives",
+          "process",
+          "timeline",
+          "aftercare",
+          "cost_fee_logic",
+          "local_shoreham_context",
+          "clinician_expertise",
+          "technology_used",
+          "faq",
+          "related_treatments_internal_links",
+          "last_reviewed_clinical_review",
+          "cta"
+        ],
+        "secondaryGeographyMentions": {},
+        "secondaryGeographyStuffing": false
+      }
     },
     {
       "route": "/treatments/periodontal-gum-care",
@@ -7065,7 +8620,35 @@
         "variantId": "hero.variant.treatment_v1"
       },
       "sectionCount": 10,
-      "surface": "champagne/surface/treatment"
+      "surface": "champagne/surface/treatment",
+      "answerSurface": {
+        "frameworkPresent": false,
+        "valid": false,
+        "status": null,
+        "presentSectionCount": 0,
+        "missingSectionIds": [
+          "direct_answer",
+          "what_this_treatment_is",
+          "who_it_is_for",
+          "who_it_may_not_be_suitable_for",
+          "benefits",
+          "risks_and_limitations",
+          "alternatives",
+          "process",
+          "timeline",
+          "aftercare",
+          "cost_fee_logic",
+          "local_shoreham_context",
+          "clinician_expertise",
+          "technology_used",
+          "faq",
+          "related_treatments_internal_links",
+          "last_reviewed_clinical_review",
+          "cta"
+        ],
+        "secondaryGeographyMentions": {},
+        "secondaryGeographyStuffing": false
+      }
     },
     {
       "route": "/treatments/endodontics-root-canal",
@@ -7078,7 +8661,35 @@
         "variantId": "hero.variant.treatment_v1"
       },
       "sectionCount": 10,
-      "surface": "champagne/surface/treatment"
+      "surface": "champagne/surface/treatment",
+      "answerSurface": {
+        "frameworkPresent": false,
+        "valid": false,
+        "status": null,
+        "presentSectionCount": 0,
+        "missingSectionIds": [
+          "direct_answer",
+          "what_this_treatment_is",
+          "who_it_is_for",
+          "who_it_may_not_be_suitable_for",
+          "benefits",
+          "risks_and_limitations",
+          "alternatives",
+          "process",
+          "timeline",
+          "aftercare",
+          "cost_fee_logic",
+          "local_shoreham_context",
+          "clinician_expertise",
+          "technology_used",
+          "faq",
+          "related_treatments_internal_links",
+          "last_reviewed_clinical_review",
+          "cta"
+        ],
+        "secondaryGeographyMentions": {},
+        "secondaryGeographyStuffing": false
+      }
     },
     {
       "route": "/treatments/extractions-and-oral-surgery",
@@ -7091,7 +8702,35 @@
         "variantId": "hero.variant.treatment_v1"
       },
       "sectionCount": 10,
-      "surface": "champagne/surface/treatment"
+      "surface": "champagne/surface/treatment",
+      "answerSurface": {
+        "frameworkPresent": false,
+        "valid": false,
+        "status": null,
+        "presentSectionCount": 0,
+        "missingSectionIds": [
+          "direct_answer",
+          "what_this_treatment_is",
+          "who_it_is_for",
+          "who_it_may_not_be_suitable_for",
+          "benefits",
+          "risks_and_limitations",
+          "alternatives",
+          "process",
+          "timeline",
+          "aftercare",
+          "cost_fee_logic",
+          "local_shoreham_context",
+          "clinician_expertise",
+          "technology_used",
+          "faq",
+          "related_treatments_internal_links",
+          "last_reviewed_clinical_review",
+          "cta"
+        ],
+        "secondaryGeographyMentions": {},
+        "secondaryGeographyStuffing": false
+      }
     },
     {
       "route": "/treatments/senior-mature-smile-care",
@@ -7104,7 +8743,35 @@
         "variantId": "hero.variant.treatment_v1"
       },
       "sectionCount": 5,
-      "surface": "champagne/surface/treatment"
+      "surface": "champagne/surface/treatment",
+      "answerSurface": {
+        "frameworkPresent": false,
+        "valid": false,
+        "status": null,
+        "presentSectionCount": 0,
+        "missingSectionIds": [
+          "direct_answer",
+          "what_this_treatment_is",
+          "who_it_is_for",
+          "who_it_may_not_be_suitable_for",
+          "benefits",
+          "risks_and_limitations",
+          "alternatives",
+          "process",
+          "timeline",
+          "aftercare",
+          "cost_fee_logic",
+          "local_shoreham_context",
+          "clinician_expertise",
+          "technology_used",
+          "faq",
+          "related_treatments_internal_links",
+          "last_reviewed_clinical_review",
+          "cta"
+        ],
+        "secondaryGeographyMentions": {},
+        "secondaryGeographyStuffing": false
+      }
     },
     {
       "route": "/treatments/tmj-jaw-comfort",
@@ -7117,7 +8784,35 @@
         "variantId": "hero.variant.treatment_v1"
       },
       "sectionCount": 10,
-      "surface": "champagne/surface/treatment"
+      "surface": "champagne/surface/treatment",
+      "answerSurface": {
+        "frameworkPresent": false,
+        "valid": false,
+        "status": null,
+        "presentSectionCount": 0,
+        "missingSectionIds": [
+          "direct_answer",
+          "what_this_treatment_is",
+          "who_it_is_for",
+          "who_it_may_not_be_suitable_for",
+          "benefits",
+          "risks_and_limitations",
+          "alternatives",
+          "process",
+          "timeline",
+          "aftercare",
+          "cost_fee_logic",
+          "local_shoreham_context",
+          "clinician_expertise",
+          "technology_used",
+          "faq",
+          "related_treatments_internal_links",
+          "last_reviewed_clinical_review",
+          "cta"
+        ],
+        "secondaryGeographyMentions": {},
+        "secondaryGeographyStuffing": false
+      }
     },
     {
       "route": "/treatments/nervous-patients",
@@ -7130,7 +8825,35 @@
         "variantId": "hero.variant.treatment_v1"
       },
       "sectionCount": 9,
-      "surface": "champagne/surface/treatment"
+      "surface": "champagne/surface/treatment",
+      "answerSurface": {
+        "frameworkPresent": false,
+        "valid": false,
+        "status": null,
+        "presentSectionCount": 0,
+        "missingSectionIds": [
+          "direct_answer",
+          "what_this_treatment_is",
+          "who_it_is_for",
+          "who_it_may_not_be_suitable_for",
+          "benefits",
+          "risks_and_limitations",
+          "alternatives",
+          "process",
+          "timeline",
+          "aftercare",
+          "cost_fee_logic",
+          "local_shoreham_context",
+          "clinician_expertise",
+          "technology_used",
+          "faq",
+          "related_treatments_internal_links",
+          "last_reviewed_clinical_review",
+          "cta"
+        ],
+        "secondaryGeographyMentions": {},
+        "secondaryGeographyStuffing": false
+      }
     },
     {
       "route": "/treatments/sedation-dentistry",
@@ -7143,7 +8866,35 @@
         "variantId": "hero.variant.treatment_v1"
       },
       "sectionCount": 10,
-      "surface": "champagne/surface/treatment"
+      "surface": "champagne/surface/treatment",
+      "answerSurface": {
+        "frameworkPresent": false,
+        "valid": false,
+        "status": null,
+        "presentSectionCount": 0,
+        "missingSectionIds": [
+          "direct_answer",
+          "what_this_treatment_is",
+          "who_it_is_for",
+          "who_it_may_not_be_suitable_for",
+          "benefits",
+          "risks_and_limitations",
+          "alternatives",
+          "process",
+          "timeline",
+          "aftercare",
+          "cost_fee_logic",
+          "local_shoreham_context",
+          "clinician_expertise",
+          "technology_used",
+          "faq",
+          "related_treatments_internal_links",
+          "last_reviewed_clinical_review",
+          "cta"
+        ],
+        "secondaryGeographyMentions": {},
+        "secondaryGeographyStuffing": false
+      }
     },
     {
       "route": "/treatments/painless-numbing-the-wand",
@@ -7156,7 +8907,35 @@
         "variantId": "hero.variant.treatment_v1"
       },
       "sectionCount": 10,
-      "surface": "champagne/surface/treatment"
+      "surface": "champagne/surface/treatment",
+      "answerSurface": {
+        "frameworkPresent": false,
+        "valid": false,
+        "status": null,
+        "presentSectionCount": 0,
+        "missingSectionIds": [
+          "direct_answer",
+          "what_this_treatment_is",
+          "who_it_is_for",
+          "who_it_may_not_be_suitable_for",
+          "benefits",
+          "risks_and_limitations",
+          "alternatives",
+          "process",
+          "timeline",
+          "aftercare",
+          "cost_fee_logic",
+          "local_shoreham_context",
+          "clinician_expertise",
+          "technology_used",
+          "faq",
+          "related_treatments_internal_links",
+          "last_reviewed_clinical_review",
+          "cta"
+        ],
+        "secondaryGeographyMentions": {},
+        "secondaryGeographyStuffing": false
+      }
     },
     {
       "route": "/treatments/tooth-wear-broken-teeth",
@@ -7169,7 +8948,35 @@
         "variantId": "hero.variant.treatment_v1"
       },
       "sectionCount": 10,
-      "surface": "champagne/surface/treatment"
+      "surface": "champagne/surface/treatment",
+      "answerSurface": {
+        "frameworkPresent": false,
+        "valid": false,
+        "status": null,
+        "presentSectionCount": 0,
+        "missingSectionIds": [
+          "direct_answer",
+          "what_this_treatment_is",
+          "who_it_is_for",
+          "who_it_may_not_be_suitable_for",
+          "benefits",
+          "risks_and_limitations",
+          "alternatives",
+          "process",
+          "timeline",
+          "aftercare",
+          "cost_fee_logic",
+          "local_shoreham_context",
+          "clinician_expertise",
+          "technology_used",
+          "faq",
+          "related_treatments_internal_links",
+          "last_reviewed_clinical_review",
+          "cta"
+        ],
+        "secondaryGeographyMentions": {},
+        "secondaryGeographyStuffing": false
+      }
     },
     {
       "route": "/treatments/facial-therapeutics",
@@ -7182,7 +8989,35 @@
         "variantId": "hero.variant.group.09_v1"
       },
       "sectionCount": 13,
-      "surface": "champagne/surface/treatment"
+      "surface": "champagne/surface/treatment",
+      "answerSurface": {
+        "frameworkPresent": false,
+        "valid": false,
+        "status": null,
+        "presentSectionCount": 0,
+        "missingSectionIds": [
+          "direct_answer",
+          "what_this_treatment_is",
+          "who_it_is_for",
+          "who_it_may_not_be_suitable_for",
+          "benefits",
+          "risks_and_limitations",
+          "alternatives",
+          "process",
+          "timeline",
+          "aftercare",
+          "cost_fee_logic",
+          "local_shoreham_context",
+          "clinician_expertise",
+          "technology_used",
+          "faq",
+          "related_treatments_internal_links",
+          "last_reviewed_clinical_review",
+          "cta"
+        ],
+        "secondaryGeographyMentions": {},
+        "secondaryGeographyStuffing": false
+      }
     },
     {
       "route": "/treatments/bruxism-and-jaw-clenching",
@@ -7195,7 +9030,35 @@
         "variantId": "hero.variant.treatment_v1"
       },
       "sectionCount": 11,
-      "surface": "champagne/surface/treatment"
+      "surface": "champagne/surface/treatment",
+      "answerSurface": {
+        "frameworkPresent": false,
+        "valid": false,
+        "status": null,
+        "presentSectionCount": 0,
+        "missingSectionIds": [
+          "direct_answer",
+          "what_this_treatment_is",
+          "who_it_is_for",
+          "who_it_may_not_be_suitable_for",
+          "benefits",
+          "risks_and_limitations",
+          "alternatives",
+          "process",
+          "timeline",
+          "aftercare",
+          "cost_fee_logic",
+          "local_shoreham_context",
+          "clinician_expertise",
+          "technology_used",
+          "faq",
+          "related_treatments_internal_links",
+          "last_reviewed_clinical_review",
+          "cta"
+        ],
+        "secondaryGeographyMentions": {},
+        "secondaryGeographyStuffing": false
+      }
     },
     {
       "route": "/treatments/facial-pain-and-headache",
@@ -7208,7 +9071,35 @@
         "variantId": "hero.variant.treatment_v1"
       },
       "sectionCount": 11,
-      "surface": "champagne/surface/treatment"
+      "surface": "champagne/surface/treatment",
+      "answerSurface": {
+        "frameworkPresent": false,
+        "valid": false,
+        "status": null,
+        "presentSectionCount": 0,
+        "missingSectionIds": [
+          "direct_answer",
+          "what_this_treatment_is",
+          "who_it_is_for",
+          "who_it_may_not_be_suitable_for",
+          "benefits",
+          "risks_and_limitations",
+          "alternatives",
+          "process",
+          "timeline",
+          "aftercare",
+          "cost_fee_logic",
+          "local_shoreham_context",
+          "clinician_expertise",
+          "technology_used",
+          "faq",
+          "related_treatments_internal_links",
+          "last_reviewed_clinical_review",
+          "cta"
+        ],
+        "secondaryGeographyMentions": {},
+        "secondaryGeographyStuffing": false
+      }
     },
     {
       "route": "/treatments/tmj-disorder-treatment",
@@ -7221,7 +9112,35 @@
         "variantId": "hero.variant.treatment_v1"
       },
       "sectionCount": 11,
-      "surface": "champagne/surface/treatment"
+      "surface": "champagne/surface/treatment",
+      "answerSurface": {
+        "frameworkPresent": false,
+        "valid": false,
+        "status": null,
+        "presentSectionCount": 0,
+        "missingSectionIds": [
+          "direct_answer",
+          "what_this_treatment_is",
+          "who_it_is_for",
+          "who_it_may_not_be_suitable_for",
+          "benefits",
+          "risks_and_limitations",
+          "alternatives",
+          "process",
+          "timeline",
+          "aftercare",
+          "cost_fee_logic",
+          "local_shoreham_context",
+          "clinician_expertise",
+          "technology_used",
+          "faq",
+          "related_treatments_internal_links",
+          "last_reviewed_clinical_review",
+          "cta"
+        ],
+        "secondaryGeographyMentions": {},
+        "secondaryGeographyStuffing": false
+      }
     },
     {
       "route": "/treatments/therapeutic-facial-injectables",
@@ -7234,7 +9153,35 @@
         "variantId": "hero.variant.treatment_v1"
       },
       "sectionCount": 12,
-      "surface": "champagne/surface/treatment"
+      "surface": "champagne/surface/treatment",
+      "answerSurface": {
+        "frameworkPresent": false,
+        "valid": false,
+        "status": null,
+        "presentSectionCount": 0,
+        "missingSectionIds": [
+          "direct_answer",
+          "what_this_treatment_is",
+          "who_it_is_for",
+          "who_it_may_not_be_suitable_for",
+          "benefits",
+          "risks_and_limitations",
+          "alternatives",
+          "process",
+          "timeline",
+          "aftercare",
+          "cost_fee_logic",
+          "local_shoreham_context",
+          "clinician_expertise",
+          "technology_used",
+          "faq",
+          "related_treatments_internal_links",
+          "last_reviewed_clinical_review",
+          "cta"
+        ],
+        "secondaryGeographyMentions": {},
+        "secondaryGeographyStuffing": false
+      }
     },
     {
       "route": "/treatments/facial-aesthetics",
@@ -7247,7 +9194,35 @@
         "variantId": "hero.variant.treatment_v1"
       },
       "sectionCount": 10,
-      "surface": "champagne/surface/treatment"
+      "surface": "champagne/surface/treatment",
+      "answerSurface": {
+        "frameworkPresent": false,
+        "valid": false,
+        "status": null,
+        "presentSectionCount": 0,
+        "missingSectionIds": [
+          "direct_answer",
+          "what_this_treatment_is",
+          "who_it_is_for",
+          "who_it_may_not_be_suitable_for",
+          "benefits",
+          "risks_and_limitations",
+          "alternatives",
+          "process",
+          "timeline",
+          "aftercare",
+          "cost_fee_logic",
+          "local_shoreham_context",
+          "clinician_expertise",
+          "technology_used",
+          "faq",
+          "related_treatments_internal_links",
+          "last_reviewed_clinical_review",
+          "cta"
+        ],
+        "secondaryGeographyMentions": {},
+        "secondaryGeographyStuffing": false
+      }
     },
     {
       "route": "/treatments/cosmetic-dentistry",
@@ -7260,7 +9235,35 @@
         "variantId": "hero.variant.treatment_v1"
       },
       "sectionCount": 10,
-      "surface": "champagne/surface/treatment"
+      "surface": "champagne/surface/treatment",
+      "answerSurface": {
+        "frameworkPresent": false,
+        "valid": false,
+        "status": null,
+        "presentSectionCount": 0,
+        "missingSectionIds": [
+          "direct_answer",
+          "what_this_treatment_is",
+          "who_it_is_for",
+          "who_it_may_not_be_suitable_for",
+          "benefits",
+          "risks_and_limitations",
+          "alternatives",
+          "process",
+          "timeline",
+          "aftercare",
+          "cost_fee_logic",
+          "local_shoreham_context",
+          "clinician_expertise",
+          "technology_used",
+          "faq",
+          "related_treatments_internal_links",
+          "last_reviewed_clinical_review",
+          "cta"
+        ],
+        "secondaryGeographyMentions": {},
+        "secondaryGeographyStuffing": false
+      }
     },
     {
       "route": "/treatments/preventive-dentistry",
@@ -7273,7 +9276,35 @@
         "variantId": "hero.variant.treatment_v1"
       },
       "sectionCount": 10,
-      "surface": "champagne/surface/treatment"
+      "surface": "champagne/surface/treatment",
+      "answerSurface": {
+        "frameworkPresent": false,
+        "valid": false,
+        "status": null,
+        "presentSectionCount": 0,
+        "missingSectionIds": [
+          "direct_answer",
+          "what_this_treatment_is",
+          "who_it_is_for",
+          "who_it_may_not_be_suitable_for",
+          "benefits",
+          "risks_and_limitations",
+          "alternatives",
+          "process",
+          "timeline",
+          "aftercare",
+          "cost_fee_logic",
+          "local_shoreham_context",
+          "clinician_expertise",
+          "technology_used",
+          "faq",
+          "related_treatments_internal_links",
+          "last_reviewed_clinical_review",
+          "cta"
+        ],
+        "secondaryGeographyMentions": {},
+        "secondaryGeographyStuffing": false
+      }
     },
     {
       "route": "/treatments/anti-wrinkle-treatments",
@@ -7286,7 +9317,35 @@
         "variantId": "hero.variant.treatment_v1"
       },
       "sectionCount": 11,
-      "surface": "champagne/surface/treatment"
+      "surface": "champagne/surface/treatment",
+      "answerSurface": {
+        "frameworkPresent": false,
+        "valid": false,
+        "status": null,
+        "presentSectionCount": 0,
+        "missingSectionIds": [
+          "direct_answer",
+          "what_this_treatment_is",
+          "who_it_is_for",
+          "who_it_may_not_be_suitable_for",
+          "benefits",
+          "risks_and_limitations",
+          "alternatives",
+          "process",
+          "timeline",
+          "aftercare",
+          "cost_fee_logic",
+          "local_shoreham_context",
+          "clinician_expertise",
+          "technology_used",
+          "faq",
+          "related_treatments_internal_links",
+          "last_reviewed_clinical_review",
+          "cta"
+        ],
+        "secondaryGeographyMentions": {},
+        "secondaryGeographyStuffing": false
+      }
     },
     {
       "route": "/treatments/dermal-fillers",
@@ -7299,7 +9358,35 @@
         "variantId": "hero.variant.treatment_v1"
       },
       "sectionCount": 11,
-      "surface": "champagne/surface/treatment"
+      "surface": "champagne/surface/treatment",
+      "answerSurface": {
+        "frameworkPresent": false,
+        "valid": false,
+        "status": null,
+        "presentSectionCount": 0,
+        "missingSectionIds": [
+          "direct_answer",
+          "what_this_treatment_is",
+          "who_it_is_for",
+          "who_it_may_not_be_suitable_for",
+          "benefits",
+          "risks_and_limitations",
+          "alternatives",
+          "process",
+          "timeline",
+          "aftercare",
+          "cost_fee_logic",
+          "local_shoreham_context",
+          "clinician_expertise",
+          "technology_used",
+          "faq",
+          "related_treatments_internal_links",
+          "last_reviewed_clinical_review",
+          "cta"
+        ],
+        "secondaryGeographyMentions": {},
+        "secondaryGeographyStuffing": false
+      }
     },
     {
       "route": "/treatments/skin-boosters",
@@ -7312,7 +9399,35 @@
         "variantId": "hero.variant.treatment_v1"
       },
       "sectionCount": 11,
-      "surface": "champagne/surface/treatment"
+      "surface": "champagne/surface/treatment",
+      "answerSurface": {
+        "frameworkPresent": false,
+        "valid": false,
+        "status": null,
+        "presentSectionCount": 0,
+        "missingSectionIds": [
+          "direct_answer",
+          "what_this_treatment_is",
+          "who_it_is_for",
+          "who_it_may_not_be_suitable_for",
+          "benefits",
+          "risks_and_limitations",
+          "alternatives",
+          "process",
+          "timeline",
+          "aftercare",
+          "cost_fee_logic",
+          "local_shoreham_context",
+          "clinician_expertise",
+          "technology_used",
+          "faq",
+          "related_treatments_internal_links",
+          "last_reviewed_clinical_review",
+          "cta"
+        ],
+        "secondaryGeographyMentions": {},
+        "secondaryGeographyStuffing": false
+      }
     },
     {
       "route": "/treatments/polynucleotides",
@@ -7325,7 +9440,35 @@
         "variantId": "hero.variant.treatment_v1"
       },
       "sectionCount": 11,
-      "surface": "champagne/surface/treatment"
+      "surface": "champagne/surface/treatment",
+      "answerSurface": {
+        "frameworkPresent": false,
+        "valid": false,
+        "status": null,
+        "presentSectionCount": 0,
+        "missingSectionIds": [
+          "direct_answer",
+          "what_this_treatment_is",
+          "who_it_is_for",
+          "who_it_may_not_be_suitable_for",
+          "benefits",
+          "risks_and_limitations",
+          "alternatives",
+          "process",
+          "timeline",
+          "aftercare",
+          "cost_fee_logic",
+          "local_shoreham_context",
+          "clinician_expertise",
+          "technology_used",
+          "faq",
+          "related_treatments_internal_links",
+          "last_reviewed_clinical_review",
+          "cta"
+        ],
+        "secondaryGeographyMentions": {},
+        "secondaryGeographyStuffing": false
+      }
     },
     {
       "route": "/treatments/mouthguards-and-retainers",
@@ -7338,9 +9481,3119 @@
         "variantId": "hero.variant.treatment_v1"
       },
       "sectionCount": 9,
-      "surface": "champagne/surface/treatment"
+      "surface": "champagne/surface/treatment",
+      "answerSurface": {
+        "frameworkPresent": false,
+        "valid": false,
+        "status": null,
+        "presentSectionCount": 0,
+        "missingSectionIds": [
+          "direct_answer",
+          "what_this_treatment_is",
+          "who_it_is_for",
+          "who_it_may_not_be_suitable_for",
+          "benefits",
+          "risks_and_limitations",
+          "alternatives",
+          "process",
+          "timeline",
+          "aftercare",
+          "cost_fee_logic",
+          "local_shoreham_context",
+          "clinician_expertise",
+          "technology_used",
+          "faq",
+          "related_treatments_internal_links",
+          "last_reviewed_clinical_review",
+          "cta"
+        ],
+        "secondaryGeographyMentions": {},
+        "secondaryGeographyStuffing": false
+      }
     }
   ],
+  "answerSurfaceCoverage": {
+    "framework": "TREATMENT_ANSWER_SURFACE_V1",
+    "requiredSectionIds": [
+      "direct_answer",
+      "what_this_treatment_is",
+      "who_it_is_for",
+      "who_it_may_not_be_suitable_for",
+      "benefits",
+      "risks_and_limitations",
+      "alternatives",
+      "process",
+      "timeline",
+      "aftercare",
+      "cost_fee_logic",
+      "local_shoreham_context",
+      "clinician_expertise",
+      "technology_used",
+      "faq",
+      "related_treatments_internal_links",
+      "last_reviewed_clinical_review",
+      "cta"
+    ],
+    "treatmentRouteCount": 78,
+    "frameworkPresentCount": 1,
+    "completeCount": 1,
+    "exampleSeedRoutes": [
+      "/treatments/implants"
+    ],
+    "routesMissingAnswerSurface": [
+      "/treatments/veneers",
+      "/treatments/clear-aligners",
+      "/treatments/clear-aligners-spark",
+      "/treatments/fixed-braces",
+      "/treatments/dental-checkups-oral-cancer-screening",
+      "/treatments/implants-single-tooth",
+      "/treatments/implants-multiple-teeth",
+      "/treatments/implants-full-arch",
+      "/treatments/implant-retained-dentures",
+      "/treatments/implant-consultation",
+      "/treatments/implants-bone-grafting",
+      "/treatments/sinus-lift",
+      "/treatments/teeth-in-a-day",
+      "/treatments/sedation-for-implants",
+      "/treatments/failed-implant-replacement",
+      "/treatments/implant-aftercare",
+      "/treatments/surgically-guided-implants",
+      "/treatments/3d-implant-restorations",
+      "/treatments/3d-printed-veneers",
+      "/treatments/composite-bonding",
+      "/treatments/injection-moulded-composite",
+      "/treatments/dental-bridges",
+      "/treatments/dental-crowns",
+      "/treatments/teeth-whitening",
+      "/treatments/home-teeth-whitening",
+      "/treatments/whitening-top-ups",
+      "/treatments/whitening-sensitive-teeth",
+      "/treatments/teeth-whitening-faqs",
+      "/treatments/orthodontics",
+      "/treatments/full-smile-makeover",
+      "/treatments/3d-digital-dentistry",
+      "/treatments/emergency-dentistry",
+      "/treatments/emergency-dental-appointments",
+      "/treatments/severe-toothache-dental-pain",
+      "/treatments/dental-abscess-infection",
+      "/treatments/broken-chipped-cracked-teeth",
+      "/treatments/knocked-out-tooth",
+      "/treatments/lost-crowns-veneers-fillings",
+      "/treatments/dental-trauma-accidents",
+      "/treatments/3d-dentistry-and-technology",
+      "/treatments/cbct-3d-scanning",
+      "/treatments/digital-smile-design",
+      "/treatments/3d-printing-lab",
+      "/treatments/inlays-onlays",
+      "/treatments/dental-fillings",
+      "/treatments/dentures",
+      "/treatments/acrylic-dentures",
+      "/treatments/chrome-dentures",
+      "/treatments/peek-partial-dentures",
+      "/treatments/3d-printed-dentures",
+      "/treatments/night-guards-occlusal-splints",
+      "/treatments/sports-mouthguards",
+      "/treatments/dental-retainers",
+      "/treatments/preventative-and-general-dentistry",
+      "/treatments/childrens-dentistry",
+      "/treatments/periodontal-gum-care",
+      "/treatments/endodontics-root-canal",
+      "/treatments/extractions-and-oral-surgery",
+      "/treatments/senior-mature-smile-care",
+      "/treatments/tmj-jaw-comfort",
+      "/treatments/nervous-patients",
+      "/treatments/sedation-dentistry",
+      "/treatments/painless-numbing-the-wand",
+      "/treatments/tooth-wear-broken-teeth",
+      "/treatments/facial-therapeutics",
+      "/treatments/bruxism-and-jaw-clenching",
+      "/treatments/facial-pain-and-headache",
+      "/treatments/tmj-disorder-treatment",
+      "/treatments/therapeutic-facial-injectables",
+      "/treatments/facial-aesthetics",
+      "/treatments/cosmetic-dentistry",
+      "/treatments/preventive-dentistry",
+      "/treatments/anti-wrinkle-treatments",
+      "/treatments/dermal-fillers",
+      "/treatments/skin-boosters",
+      "/treatments/polynucleotides",
+      "/treatments/mouthguards-and-retainers"
+    ],
+    "routesWithMissingSections": [],
+    "routesWithSecondaryGeographyStuffing": [],
+    "entries": [
+      {
+        "route": "/treatments/implants",
+        "pageId": "implants",
+        "label": "Dental Implants in Shoreham-by-Sea",
+        "validation": {
+          "frameworkPresent": true,
+          "valid": true,
+          "status": "example_seed",
+          "exampleSeed": true,
+          "presentSectionIds": [
+            "direct_answer",
+            "what_this_treatment_is",
+            "who_it_is_for",
+            "who_it_may_not_be_suitable_for",
+            "benefits",
+            "risks_and_limitations",
+            "alternatives",
+            "process",
+            "timeline",
+            "aftercare",
+            "cost_fee_logic",
+            "local_shoreham_context",
+            "clinician_expertise",
+            "technology_used",
+            "faq",
+            "related_treatments_internal_links",
+            "last_reviewed_clinical_review",
+            "cta"
+          ],
+          "missingSectionIds": [],
+          "duplicateSectionIds": [],
+          "unknownSectionIds": [],
+          "emptySectionIds": [],
+          "secondaryGeographyMentions": {
+            "Brighton": 0,
+            "Worthing": 0,
+            "Lancing": 0,
+            "Southwick": 0
+          },
+          "secondaryGeographyStuffing": false,
+          "errors": [],
+          "warnings": []
+        }
+      },
+      {
+        "route": "/treatments/veneers",
+        "pageId": "veneers",
+        "label": "Dental veneers in Shoreham-by-Sea",
+        "validation": {
+          "frameworkPresent": false,
+          "valid": false,
+          "status": null,
+          "exampleSeed": false,
+          "presentSectionIds": [],
+          "missingSectionIds": [
+            "direct_answer",
+            "what_this_treatment_is",
+            "who_it_is_for",
+            "who_it_may_not_be_suitable_for",
+            "benefits",
+            "risks_and_limitations",
+            "alternatives",
+            "process",
+            "timeline",
+            "aftercare",
+            "cost_fee_logic",
+            "local_shoreham_context",
+            "clinician_expertise",
+            "technology_used",
+            "faq",
+            "related_treatments_internal_links",
+            "last_reviewed_clinical_review",
+            "cta"
+          ],
+          "secondaryGeographyMentions": {},
+          "secondaryGeographyStuffing": false,
+          "errors": [
+            "answerSurface is missing"
+          ],
+          "warnings": []
+        }
+      },
+      {
+        "route": "/treatments/clear-aligners",
+        "pageId": "clear_aligners",
+        "label": "Clear Aligners in Shoreham-by-Sea",
+        "validation": {
+          "frameworkPresent": false,
+          "valid": false,
+          "status": null,
+          "exampleSeed": false,
+          "presentSectionIds": [],
+          "missingSectionIds": [
+            "direct_answer",
+            "what_this_treatment_is",
+            "who_it_is_for",
+            "who_it_may_not_be_suitable_for",
+            "benefits",
+            "risks_and_limitations",
+            "alternatives",
+            "process",
+            "timeline",
+            "aftercare",
+            "cost_fee_logic",
+            "local_shoreham_context",
+            "clinician_expertise",
+            "technology_used",
+            "faq",
+            "related_treatments_internal_links",
+            "last_reviewed_clinical_review",
+            "cta"
+          ],
+          "secondaryGeographyMentions": {},
+          "secondaryGeographyStuffing": false,
+          "errors": [
+            "answerSurface is missing"
+          ],
+          "warnings": []
+        }
+      },
+      {
+        "route": "/treatments/clear-aligners-spark",
+        "pageId": "clear_aligners_spark",
+        "label": "Spark clear aligners in Shoreham-by-Sea",
+        "validation": {
+          "frameworkPresent": false,
+          "valid": false,
+          "status": null,
+          "exampleSeed": false,
+          "presentSectionIds": [],
+          "missingSectionIds": [
+            "direct_answer",
+            "what_this_treatment_is",
+            "who_it_is_for",
+            "who_it_may_not_be_suitable_for",
+            "benefits",
+            "risks_and_limitations",
+            "alternatives",
+            "process",
+            "timeline",
+            "aftercare",
+            "cost_fee_logic",
+            "local_shoreham_context",
+            "clinician_expertise",
+            "technology_used",
+            "faq",
+            "related_treatments_internal_links",
+            "last_reviewed_clinical_review",
+            "cta"
+          ],
+          "secondaryGeographyMentions": {},
+          "secondaryGeographyStuffing": false,
+          "errors": [
+            "answerSurface is missing"
+          ],
+          "warnings": []
+        }
+      },
+      {
+        "route": "/treatments/fixed-braces",
+        "pageId": "fixed_braces",
+        "label": "Fixed braces",
+        "validation": {
+          "frameworkPresent": false,
+          "valid": false,
+          "status": null,
+          "exampleSeed": false,
+          "presentSectionIds": [],
+          "missingSectionIds": [
+            "direct_answer",
+            "what_this_treatment_is",
+            "who_it_is_for",
+            "who_it_may_not_be_suitable_for",
+            "benefits",
+            "risks_and_limitations",
+            "alternatives",
+            "process",
+            "timeline",
+            "aftercare",
+            "cost_fee_logic",
+            "local_shoreham_context",
+            "clinician_expertise",
+            "technology_used",
+            "faq",
+            "related_treatments_internal_links",
+            "last_reviewed_clinical_review",
+            "cta"
+          ],
+          "secondaryGeographyMentions": {},
+          "secondaryGeographyStuffing": false,
+          "errors": [
+            "answerSurface is missing"
+          ],
+          "warnings": []
+        }
+      },
+      {
+        "route": "/treatments/dental-checkups-oral-cancer-screening",
+        "pageId": "dental_checkups_oral_cancer_screening_treatments",
+        "label": "Dental Check-Ups & Oral Cancer Screening",
+        "validation": {
+          "frameworkPresent": false,
+          "valid": false,
+          "status": null,
+          "exampleSeed": false,
+          "presentSectionIds": [],
+          "missingSectionIds": [
+            "direct_answer",
+            "what_this_treatment_is",
+            "who_it_is_for",
+            "who_it_may_not_be_suitable_for",
+            "benefits",
+            "risks_and_limitations",
+            "alternatives",
+            "process",
+            "timeline",
+            "aftercare",
+            "cost_fee_logic",
+            "local_shoreham_context",
+            "clinician_expertise",
+            "technology_used",
+            "faq",
+            "related_treatments_internal_links",
+            "last_reviewed_clinical_review",
+            "cta"
+          ],
+          "secondaryGeographyMentions": {},
+          "secondaryGeographyStuffing": false,
+          "errors": [
+            "answerSurface is missing"
+          ],
+          "warnings": []
+        }
+      },
+      {
+        "route": "/treatments/implants-single-tooth",
+        "pageId": "implants_single_tooth",
+        "label": "Single-tooth dental implants in Shoreham-by-Sea",
+        "validation": {
+          "frameworkPresent": false,
+          "valid": false,
+          "status": null,
+          "exampleSeed": false,
+          "presentSectionIds": [],
+          "missingSectionIds": [
+            "direct_answer",
+            "what_this_treatment_is",
+            "who_it_is_for",
+            "who_it_may_not_be_suitable_for",
+            "benefits",
+            "risks_and_limitations",
+            "alternatives",
+            "process",
+            "timeline",
+            "aftercare",
+            "cost_fee_logic",
+            "local_shoreham_context",
+            "clinician_expertise",
+            "technology_used",
+            "faq",
+            "related_treatments_internal_links",
+            "last_reviewed_clinical_review",
+            "cta"
+          ],
+          "secondaryGeographyMentions": {},
+          "secondaryGeographyStuffing": false,
+          "errors": [
+            "answerSurface is missing"
+          ],
+          "warnings": []
+        }
+      },
+      {
+        "route": "/treatments/implants-multiple-teeth",
+        "pageId": "implants_multiple_teeth",
+        "label": "Multiple teeth implant options",
+        "validation": {
+          "frameworkPresent": false,
+          "valid": false,
+          "status": null,
+          "exampleSeed": false,
+          "presentSectionIds": [],
+          "missingSectionIds": [
+            "direct_answer",
+            "what_this_treatment_is",
+            "who_it_is_for",
+            "who_it_may_not_be_suitable_for",
+            "benefits",
+            "risks_and_limitations",
+            "alternatives",
+            "process",
+            "timeline",
+            "aftercare",
+            "cost_fee_logic",
+            "local_shoreham_context",
+            "clinician_expertise",
+            "technology_used",
+            "faq",
+            "related_treatments_internal_links",
+            "last_reviewed_clinical_review",
+            "cta"
+          ],
+          "secondaryGeographyMentions": {},
+          "secondaryGeographyStuffing": false,
+          "errors": [
+            "answerSurface is missing"
+          ],
+          "warnings": []
+        }
+      },
+      {
+        "route": "/treatments/implants-full-arch",
+        "pageId": "implants_full_arch",
+        "label": "Full arch implant rehabilitation",
+        "validation": {
+          "frameworkPresent": false,
+          "valid": false,
+          "status": null,
+          "exampleSeed": false,
+          "presentSectionIds": [],
+          "missingSectionIds": [
+            "direct_answer",
+            "what_this_treatment_is",
+            "who_it_is_for",
+            "who_it_may_not_be_suitable_for",
+            "benefits",
+            "risks_and_limitations",
+            "alternatives",
+            "process",
+            "timeline",
+            "aftercare",
+            "cost_fee_logic",
+            "local_shoreham_context",
+            "clinician_expertise",
+            "technology_used",
+            "faq",
+            "related_treatments_internal_links",
+            "last_reviewed_clinical_review",
+            "cta"
+          ],
+          "secondaryGeographyMentions": {},
+          "secondaryGeographyStuffing": false,
+          "errors": [
+            "answerSurface is missing"
+          ],
+          "warnings": []
+        }
+      },
+      {
+        "route": "/treatments/implant-retained-dentures",
+        "pageId": "implant_retained_dentures",
+        "label": "Implant-retained dentures",
+        "validation": {
+          "frameworkPresent": false,
+          "valid": false,
+          "status": null,
+          "exampleSeed": false,
+          "presentSectionIds": [],
+          "missingSectionIds": [
+            "direct_answer",
+            "what_this_treatment_is",
+            "who_it_is_for",
+            "who_it_may_not_be_suitable_for",
+            "benefits",
+            "risks_and_limitations",
+            "alternatives",
+            "process",
+            "timeline",
+            "aftercare",
+            "cost_fee_logic",
+            "local_shoreham_context",
+            "clinician_expertise",
+            "technology_used",
+            "faq",
+            "related_treatments_internal_links",
+            "last_reviewed_clinical_review",
+            "cta"
+          ],
+          "secondaryGeographyMentions": {},
+          "secondaryGeographyStuffing": false,
+          "errors": [
+            "answerSurface is missing"
+          ],
+          "warnings": []
+        }
+      },
+      {
+        "route": "/treatments/implant-consultation",
+        "pageId": "implants_consultation",
+        "label": "Implant consultation & planning in Shoreham-by-Sea",
+        "validation": {
+          "frameworkPresent": false,
+          "valid": false,
+          "status": null,
+          "exampleSeed": false,
+          "presentSectionIds": [],
+          "missingSectionIds": [
+            "direct_answer",
+            "what_this_treatment_is",
+            "who_it_is_for",
+            "who_it_may_not_be_suitable_for",
+            "benefits",
+            "risks_and_limitations",
+            "alternatives",
+            "process",
+            "timeline",
+            "aftercare",
+            "cost_fee_logic",
+            "local_shoreham_context",
+            "clinician_expertise",
+            "technology_used",
+            "faq",
+            "related_treatments_internal_links",
+            "last_reviewed_clinical_review",
+            "cta"
+          ],
+          "secondaryGeographyMentions": {},
+          "secondaryGeographyStuffing": false,
+          "errors": [
+            "answerSurface is missing"
+          ],
+          "warnings": []
+        }
+      },
+      {
+        "route": "/treatments/implants-bone-grafting",
+        "pageId": "implants_bone_grafting",
+        "label": "Bone grafting for dental implants",
+        "validation": {
+          "frameworkPresent": false,
+          "valid": false,
+          "status": null,
+          "exampleSeed": false,
+          "presentSectionIds": [],
+          "missingSectionIds": [
+            "direct_answer",
+            "what_this_treatment_is",
+            "who_it_is_for",
+            "who_it_may_not_be_suitable_for",
+            "benefits",
+            "risks_and_limitations",
+            "alternatives",
+            "process",
+            "timeline",
+            "aftercare",
+            "cost_fee_logic",
+            "local_shoreham_context",
+            "clinician_expertise",
+            "technology_used",
+            "faq",
+            "related_treatments_internal_links",
+            "last_reviewed_clinical_review",
+            "cta"
+          ],
+          "secondaryGeographyMentions": {},
+          "secondaryGeographyStuffing": false,
+          "errors": [
+            "answerSurface is missing"
+          ],
+          "warnings": []
+        }
+      },
+      {
+        "route": "/treatments/sinus-lift",
+        "pageId": "implants_sinus_lift",
+        "label": "Sinus lift for dental implants in Shoreham-by-Sea",
+        "validation": {
+          "frameworkPresent": false,
+          "valid": false,
+          "status": null,
+          "exampleSeed": false,
+          "presentSectionIds": [],
+          "missingSectionIds": [
+            "direct_answer",
+            "what_this_treatment_is",
+            "who_it_is_for",
+            "who_it_may_not_be_suitable_for",
+            "benefits",
+            "risks_and_limitations",
+            "alternatives",
+            "process",
+            "timeline",
+            "aftercare",
+            "cost_fee_logic",
+            "local_shoreham_context",
+            "clinician_expertise",
+            "technology_used",
+            "faq",
+            "related_treatments_internal_links",
+            "last_reviewed_clinical_review",
+            "cta"
+          ],
+          "secondaryGeographyMentions": {},
+          "secondaryGeographyStuffing": false,
+          "errors": [
+            "answerSurface is missing"
+          ],
+          "warnings": []
+        }
+      },
+      {
+        "route": "/treatments/teeth-in-a-day",
+        "pageId": "implants_teeth_in_a_day",
+        "label": "Teeth-in-a-Day implants in Shoreham-by-Sea",
+        "validation": {
+          "frameworkPresent": false,
+          "valid": false,
+          "status": null,
+          "exampleSeed": false,
+          "presentSectionIds": [],
+          "missingSectionIds": [
+            "direct_answer",
+            "what_this_treatment_is",
+            "who_it_is_for",
+            "who_it_may_not_be_suitable_for",
+            "benefits",
+            "risks_and_limitations",
+            "alternatives",
+            "process",
+            "timeline",
+            "aftercare",
+            "cost_fee_logic",
+            "local_shoreham_context",
+            "clinician_expertise",
+            "technology_used",
+            "faq",
+            "related_treatments_internal_links",
+            "last_reviewed_clinical_review",
+            "cta"
+          ],
+          "secondaryGeographyMentions": {},
+          "secondaryGeographyStuffing": false,
+          "errors": [
+            "answerSurface is missing"
+          ],
+          "warnings": []
+        }
+      },
+      {
+        "route": "/treatments/sedation-for-implants",
+        "pageId": "implants_sedation",
+        "label": "Sedation for dental implant treatment in Shoreham-by-Sea",
+        "validation": {
+          "frameworkPresent": false,
+          "valid": false,
+          "status": null,
+          "exampleSeed": false,
+          "presentSectionIds": [],
+          "missingSectionIds": [
+            "direct_answer",
+            "what_this_treatment_is",
+            "who_it_is_for",
+            "who_it_may_not_be_suitable_for",
+            "benefits",
+            "risks_and_limitations",
+            "alternatives",
+            "process",
+            "timeline",
+            "aftercare",
+            "cost_fee_logic",
+            "local_shoreham_context",
+            "clinician_expertise",
+            "technology_used",
+            "faq",
+            "related_treatments_internal_links",
+            "last_reviewed_clinical_review",
+            "cta"
+          ],
+          "secondaryGeographyMentions": {},
+          "secondaryGeographyStuffing": false,
+          "errors": [
+            "answerSurface is missing"
+          ],
+          "warnings": []
+        }
+      },
+      {
+        "route": "/treatments/failed-implant-replacement",
+        "pageId": "implants_failed_replacement",
+        "label": "Failed implant replacement in Shoreham-by-Sea",
+        "validation": {
+          "frameworkPresent": false,
+          "valid": false,
+          "status": null,
+          "exampleSeed": false,
+          "presentSectionIds": [],
+          "missingSectionIds": [
+            "direct_answer",
+            "what_this_treatment_is",
+            "who_it_is_for",
+            "who_it_may_not_be_suitable_for",
+            "benefits",
+            "risks_and_limitations",
+            "alternatives",
+            "process",
+            "timeline",
+            "aftercare",
+            "cost_fee_logic",
+            "local_shoreham_context",
+            "clinician_expertise",
+            "technology_used",
+            "faq",
+            "related_treatments_internal_links",
+            "last_reviewed_clinical_review",
+            "cta"
+          ],
+          "secondaryGeographyMentions": {},
+          "secondaryGeographyStuffing": false,
+          "errors": [
+            "answerSurface is missing"
+          ],
+          "warnings": []
+        }
+      },
+      {
+        "route": "/treatments/implant-aftercare",
+        "pageId": "implants_aftercare",
+        "label": "Implant aftercare & recovery in Shoreham-by-Sea",
+        "validation": {
+          "frameworkPresent": false,
+          "valid": false,
+          "status": null,
+          "exampleSeed": false,
+          "presentSectionIds": [],
+          "missingSectionIds": [
+            "direct_answer",
+            "what_this_treatment_is",
+            "who_it_is_for",
+            "who_it_may_not_be_suitable_for",
+            "benefits",
+            "risks_and_limitations",
+            "alternatives",
+            "process",
+            "timeline",
+            "aftercare",
+            "cost_fee_logic",
+            "local_shoreham_context",
+            "clinician_expertise",
+            "technology_used",
+            "faq",
+            "related_treatments_internal_links",
+            "last_reviewed_clinical_review",
+            "cta"
+          ],
+          "secondaryGeographyMentions": {},
+          "secondaryGeographyStuffing": false,
+          "errors": [
+            "answerSurface is missing"
+          ],
+          "warnings": []
+        }
+      },
+      {
+        "route": "/treatments/surgically-guided-implants",
+        "pageId": "surgically_guided_implants",
+        "label": "Surgically Guided Implants in Shoreham-by-Sea",
+        "validation": {
+          "frameworkPresent": false,
+          "valid": false,
+          "status": null,
+          "exampleSeed": false,
+          "presentSectionIds": [],
+          "missingSectionIds": [
+            "direct_answer",
+            "what_this_treatment_is",
+            "who_it_is_for",
+            "who_it_may_not_be_suitable_for",
+            "benefits",
+            "risks_and_limitations",
+            "alternatives",
+            "process",
+            "timeline",
+            "aftercare",
+            "cost_fee_logic",
+            "local_shoreham_context",
+            "clinician_expertise",
+            "technology_used",
+            "faq",
+            "related_treatments_internal_links",
+            "last_reviewed_clinical_review",
+            "cta"
+          ],
+          "secondaryGeographyMentions": {},
+          "secondaryGeographyStuffing": false,
+          "errors": [
+            "answerSurface is missing"
+          ],
+          "warnings": []
+        }
+      },
+      {
+        "route": "/treatments/3d-implant-restorations",
+        "pageId": "3d_implant_restorations",
+        "label": "3D implant restorations",
+        "validation": {
+          "frameworkPresent": false,
+          "valid": false,
+          "status": null,
+          "exampleSeed": false,
+          "presentSectionIds": [],
+          "missingSectionIds": [
+            "direct_answer",
+            "what_this_treatment_is",
+            "who_it_is_for",
+            "who_it_may_not_be_suitable_for",
+            "benefits",
+            "risks_and_limitations",
+            "alternatives",
+            "process",
+            "timeline",
+            "aftercare",
+            "cost_fee_logic",
+            "local_shoreham_context",
+            "clinician_expertise",
+            "technology_used",
+            "faq",
+            "related_treatments_internal_links",
+            "last_reviewed_clinical_review",
+            "cta"
+          ],
+          "secondaryGeographyMentions": {},
+          "secondaryGeographyStuffing": false,
+          "errors": [
+            "answerSurface is missing"
+          ],
+          "warnings": []
+        }
+      },
+      {
+        "route": "/treatments/3d-printed-veneers",
+        "pageId": "3d_printed_veneers",
+        "label": "3D printed veneers",
+        "validation": {
+          "frameworkPresent": false,
+          "valid": false,
+          "status": null,
+          "exampleSeed": false,
+          "presentSectionIds": [],
+          "missingSectionIds": [
+            "direct_answer",
+            "what_this_treatment_is",
+            "who_it_is_for",
+            "who_it_may_not_be_suitable_for",
+            "benefits",
+            "risks_and_limitations",
+            "alternatives",
+            "process",
+            "timeline",
+            "aftercare",
+            "cost_fee_logic",
+            "local_shoreham_context",
+            "clinician_expertise",
+            "technology_used",
+            "faq",
+            "related_treatments_internal_links",
+            "last_reviewed_clinical_review",
+            "cta"
+          ],
+          "secondaryGeographyMentions": {},
+          "secondaryGeographyStuffing": false,
+          "errors": [
+            "answerSurface is missing"
+          ],
+          "warnings": []
+        }
+      },
+      {
+        "route": "/treatments/composite-bonding",
+        "pageId": "composite_bonding",
+        "label": "Composite bonding",
+        "validation": {
+          "frameworkPresent": false,
+          "valid": false,
+          "status": null,
+          "exampleSeed": false,
+          "presentSectionIds": [],
+          "missingSectionIds": [
+            "direct_answer",
+            "what_this_treatment_is",
+            "who_it_is_for",
+            "who_it_may_not_be_suitable_for",
+            "benefits",
+            "risks_and_limitations",
+            "alternatives",
+            "process",
+            "timeline",
+            "aftercare",
+            "cost_fee_logic",
+            "local_shoreham_context",
+            "clinician_expertise",
+            "technology_used",
+            "faq",
+            "related_treatments_internal_links",
+            "last_reviewed_clinical_review",
+            "cta"
+          ],
+          "secondaryGeographyMentions": {},
+          "secondaryGeographyStuffing": false,
+          "errors": [
+            "answerSurface is missing"
+          ],
+          "warnings": []
+        }
+      },
+      {
+        "route": "/treatments/injection-moulded-composite",
+        "pageId": "injection_moulded_composite",
+        "label": "Injection-moulded composite",
+        "validation": {
+          "frameworkPresent": false,
+          "valid": false,
+          "status": null,
+          "exampleSeed": false,
+          "presentSectionIds": [],
+          "missingSectionIds": [
+            "direct_answer",
+            "what_this_treatment_is",
+            "who_it_is_for",
+            "who_it_may_not_be_suitable_for",
+            "benefits",
+            "risks_and_limitations",
+            "alternatives",
+            "process",
+            "timeline",
+            "aftercare",
+            "cost_fee_logic",
+            "local_shoreham_context",
+            "clinician_expertise",
+            "technology_used",
+            "faq",
+            "related_treatments_internal_links",
+            "last_reviewed_clinical_review",
+            "cta"
+          ],
+          "secondaryGeographyMentions": {},
+          "secondaryGeographyStuffing": false,
+          "errors": [
+            "answerSurface is missing"
+          ],
+          "warnings": []
+        }
+      },
+      {
+        "route": "/treatments/dental-bridges",
+        "pageId": "dental_bridges",
+        "label": "Dental bridges",
+        "validation": {
+          "frameworkPresent": false,
+          "valid": false,
+          "status": null,
+          "exampleSeed": false,
+          "presentSectionIds": [],
+          "missingSectionIds": [
+            "direct_answer",
+            "what_this_treatment_is",
+            "who_it_is_for",
+            "who_it_may_not_be_suitable_for",
+            "benefits",
+            "risks_and_limitations",
+            "alternatives",
+            "process",
+            "timeline",
+            "aftercare",
+            "cost_fee_logic",
+            "local_shoreham_context",
+            "clinician_expertise",
+            "technology_used",
+            "faq",
+            "related_treatments_internal_links",
+            "last_reviewed_clinical_review",
+            "cta"
+          ],
+          "secondaryGeographyMentions": {},
+          "secondaryGeographyStuffing": false,
+          "errors": [
+            "answerSurface is missing"
+          ],
+          "warnings": []
+        }
+      },
+      {
+        "route": "/treatments/dental-crowns",
+        "pageId": "dental_crowns",
+        "label": "Dental crowns",
+        "validation": {
+          "frameworkPresent": false,
+          "valid": false,
+          "status": null,
+          "exampleSeed": false,
+          "presentSectionIds": [],
+          "missingSectionIds": [
+            "direct_answer",
+            "what_this_treatment_is",
+            "who_it_is_for",
+            "who_it_may_not_be_suitable_for",
+            "benefits",
+            "risks_and_limitations",
+            "alternatives",
+            "process",
+            "timeline",
+            "aftercare",
+            "cost_fee_logic",
+            "local_shoreham_context",
+            "clinician_expertise",
+            "technology_used",
+            "faq",
+            "related_treatments_internal_links",
+            "last_reviewed_clinical_review",
+            "cta"
+          ],
+          "secondaryGeographyMentions": {},
+          "secondaryGeographyStuffing": false,
+          "errors": [
+            "answerSurface is missing"
+          ],
+          "warnings": []
+        }
+      },
+      {
+        "route": "/treatments/teeth-whitening",
+        "pageId": "whitening_hub",
+        "label": "Teeth whitening",
+        "validation": {
+          "frameworkPresent": false,
+          "valid": false,
+          "status": null,
+          "exampleSeed": false,
+          "presentSectionIds": [],
+          "missingSectionIds": [
+            "direct_answer",
+            "what_this_treatment_is",
+            "who_it_is_for",
+            "who_it_may_not_be_suitable_for",
+            "benefits",
+            "risks_and_limitations",
+            "alternatives",
+            "process",
+            "timeline",
+            "aftercare",
+            "cost_fee_logic",
+            "local_shoreham_context",
+            "clinician_expertise",
+            "technology_used",
+            "faq",
+            "related_treatments_internal_links",
+            "last_reviewed_clinical_review",
+            "cta"
+          ],
+          "secondaryGeographyMentions": {},
+          "secondaryGeographyStuffing": false,
+          "errors": [
+            "answerSurface is missing"
+          ],
+          "warnings": []
+        }
+      },
+      {
+        "route": "/treatments/home-teeth-whitening",
+        "pageId": "home_teeth_whitening",
+        "label": "Home teeth whitening",
+        "validation": {
+          "frameworkPresent": false,
+          "valid": false,
+          "status": null,
+          "exampleSeed": false,
+          "presentSectionIds": [],
+          "missingSectionIds": [
+            "direct_answer",
+            "what_this_treatment_is",
+            "who_it_is_for",
+            "who_it_may_not_be_suitable_for",
+            "benefits",
+            "risks_and_limitations",
+            "alternatives",
+            "process",
+            "timeline",
+            "aftercare",
+            "cost_fee_logic",
+            "local_shoreham_context",
+            "clinician_expertise",
+            "technology_used",
+            "faq",
+            "related_treatments_internal_links",
+            "last_reviewed_clinical_review",
+            "cta"
+          ],
+          "secondaryGeographyMentions": {},
+          "secondaryGeographyStuffing": false,
+          "errors": [
+            "answerSurface is missing"
+          ],
+          "warnings": []
+        }
+      },
+      {
+        "route": "/treatments/whitening-top-ups",
+        "pageId": "whitening_topups",
+        "label": "Whitening top-ups & maintenance",
+        "validation": {
+          "frameworkPresent": false,
+          "valid": false,
+          "status": null,
+          "exampleSeed": false,
+          "presentSectionIds": [],
+          "missingSectionIds": [
+            "direct_answer",
+            "what_this_treatment_is",
+            "who_it_is_for",
+            "who_it_may_not_be_suitable_for",
+            "benefits",
+            "risks_and_limitations",
+            "alternatives",
+            "process",
+            "timeline",
+            "aftercare",
+            "cost_fee_logic",
+            "local_shoreham_context",
+            "clinician_expertise",
+            "technology_used",
+            "faq",
+            "related_treatments_internal_links",
+            "last_reviewed_clinical_review",
+            "cta"
+          ],
+          "secondaryGeographyMentions": {},
+          "secondaryGeographyStuffing": false,
+          "errors": [
+            "answerSurface is missing"
+          ],
+          "warnings": []
+        }
+      },
+      {
+        "route": "/treatments/whitening-sensitive-teeth",
+        "pageId": "whitening_sensitivity",
+        "label": "Sensitive teeth & whitening",
+        "validation": {
+          "frameworkPresent": false,
+          "valid": false,
+          "status": null,
+          "exampleSeed": false,
+          "presentSectionIds": [],
+          "missingSectionIds": [
+            "direct_answer",
+            "what_this_treatment_is",
+            "who_it_is_for",
+            "who_it_may_not_be_suitable_for",
+            "benefits",
+            "risks_and_limitations",
+            "alternatives",
+            "process",
+            "timeline",
+            "aftercare",
+            "cost_fee_logic",
+            "local_shoreham_context",
+            "clinician_expertise",
+            "technology_used",
+            "faq",
+            "related_treatments_internal_links",
+            "last_reviewed_clinical_review",
+            "cta"
+          ],
+          "secondaryGeographyMentions": {},
+          "secondaryGeographyStuffing": false,
+          "errors": [
+            "answerSurface is missing"
+          ],
+          "warnings": []
+        }
+      },
+      {
+        "route": "/treatments/teeth-whitening-faqs",
+        "pageId": "whitening_faq",
+        "label": "Teeth whitening FAQs",
+        "validation": {
+          "frameworkPresent": false,
+          "valid": false,
+          "status": null,
+          "exampleSeed": false,
+          "presentSectionIds": [],
+          "missingSectionIds": [
+            "direct_answer",
+            "what_this_treatment_is",
+            "who_it_is_for",
+            "who_it_may_not_be_suitable_for",
+            "benefits",
+            "risks_and_limitations",
+            "alternatives",
+            "process",
+            "timeline",
+            "aftercare",
+            "cost_fee_logic",
+            "local_shoreham_context",
+            "clinician_expertise",
+            "technology_used",
+            "faq",
+            "related_treatments_internal_links",
+            "last_reviewed_clinical_review",
+            "cta"
+          ],
+          "secondaryGeographyMentions": {},
+          "secondaryGeographyStuffing": false,
+          "errors": [
+            "answerSurface is missing"
+          ],
+          "warnings": []
+        }
+      },
+      {
+        "route": "/treatments/orthodontics",
+        "pageId": "orthodontics",
+        "label": "Orthodontics",
+        "validation": {
+          "frameworkPresent": false,
+          "valid": false,
+          "status": null,
+          "exampleSeed": false,
+          "presentSectionIds": [],
+          "missingSectionIds": [
+            "direct_answer",
+            "what_this_treatment_is",
+            "who_it_is_for",
+            "who_it_may_not_be_suitable_for",
+            "benefits",
+            "risks_and_limitations",
+            "alternatives",
+            "process",
+            "timeline",
+            "aftercare",
+            "cost_fee_logic",
+            "local_shoreham_context",
+            "clinician_expertise",
+            "technology_used",
+            "faq",
+            "related_treatments_internal_links",
+            "last_reviewed_clinical_review",
+            "cta"
+          ],
+          "secondaryGeographyMentions": {},
+          "secondaryGeographyStuffing": false,
+          "errors": [
+            "answerSurface is missing"
+          ],
+          "warnings": []
+        }
+      },
+      {
+        "route": "/treatments/full-smile-makeover",
+        "pageId": "full_smile_makeover",
+        "label": "Full smile makeover",
+        "validation": {
+          "frameworkPresent": false,
+          "valid": false,
+          "status": null,
+          "exampleSeed": false,
+          "presentSectionIds": [],
+          "missingSectionIds": [
+            "direct_answer",
+            "what_this_treatment_is",
+            "who_it_is_for",
+            "who_it_may_not_be_suitable_for",
+            "benefits",
+            "risks_and_limitations",
+            "alternatives",
+            "process",
+            "timeline",
+            "aftercare",
+            "cost_fee_logic",
+            "local_shoreham_context",
+            "clinician_expertise",
+            "technology_used",
+            "faq",
+            "related_treatments_internal_links",
+            "last_reviewed_clinical_review",
+            "cta"
+          ],
+          "secondaryGeographyMentions": {},
+          "secondaryGeographyStuffing": false,
+          "errors": [
+            "answerSurface is missing"
+          ],
+          "warnings": []
+        }
+      },
+      {
+        "route": "/treatments/3d-digital-dentistry",
+        "pageId": "technology_digital_dentistry",
+        "label": "3D & digital dentistry",
+        "validation": {
+          "frameworkPresent": false,
+          "valid": false,
+          "status": null,
+          "exampleSeed": false,
+          "presentSectionIds": [],
+          "missingSectionIds": [
+            "direct_answer",
+            "what_this_treatment_is",
+            "who_it_is_for",
+            "who_it_may_not_be_suitable_for",
+            "benefits",
+            "risks_and_limitations",
+            "alternatives",
+            "process",
+            "timeline",
+            "aftercare",
+            "cost_fee_logic",
+            "local_shoreham_context",
+            "clinician_expertise",
+            "technology_used",
+            "faq",
+            "related_treatments_internal_links",
+            "last_reviewed_clinical_review",
+            "cta"
+          ],
+          "secondaryGeographyMentions": {},
+          "secondaryGeographyStuffing": false,
+          "errors": [
+            "answerSurface is missing"
+          ],
+          "warnings": []
+        }
+      },
+      {
+        "route": "/treatments/emergency-dentistry",
+        "pageId": "emergency_dentistry",
+        "label": "Emergency dentistry",
+        "validation": {
+          "frameworkPresent": false,
+          "valid": false,
+          "status": null,
+          "exampleSeed": false,
+          "presentSectionIds": [],
+          "missingSectionIds": [
+            "direct_answer",
+            "what_this_treatment_is",
+            "who_it_is_for",
+            "who_it_may_not_be_suitable_for",
+            "benefits",
+            "risks_and_limitations",
+            "alternatives",
+            "process",
+            "timeline",
+            "aftercare",
+            "cost_fee_logic",
+            "local_shoreham_context",
+            "clinician_expertise",
+            "technology_used",
+            "faq",
+            "related_treatments_internal_links",
+            "last_reviewed_clinical_review",
+            "cta"
+          ],
+          "secondaryGeographyMentions": {},
+          "secondaryGeographyStuffing": false,
+          "errors": [
+            "answerSurface is missing"
+          ],
+          "warnings": []
+        }
+      },
+      {
+        "route": "/treatments/emergency-dental-appointments",
+        "pageId": "emergency_dental_appointments",
+        "label": "Emergency dental appointments",
+        "validation": {
+          "frameworkPresent": false,
+          "valid": false,
+          "status": null,
+          "exampleSeed": false,
+          "presentSectionIds": [],
+          "missingSectionIds": [
+            "direct_answer",
+            "what_this_treatment_is",
+            "who_it_is_for",
+            "who_it_may_not_be_suitable_for",
+            "benefits",
+            "risks_and_limitations",
+            "alternatives",
+            "process",
+            "timeline",
+            "aftercare",
+            "cost_fee_logic",
+            "local_shoreham_context",
+            "clinician_expertise",
+            "technology_used",
+            "faq",
+            "related_treatments_internal_links",
+            "last_reviewed_clinical_review",
+            "cta"
+          ],
+          "secondaryGeographyMentions": {},
+          "secondaryGeographyStuffing": false,
+          "errors": [
+            "answerSurface is missing"
+          ],
+          "warnings": []
+        }
+      },
+      {
+        "route": "/treatments/severe-toothache-dental-pain",
+        "pageId": "emergency_severe_toothache",
+        "label": "Severe toothache & dental pain",
+        "validation": {
+          "frameworkPresent": false,
+          "valid": false,
+          "status": null,
+          "exampleSeed": false,
+          "presentSectionIds": [],
+          "missingSectionIds": [
+            "direct_answer",
+            "what_this_treatment_is",
+            "who_it_is_for",
+            "who_it_may_not_be_suitable_for",
+            "benefits",
+            "risks_and_limitations",
+            "alternatives",
+            "process",
+            "timeline",
+            "aftercare",
+            "cost_fee_logic",
+            "local_shoreham_context",
+            "clinician_expertise",
+            "technology_used",
+            "faq",
+            "related_treatments_internal_links",
+            "last_reviewed_clinical_review",
+            "cta"
+          ],
+          "secondaryGeographyMentions": {},
+          "secondaryGeographyStuffing": false,
+          "errors": [
+            "answerSurface is missing"
+          ],
+          "warnings": []
+        }
+      },
+      {
+        "route": "/treatments/dental-abscess-infection",
+        "pageId": "emergency_dental_abscess",
+        "label": "Dental abscess & infection",
+        "validation": {
+          "frameworkPresent": false,
+          "valid": false,
+          "status": null,
+          "exampleSeed": false,
+          "presentSectionIds": [],
+          "missingSectionIds": [
+            "direct_answer",
+            "what_this_treatment_is",
+            "who_it_is_for",
+            "who_it_may_not_be_suitable_for",
+            "benefits",
+            "risks_and_limitations",
+            "alternatives",
+            "process",
+            "timeline",
+            "aftercare",
+            "cost_fee_logic",
+            "local_shoreham_context",
+            "clinician_expertise",
+            "technology_used",
+            "faq",
+            "related_treatments_internal_links",
+            "last_reviewed_clinical_review",
+            "cta"
+          ],
+          "secondaryGeographyMentions": {},
+          "secondaryGeographyStuffing": false,
+          "errors": [
+            "answerSurface is missing"
+          ],
+          "warnings": []
+        }
+      },
+      {
+        "route": "/treatments/broken-chipped-cracked-teeth",
+        "pageId": "emergency_broken_chipped_teeth",
+        "label": "Broken, chipped or cracked teeth",
+        "validation": {
+          "frameworkPresent": false,
+          "valid": false,
+          "status": null,
+          "exampleSeed": false,
+          "presentSectionIds": [],
+          "missingSectionIds": [
+            "direct_answer",
+            "what_this_treatment_is",
+            "who_it_is_for",
+            "who_it_may_not_be_suitable_for",
+            "benefits",
+            "risks_and_limitations",
+            "alternatives",
+            "process",
+            "timeline",
+            "aftercare",
+            "cost_fee_logic",
+            "local_shoreham_context",
+            "clinician_expertise",
+            "technology_used",
+            "faq",
+            "related_treatments_internal_links",
+            "last_reviewed_clinical_review",
+            "cta"
+          ],
+          "secondaryGeographyMentions": {},
+          "secondaryGeographyStuffing": false,
+          "errors": [
+            "answerSurface is missing"
+          ],
+          "warnings": []
+        }
+      },
+      {
+        "route": "/treatments/knocked-out-tooth",
+        "pageId": "emergency_knocked_out_tooth",
+        "label": "Knocked-out (avulsed) tooth",
+        "validation": {
+          "frameworkPresent": false,
+          "valid": false,
+          "status": null,
+          "exampleSeed": false,
+          "presentSectionIds": [],
+          "missingSectionIds": [
+            "direct_answer",
+            "what_this_treatment_is",
+            "who_it_is_for",
+            "who_it_may_not_be_suitable_for",
+            "benefits",
+            "risks_and_limitations",
+            "alternatives",
+            "process",
+            "timeline",
+            "aftercare",
+            "cost_fee_logic",
+            "local_shoreham_context",
+            "clinician_expertise",
+            "technology_used",
+            "faq",
+            "related_treatments_internal_links",
+            "last_reviewed_clinical_review",
+            "cta"
+          ],
+          "secondaryGeographyMentions": {},
+          "secondaryGeographyStuffing": false,
+          "errors": [
+            "answerSurface is missing"
+          ],
+          "warnings": []
+        }
+      },
+      {
+        "route": "/treatments/lost-crowns-veneers-fillings",
+        "pageId": "emergency_lost_crowns",
+        "label": "Lost crowns, veneers & fillings",
+        "validation": {
+          "frameworkPresent": false,
+          "valid": false,
+          "status": null,
+          "exampleSeed": false,
+          "presentSectionIds": [],
+          "missingSectionIds": [
+            "direct_answer",
+            "what_this_treatment_is",
+            "who_it_is_for",
+            "who_it_may_not_be_suitable_for",
+            "benefits",
+            "risks_and_limitations",
+            "alternatives",
+            "process",
+            "timeline",
+            "aftercare",
+            "cost_fee_logic",
+            "local_shoreham_context",
+            "clinician_expertise",
+            "technology_used",
+            "faq",
+            "related_treatments_internal_links",
+            "last_reviewed_clinical_review",
+            "cta"
+          ],
+          "secondaryGeographyMentions": {},
+          "secondaryGeographyStuffing": false,
+          "errors": [
+            "answerSurface is missing"
+          ],
+          "warnings": []
+        }
+      },
+      {
+        "route": "/treatments/dental-trauma-accidents",
+        "pageId": "emergency_dental_trauma",
+        "label": "Dental trauma & accidents",
+        "validation": {
+          "frameworkPresent": false,
+          "valid": false,
+          "status": null,
+          "exampleSeed": false,
+          "presentSectionIds": [],
+          "missingSectionIds": [
+            "direct_answer",
+            "what_this_treatment_is",
+            "who_it_is_for",
+            "who_it_may_not_be_suitable_for",
+            "benefits",
+            "risks_and_limitations",
+            "alternatives",
+            "process",
+            "timeline",
+            "aftercare",
+            "cost_fee_logic",
+            "local_shoreham_context",
+            "clinician_expertise",
+            "technology_used",
+            "faq",
+            "related_treatments_internal_links",
+            "last_reviewed_clinical_review",
+            "cta"
+          ],
+          "secondaryGeographyMentions": {},
+          "secondaryGeographyStuffing": false,
+          "errors": [
+            "answerSurface is missing"
+          ],
+          "warnings": []
+        }
+      },
+      {
+        "route": "/treatments/3d-dentistry-and-technology",
+        "pageId": "3d_dentistry_and_technology",
+        "label": "3D dentistry & technology",
+        "validation": {
+          "frameworkPresent": false,
+          "valid": false,
+          "status": null,
+          "exampleSeed": false,
+          "presentSectionIds": [],
+          "missingSectionIds": [
+            "direct_answer",
+            "what_this_treatment_is",
+            "who_it_is_for",
+            "who_it_may_not_be_suitable_for",
+            "benefits",
+            "risks_and_limitations",
+            "alternatives",
+            "process",
+            "timeline",
+            "aftercare",
+            "cost_fee_logic",
+            "local_shoreham_context",
+            "clinician_expertise",
+            "technology_used",
+            "faq",
+            "related_treatments_internal_links",
+            "last_reviewed_clinical_review",
+            "cta"
+          ],
+          "secondaryGeographyMentions": {},
+          "secondaryGeographyStuffing": false,
+          "errors": [
+            "answerSurface is missing"
+          ],
+          "warnings": []
+        }
+      },
+      {
+        "route": "/treatments/cbct-3d-scanning",
+        "pageId": "cbct_3d_scanning",
+        "label": "CBCT / 3D scanning",
+        "validation": {
+          "frameworkPresent": false,
+          "valid": false,
+          "status": null,
+          "exampleSeed": false,
+          "presentSectionIds": [],
+          "missingSectionIds": [
+            "direct_answer",
+            "what_this_treatment_is",
+            "who_it_is_for",
+            "who_it_may_not_be_suitable_for",
+            "benefits",
+            "risks_and_limitations",
+            "alternatives",
+            "process",
+            "timeline",
+            "aftercare",
+            "cost_fee_logic",
+            "local_shoreham_context",
+            "clinician_expertise",
+            "technology_used",
+            "faq",
+            "related_treatments_internal_links",
+            "last_reviewed_clinical_review",
+            "cta"
+          ],
+          "secondaryGeographyMentions": {},
+          "secondaryGeographyStuffing": false,
+          "errors": [
+            "answerSurface is missing"
+          ],
+          "warnings": []
+        }
+      },
+      {
+        "route": "/treatments/digital-smile-design",
+        "pageId": "digital_smile_design",
+        "label": "Digital smile design",
+        "validation": {
+          "frameworkPresent": false,
+          "valid": false,
+          "status": null,
+          "exampleSeed": false,
+          "presentSectionIds": [],
+          "missingSectionIds": [
+            "direct_answer",
+            "what_this_treatment_is",
+            "who_it_is_for",
+            "who_it_may_not_be_suitable_for",
+            "benefits",
+            "risks_and_limitations",
+            "alternatives",
+            "process",
+            "timeline",
+            "aftercare",
+            "cost_fee_logic",
+            "local_shoreham_context",
+            "clinician_expertise",
+            "technology_used",
+            "faq",
+            "related_treatments_internal_links",
+            "last_reviewed_clinical_review",
+            "cta"
+          ],
+          "secondaryGeographyMentions": {},
+          "secondaryGeographyStuffing": false,
+          "errors": [
+            "answerSurface is missing"
+          ],
+          "warnings": []
+        }
+      },
+      {
+        "route": "/treatments/3d-printing-lab",
+        "pageId": "3d_printing_lab",
+        "label": "3D printing lab",
+        "validation": {
+          "frameworkPresent": false,
+          "valid": false,
+          "status": null,
+          "exampleSeed": false,
+          "presentSectionIds": [],
+          "missingSectionIds": [
+            "direct_answer",
+            "what_this_treatment_is",
+            "who_it_is_for",
+            "who_it_may_not_be_suitable_for",
+            "benefits",
+            "risks_and_limitations",
+            "alternatives",
+            "process",
+            "timeline",
+            "aftercare",
+            "cost_fee_logic",
+            "local_shoreham_context",
+            "clinician_expertise",
+            "technology_used",
+            "faq",
+            "related_treatments_internal_links",
+            "last_reviewed_clinical_review",
+            "cta"
+          ],
+          "secondaryGeographyMentions": {},
+          "secondaryGeographyStuffing": false,
+          "errors": [
+            "answerSurface is missing"
+          ],
+          "warnings": []
+        }
+      },
+      {
+        "route": "/treatments/inlays-onlays",
+        "pageId": "inlays_onlays",
+        "label": "Inlays & onlays",
+        "validation": {
+          "frameworkPresent": false,
+          "valid": false,
+          "status": null,
+          "exampleSeed": false,
+          "presentSectionIds": [],
+          "missingSectionIds": [
+            "direct_answer",
+            "what_this_treatment_is",
+            "who_it_is_for",
+            "who_it_may_not_be_suitable_for",
+            "benefits",
+            "risks_and_limitations",
+            "alternatives",
+            "process",
+            "timeline",
+            "aftercare",
+            "cost_fee_logic",
+            "local_shoreham_context",
+            "clinician_expertise",
+            "technology_used",
+            "faq",
+            "related_treatments_internal_links",
+            "last_reviewed_clinical_review",
+            "cta"
+          ],
+          "secondaryGeographyMentions": {},
+          "secondaryGeographyStuffing": false,
+          "errors": [
+            "answerSurface is missing"
+          ],
+          "warnings": []
+        }
+      },
+      {
+        "route": "/treatments/dental-fillings",
+        "pageId": "dental_fillings",
+        "label": "Dental fillings",
+        "validation": {
+          "frameworkPresent": false,
+          "valid": false,
+          "status": null,
+          "exampleSeed": false,
+          "presentSectionIds": [],
+          "missingSectionIds": [
+            "direct_answer",
+            "what_this_treatment_is",
+            "who_it_is_for",
+            "who_it_may_not_be_suitable_for",
+            "benefits",
+            "risks_and_limitations",
+            "alternatives",
+            "process",
+            "timeline",
+            "aftercare",
+            "cost_fee_logic",
+            "local_shoreham_context",
+            "clinician_expertise",
+            "technology_used",
+            "faq",
+            "related_treatments_internal_links",
+            "last_reviewed_clinical_review",
+            "cta"
+          ],
+          "secondaryGeographyMentions": {},
+          "secondaryGeographyStuffing": false,
+          "errors": [
+            "answerSurface is missing"
+          ],
+          "warnings": []
+        }
+      },
+      {
+        "route": "/treatments/dentures",
+        "pageId": "dentures",
+        "label": "Dentures & tooth replacement",
+        "validation": {
+          "frameworkPresent": false,
+          "valid": false,
+          "status": null,
+          "exampleSeed": false,
+          "presentSectionIds": [],
+          "missingSectionIds": [
+            "direct_answer",
+            "what_this_treatment_is",
+            "who_it_is_for",
+            "who_it_may_not_be_suitable_for",
+            "benefits",
+            "risks_and_limitations",
+            "alternatives",
+            "process",
+            "timeline",
+            "aftercare",
+            "cost_fee_logic",
+            "local_shoreham_context",
+            "clinician_expertise",
+            "technology_used",
+            "faq",
+            "related_treatments_internal_links",
+            "last_reviewed_clinical_review",
+            "cta"
+          ],
+          "secondaryGeographyMentions": {},
+          "secondaryGeographyStuffing": false,
+          "errors": [
+            "answerSurface is missing"
+          ],
+          "warnings": []
+        }
+      },
+      {
+        "route": "/treatments/acrylic-dentures",
+        "pageId": "acrylic_dentures",
+        "label": "Acrylic dentures",
+        "validation": {
+          "frameworkPresent": false,
+          "valid": false,
+          "status": null,
+          "exampleSeed": false,
+          "presentSectionIds": [],
+          "missingSectionIds": [
+            "direct_answer",
+            "what_this_treatment_is",
+            "who_it_is_for",
+            "who_it_may_not_be_suitable_for",
+            "benefits",
+            "risks_and_limitations",
+            "alternatives",
+            "process",
+            "timeline",
+            "aftercare",
+            "cost_fee_logic",
+            "local_shoreham_context",
+            "clinician_expertise",
+            "technology_used",
+            "faq",
+            "related_treatments_internal_links",
+            "last_reviewed_clinical_review",
+            "cta"
+          ],
+          "secondaryGeographyMentions": {},
+          "secondaryGeographyStuffing": false,
+          "errors": [
+            "answerSurface is missing"
+          ],
+          "warnings": []
+        }
+      },
+      {
+        "route": "/treatments/chrome-dentures",
+        "pageId": "chrome_dentures",
+        "label": "Chrome dentures",
+        "validation": {
+          "frameworkPresent": false,
+          "valid": false,
+          "status": null,
+          "exampleSeed": false,
+          "presentSectionIds": [],
+          "missingSectionIds": [
+            "direct_answer",
+            "what_this_treatment_is",
+            "who_it_is_for",
+            "who_it_may_not_be_suitable_for",
+            "benefits",
+            "risks_and_limitations",
+            "alternatives",
+            "process",
+            "timeline",
+            "aftercare",
+            "cost_fee_logic",
+            "local_shoreham_context",
+            "clinician_expertise",
+            "technology_used",
+            "faq",
+            "related_treatments_internal_links",
+            "last_reviewed_clinical_review",
+            "cta"
+          ],
+          "secondaryGeographyMentions": {},
+          "secondaryGeographyStuffing": false,
+          "errors": [
+            "answerSurface is missing"
+          ],
+          "warnings": []
+        }
+      },
+      {
+        "route": "/treatments/peek-partial-dentures",
+        "pageId": "peek_partial_dentures",
+        "label": "PEEK partial dentures",
+        "validation": {
+          "frameworkPresent": false,
+          "valid": false,
+          "status": null,
+          "exampleSeed": false,
+          "presentSectionIds": [],
+          "missingSectionIds": [
+            "direct_answer",
+            "what_this_treatment_is",
+            "who_it_is_for",
+            "who_it_may_not_be_suitable_for",
+            "benefits",
+            "risks_and_limitations",
+            "alternatives",
+            "process",
+            "timeline",
+            "aftercare",
+            "cost_fee_logic",
+            "local_shoreham_context",
+            "clinician_expertise",
+            "technology_used",
+            "faq",
+            "related_treatments_internal_links",
+            "last_reviewed_clinical_review",
+            "cta"
+          ],
+          "secondaryGeographyMentions": {},
+          "secondaryGeographyStuffing": false,
+          "errors": [
+            "answerSurface is missing"
+          ],
+          "warnings": []
+        }
+      },
+      {
+        "route": "/treatments/3d-printed-dentures",
+        "pageId": "printed_dentures_3d",
+        "label": "3D printed dentures",
+        "validation": {
+          "frameworkPresent": false,
+          "valid": false,
+          "status": null,
+          "exampleSeed": false,
+          "presentSectionIds": [],
+          "missingSectionIds": [
+            "direct_answer",
+            "what_this_treatment_is",
+            "who_it_is_for",
+            "who_it_may_not_be_suitable_for",
+            "benefits",
+            "risks_and_limitations",
+            "alternatives",
+            "process",
+            "timeline",
+            "aftercare",
+            "cost_fee_logic",
+            "local_shoreham_context",
+            "clinician_expertise",
+            "technology_used",
+            "faq",
+            "related_treatments_internal_links",
+            "last_reviewed_clinical_review",
+            "cta"
+          ],
+          "secondaryGeographyMentions": {},
+          "secondaryGeographyStuffing": false,
+          "errors": [
+            "answerSurface is missing"
+          ],
+          "warnings": []
+        }
+      },
+      {
+        "route": "/treatments/night-guards-occlusal-splints",
+        "pageId": "night_guards_occlusal_splints",
+        "label": "Night guards (occlusal splints)",
+        "validation": {
+          "frameworkPresent": false,
+          "valid": false,
+          "status": null,
+          "exampleSeed": false,
+          "presentSectionIds": [],
+          "missingSectionIds": [
+            "direct_answer",
+            "what_this_treatment_is",
+            "who_it_is_for",
+            "who_it_may_not_be_suitable_for",
+            "benefits",
+            "risks_and_limitations",
+            "alternatives",
+            "process",
+            "timeline",
+            "aftercare",
+            "cost_fee_logic",
+            "local_shoreham_context",
+            "clinician_expertise",
+            "technology_used",
+            "faq",
+            "related_treatments_internal_links",
+            "last_reviewed_clinical_review",
+            "cta"
+          ],
+          "secondaryGeographyMentions": {},
+          "secondaryGeographyStuffing": false,
+          "errors": [
+            "answerSurface is missing"
+          ],
+          "warnings": []
+        }
+      },
+      {
+        "route": "/treatments/sports-mouthguards",
+        "pageId": "sports_mouthguards",
+        "label": "Sports mouthguards",
+        "validation": {
+          "frameworkPresent": false,
+          "valid": false,
+          "status": null,
+          "exampleSeed": false,
+          "presentSectionIds": [],
+          "missingSectionIds": [
+            "direct_answer",
+            "what_this_treatment_is",
+            "who_it_is_for",
+            "who_it_may_not_be_suitable_for",
+            "benefits",
+            "risks_and_limitations",
+            "alternatives",
+            "process",
+            "timeline",
+            "aftercare",
+            "cost_fee_logic",
+            "local_shoreham_context",
+            "clinician_expertise",
+            "technology_used",
+            "faq",
+            "related_treatments_internal_links",
+            "last_reviewed_clinical_review",
+            "cta"
+          ],
+          "secondaryGeographyMentions": {},
+          "secondaryGeographyStuffing": false,
+          "errors": [
+            "answerSurface is missing"
+          ],
+          "warnings": []
+        }
+      },
+      {
+        "route": "/treatments/dental-retainers",
+        "pageId": "dental_retainers",
+        "label": "Retainers",
+        "validation": {
+          "frameworkPresent": false,
+          "valid": false,
+          "status": null,
+          "exampleSeed": false,
+          "presentSectionIds": [],
+          "missingSectionIds": [
+            "direct_answer",
+            "what_this_treatment_is",
+            "who_it_is_for",
+            "who_it_may_not_be_suitable_for",
+            "benefits",
+            "risks_and_limitations",
+            "alternatives",
+            "process",
+            "timeline",
+            "aftercare",
+            "cost_fee_logic",
+            "local_shoreham_context",
+            "clinician_expertise",
+            "technology_used",
+            "faq",
+            "related_treatments_internal_links",
+            "last_reviewed_clinical_review",
+            "cta"
+          ],
+          "secondaryGeographyMentions": {},
+          "secondaryGeographyStuffing": false,
+          "errors": [
+            "answerSurface is missing"
+          ],
+          "warnings": []
+        }
+      },
+      {
+        "route": "/treatments/preventative-and-general-dentistry",
+        "pageId": "preventative_and_general_dentistry",
+        "label": "Preventative & general dentistry",
+        "validation": {
+          "frameworkPresent": false,
+          "valid": false,
+          "status": null,
+          "exampleSeed": false,
+          "presentSectionIds": [],
+          "missingSectionIds": [
+            "direct_answer",
+            "what_this_treatment_is",
+            "who_it_is_for",
+            "who_it_may_not_be_suitable_for",
+            "benefits",
+            "risks_and_limitations",
+            "alternatives",
+            "process",
+            "timeline",
+            "aftercare",
+            "cost_fee_logic",
+            "local_shoreham_context",
+            "clinician_expertise",
+            "technology_used",
+            "faq",
+            "related_treatments_internal_links",
+            "last_reviewed_clinical_review",
+            "cta"
+          ],
+          "secondaryGeographyMentions": {},
+          "secondaryGeographyStuffing": false,
+          "errors": [
+            "answerSurface is missing"
+          ],
+          "warnings": []
+        }
+      },
+      {
+        "route": "/treatments/childrens-dentistry",
+        "pageId": "childrens_dentistry",
+        "label": "Children’s dentistry",
+        "validation": {
+          "frameworkPresent": false,
+          "valid": false,
+          "status": null,
+          "exampleSeed": false,
+          "presentSectionIds": [],
+          "missingSectionIds": [
+            "direct_answer",
+            "what_this_treatment_is",
+            "who_it_is_for",
+            "who_it_may_not_be_suitable_for",
+            "benefits",
+            "risks_and_limitations",
+            "alternatives",
+            "process",
+            "timeline",
+            "aftercare",
+            "cost_fee_logic",
+            "local_shoreham_context",
+            "clinician_expertise",
+            "technology_used",
+            "faq",
+            "related_treatments_internal_links",
+            "last_reviewed_clinical_review",
+            "cta"
+          ],
+          "secondaryGeographyMentions": {},
+          "secondaryGeographyStuffing": false,
+          "errors": [
+            "answerSurface is missing"
+          ],
+          "warnings": []
+        }
+      },
+      {
+        "route": "/treatments/periodontal-gum-care",
+        "pageId": "periodontal_gum_care",
+        "label": "Gum disease",
+        "validation": {
+          "frameworkPresent": false,
+          "valid": false,
+          "status": null,
+          "exampleSeed": false,
+          "presentSectionIds": [],
+          "missingSectionIds": [
+            "direct_answer",
+            "what_this_treatment_is",
+            "who_it_is_for",
+            "who_it_may_not_be_suitable_for",
+            "benefits",
+            "risks_and_limitations",
+            "alternatives",
+            "process",
+            "timeline",
+            "aftercare",
+            "cost_fee_logic",
+            "local_shoreham_context",
+            "clinician_expertise",
+            "technology_used",
+            "faq",
+            "related_treatments_internal_links",
+            "last_reviewed_clinical_review",
+            "cta"
+          ],
+          "secondaryGeographyMentions": {},
+          "secondaryGeographyStuffing": false,
+          "errors": [
+            "answerSurface is missing"
+          ],
+          "warnings": []
+        }
+      },
+      {
+        "route": "/treatments/endodontics-root-canal",
+        "pageId": "endodontics_root_canal",
+        "label": "Endodontics & root canal care",
+        "validation": {
+          "frameworkPresent": false,
+          "valid": false,
+          "status": null,
+          "exampleSeed": false,
+          "presentSectionIds": [],
+          "missingSectionIds": [
+            "direct_answer",
+            "what_this_treatment_is",
+            "who_it_is_for",
+            "who_it_may_not_be_suitable_for",
+            "benefits",
+            "risks_and_limitations",
+            "alternatives",
+            "process",
+            "timeline",
+            "aftercare",
+            "cost_fee_logic",
+            "local_shoreham_context",
+            "clinician_expertise",
+            "technology_used",
+            "faq",
+            "related_treatments_internal_links",
+            "last_reviewed_clinical_review",
+            "cta"
+          ],
+          "secondaryGeographyMentions": {},
+          "secondaryGeographyStuffing": false,
+          "errors": [
+            "answerSurface is missing"
+          ],
+          "warnings": []
+        }
+      },
+      {
+        "route": "/treatments/extractions-and-oral-surgery",
+        "pageId": "extractions_and_oral_surgery",
+        "label": "Extractions & oral surgery",
+        "validation": {
+          "frameworkPresent": false,
+          "valid": false,
+          "status": null,
+          "exampleSeed": false,
+          "presentSectionIds": [],
+          "missingSectionIds": [
+            "direct_answer",
+            "what_this_treatment_is",
+            "who_it_is_for",
+            "who_it_may_not_be_suitable_for",
+            "benefits",
+            "risks_and_limitations",
+            "alternatives",
+            "process",
+            "timeline",
+            "aftercare",
+            "cost_fee_logic",
+            "local_shoreham_context",
+            "clinician_expertise",
+            "technology_used",
+            "faq",
+            "related_treatments_internal_links",
+            "last_reviewed_clinical_review",
+            "cta"
+          ],
+          "secondaryGeographyMentions": {},
+          "secondaryGeographyStuffing": false,
+          "errors": [
+            "answerSurface is missing"
+          ],
+          "warnings": []
+        }
+      },
+      {
+        "route": "/treatments/senior-mature-smile-care",
+        "pageId": "senior_mature_smile_care",
+        "label": "Senior and mature smile care",
+        "validation": {
+          "frameworkPresent": false,
+          "valid": false,
+          "status": null,
+          "exampleSeed": false,
+          "presentSectionIds": [],
+          "missingSectionIds": [
+            "direct_answer",
+            "what_this_treatment_is",
+            "who_it_is_for",
+            "who_it_may_not_be_suitable_for",
+            "benefits",
+            "risks_and_limitations",
+            "alternatives",
+            "process",
+            "timeline",
+            "aftercare",
+            "cost_fee_logic",
+            "local_shoreham_context",
+            "clinician_expertise",
+            "technology_used",
+            "faq",
+            "related_treatments_internal_links",
+            "last_reviewed_clinical_review",
+            "cta"
+          ],
+          "secondaryGeographyMentions": {},
+          "secondaryGeographyStuffing": false,
+          "errors": [
+            "answerSurface is missing"
+          ],
+          "warnings": []
+        }
+      },
+      {
+        "route": "/treatments/tmj-jaw-comfort",
+        "pageId": "tmj_jaw_comfort",
+        "label": "Jaw joint (TMJ) comfort",
+        "validation": {
+          "frameworkPresent": false,
+          "valid": false,
+          "status": null,
+          "exampleSeed": false,
+          "presentSectionIds": [],
+          "missingSectionIds": [
+            "direct_answer",
+            "what_this_treatment_is",
+            "who_it_is_for",
+            "who_it_may_not_be_suitable_for",
+            "benefits",
+            "risks_and_limitations",
+            "alternatives",
+            "process",
+            "timeline",
+            "aftercare",
+            "cost_fee_logic",
+            "local_shoreham_context",
+            "clinician_expertise",
+            "technology_used",
+            "faq",
+            "related_treatments_internal_links",
+            "last_reviewed_clinical_review",
+            "cta"
+          ],
+          "secondaryGeographyMentions": {},
+          "secondaryGeographyStuffing": false,
+          "errors": [
+            "answerSurface is missing"
+          ],
+          "warnings": []
+        }
+      },
+      {
+        "route": "/treatments/nervous-patients",
+        "pageId": "nervous_patients",
+        "label": "Nervous patients",
+        "validation": {
+          "frameworkPresent": false,
+          "valid": false,
+          "status": null,
+          "exampleSeed": false,
+          "presentSectionIds": [],
+          "missingSectionIds": [
+            "direct_answer",
+            "what_this_treatment_is",
+            "who_it_is_for",
+            "who_it_may_not_be_suitable_for",
+            "benefits",
+            "risks_and_limitations",
+            "alternatives",
+            "process",
+            "timeline",
+            "aftercare",
+            "cost_fee_logic",
+            "local_shoreham_context",
+            "clinician_expertise",
+            "technology_used",
+            "faq",
+            "related_treatments_internal_links",
+            "last_reviewed_clinical_review",
+            "cta"
+          ],
+          "secondaryGeographyMentions": {},
+          "secondaryGeographyStuffing": false,
+          "errors": [
+            "answerSurface is missing"
+          ],
+          "warnings": []
+        }
+      },
+      {
+        "route": "/treatments/sedation-dentistry",
+        "pageId": "sedation_dentistry",
+        "label": "Sedation dentistry",
+        "validation": {
+          "frameworkPresent": false,
+          "valid": false,
+          "status": null,
+          "exampleSeed": false,
+          "presentSectionIds": [],
+          "missingSectionIds": [
+            "direct_answer",
+            "what_this_treatment_is",
+            "who_it_is_for",
+            "who_it_may_not_be_suitable_for",
+            "benefits",
+            "risks_and_limitations",
+            "alternatives",
+            "process",
+            "timeline",
+            "aftercare",
+            "cost_fee_logic",
+            "local_shoreham_context",
+            "clinician_expertise",
+            "technology_used",
+            "faq",
+            "related_treatments_internal_links",
+            "last_reviewed_clinical_review",
+            "cta"
+          ],
+          "secondaryGeographyMentions": {},
+          "secondaryGeographyStuffing": false,
+          "errors": [
+            "answerSurface is missing"
+          ],
+          "warnings": []
+        }
+      },
+      {
+        "route": "/treatments/painless-numbing-the-wand",
+        "pageId": "painless_numbing_the_wand",
+        "label": "The Wand numbing system",
+        "validation": {
+          "frameworkPresent": false,
+          "valid": false,
+          "status": null,
+          "exampleSeed": false,
+          "presentSectionIds": [],
+          "missingSectionIds": [
+            "direct_answer",
+            "what_this_treatment_is",
+            "who_it_is_for",
+            "who_it_may_not_be_suitable_for",
+            "benefits",
+            "risks_and_limitations",
+            "alternatives",
+            "process",
+            "timeline",
+            "aftercare",
+            "cost_fee_logic",
+            "local_shoreham_context",
+            "clinician_expertise",
+            "technology_used",
+            "faq",
+            "related_treatments_internal_links",
+            "last_reviewed_clinical_review",
+            "cta"
+          ],
+          "secondaryGeographyMentions": {},
+          "secondaryGeographyStuffing": false,
+          "errors": [
+            "answerSurface is missing"
+          ],
+          "warnings": []
+        }
+      },
+      {
+        "route": "/treatments/tooth-wear-broken-teeth",
+        "pageId": "tooth_wear_broken_teeth",
+        "label": "Tooth Wear & Broken Teeth",
+        "validation": {
+          "frameworkPresent": false,
+          "valid": false,
+          "status": null,
+          "exampleSeed": false,
+          "presentSectionIds": [],
+          "missingSectionIds": [
+            "direct_answer",
+            "what_this_treatment_is",
+            "who_it_is_for",
+            "who_it_may_not_be_suitable_for",
+            "benefits",
+            "risks_and_limitations",
+            "alternatives",
+            "process",
+            "timeline",
+            "aftercare",
+            "cost_fee_logic",
+            "local_shoreham_context",
+            "clinician_expertise",
+            "technology_used",
+            "faq",
+            "related_treatments_internal_links",
+            "last_reviewed_clinical_review",
+            "cta"
+          ],
+          "secondaryGeographyMentions": {},
+          "secondaryGeographyStuffing": false,
+          "errors": [
+            "answerSurface is missing"
+          ],
+          "warnings": []
+        }
+      },
+      {
+        "route": "/treatments/facial-therapeutics",
+        "pageId": "facial_therapeutics",
+        "label": "Facial therapeutics in Shoreham-by-Sea",
+        "validation": {
+          "frameworkPresent": false,
+          "valid": false,
+          "status": null,
+          "exampleSeed": false,
+          "presentSectionIds": [],
+          "missingSectionIds": [
+            "direct_answer",
+            "what_this_treatment_is",
+            "who_it_is_for",
+            "who_it_may_not_be_suitable_for",
+            "benefits",
+            "risks_and_limitations",
+            "alternatives",
+            "process",
+            "timeline",
+            "aftercare",
+            "cost_fee_logic",
+            "local_shoreham_context",
+            "clinician_expertise",
+            "technology_used",
+            "faq",
+            "related_treatments_internal_links",
+            "last_reviewed_clinical_review",
+            "cta"
+          ],
+          "secondaryGeographyMentions": {},
+          "secondaryGeographyStuffing": false,
+          "errors": [
+            "answerSurface is missing"
+          ],
+          "warnings": []
+        }
+      },
+      {
+        "route": "/treatments/bruxism-and-jaw-clenching",
+        "pageId": "bruxism_jaw_clenching",
+        "label": "Bruxism (grinding) and jaw clenching",
+        "validation": {
+          "frameworkPresent": false,
+          "valid": false,
+          "status": null,
+          "exampleSeed": false,
+          "presentSectionIds": [],
+          "missingSectionIds": [
+            "direct_answer",
+            "what_this_treatment_is",
+            "who_it_is_for",
+            "who_it_may_not_be_suitable_for",
+            "benefits",
+            "risks_and_limitations",
+            "alternatives",
+            "process",
+            "timeline",
+            "aftercare",
+            "cost_fee_logic",
+            "local_shoreham_context",
+            "clinician_expertise",
+            "technology_used",
+            "faq",
+            "related_treatments_internal_links",
+            "last_reviewed_clinical_review",
+            "cta"
+          ],
+          "secondaryGeographyMentions": {},
+          "secondaryGeographyStuffing": false,
+          "errors": [
+            "answerSurface is missing"
+          ],
+          "warnings": []
+        }
+      },
+      {
+        "route": "/treatments/facial-pain-and-headache",
+        "pageId": "facial_pain_headache",
+        "label": "Facial pain and headache pathways",
+        "validation": {
+          "frameworkPresent": false,
+          "valid": false,
+          "status": null,
+          "exampleSeed": false,
+          "presentSectionIds": [],
+          "missingSectionIds": [
+            "direct_answer",
+            "what_this_treatment_is",
+            "who_it_is_for",
+            "who_it_may_not_be_suitable_for",
+            "benefits",
+            "risks_and_limitations",
+            "alternatives",
+            "process",
+            "timeline",
+            "aftercare",
+            "cost_fee_logic",
+            "local_shoreham_context",
+            "clinician_expertise",
+            "technology_used",
+            "faq",
+            "related_treatments_internal_links",
+            "last_reviewed_clinical_review",
+            "cta"
+          ],
+          "secondaryGeographyMentions": {},
+          "secondaryGeographyStuffing": false,
+          "errors": [
+            "answerSurface is missing"
+          ],
+          "warnings": []
+        }
+      },
+      {
+        "route": "/treatments/tmj-disorder-treatment",
+        "pageId": "tmj_disorder_treatment",
+        "label": "TMJ disorder treatment",
+        "validation": {
+          "frameworkPresent": false,
+          "valid": false,
+          "status": null,
+          "exampleSeed": false,
+          "presentSectionIds": [],
+          "missingSectionIds": [
+            "direct_answer",
+            "what_this_treatment_is",
+            "who_it_is_for",
+            "who_it_may_not_be_suitable_for",
+            "benefits",
+            "risks_and_limitations",
+            "alternatives",
+            "process",
+            "timeline",
+            "aftercare",
+            "cost_fee_logic",
+            "local_shoreham_context",
+            "clinician_expertise",
+            "technology_used",
+            "faq",
+            "related_treatments_internal_links",
+            "last_reviewed_clinical_review",
+            "cta"
+          ],
+          "secondaryGeographyMentions": {},
+          "secondaryGeographyStuffing": false,
+          "errors": [
+            "answerSurface is missing"
+          ],
+          "warnings": []
+        }
+      },
+      {
+        "route": "/treatments/therapeutic-facial-injectables",
+        "pageId": "therapeutic_facial_injectables",
+        "label": "Therapeutic facial injectables",
+        "validation": {
+          "frameworkPresent": false,
+          "valid": false,
+          "status": null,
+          "exampleSeed": false,
+          "presentSectionIds": [],
+          "missingSectionIds": [
+            "direct_answer",
+            "what_this_treatment_is",
+            "who_it_is_for",
+            "who_it_may_not_be_suitable_for",
+            "benefits",
+            "risks_and_limitations",
+            "alternatives",
+            "process",
+            "timeline",
+            "aftercare",
+            "cost_fee_logic",
+            "local_shoreham_context",
+            "clinician_expertise",
+            "technology_used",
+            "faq",
+            "related_treatments_internal_links",
+            "last_reviewed_clinical_review",
+            "cta"
+          ],
+          "secondaryGeographyMentions": {},
+          "secondaryGeographyStuffing": false,
+          "errors": [
+            "answerSurface is missing"
+          ],
+          "warnings": []
+        }
+      },
+      {
+        "route": "/treatments/facial-aesthetics",
+        "pageId": "facial_aesthetics",
+        "label": "Facial aesthetics",
+        "validation": {
+          "frameworkPresent": false,
+          "valid": false,
+          "status": null,
+          "exampleSeed": false,
+          "presentSectionIds": [],
+          "missingSectionIds": [
+            "direct_answer",
+            "what_this_treatment_is",
+            "who_it_is_for",
+            "who_it_may_not_be_suitable_for",
+            "benefits",
+            "risks_and_limitations",
+            "alternatives",
+            "process",
+            "timeline",
+            "aftercare",
+            "cost_fee_logic",
+            "local_shoreham_context",
+            "clinician_expertise",
+            "technology_used",
+            "faq",
+            "related_treatments_internal_links",
+            "last_reviewed_clinical_review",
+            "cta"
+          ],
+          "secondaryGeographyMentions": {},
+          "secondaryGeographyStuffing": false,
+          "errors": [
+            "answerSurface is missing"
+          ],
+          "warnings": []
+        }
+      },
+      {
+        "route": "/treatments/cosmetic-dentistry",
+        "pageId": "cosmetic_dentistry",
+        "label": "Cosmetic dentistry",
+        "validation": {
+          "frameworkPresent": false,
+          "valid": false,
+          "status": null,
+          "exampleSeed": false,
+          "presentSectionIds": [],
+          "missingSectionIds": [
+            "direct_answer",
+            "what_this_treatment_is",
+            "who_it_is_for",
+            "who_it_may_not_be_suitable_for",
+            "benefits",
+            "risks_and_limitations",
+            "alternatives",
+            "process",
+            "timeline",
+            "aftercare",
+            "cost_fee_logic",
+            "local_shoreham_context",
+            "clinician_expertise",
+            "technology_used",
+            "faq",
+            "related_treatments_internal_links",
+            "last_reviewed_clinical_review",
+            "cta"
+          ],
+          "secondaryGeographyMentions": {},
+          "secondaryGeographyStuffing": false,
+          "errors": [
+            "answerSurface is missing"
+          ],
+          "warnings": []
+        }
+      },
+      {
+        "route": "/treatments/preventive-dentistry",
+        "pageId": "preventive_dentistry",
+        "label": "Preventive dentistry",
+        "validation": {
+          "frameworkPresent": false,
+          "valid": false,
+          "status": null,
+          "exampleSeed": false,
+          "presentSectionIds": [],
+          "missingSectionIds": [
+            "direct_answer",
+            "what_this_treatment_is",
+            "who_it_is_for",
+            "who_it_may_not_be_suitable_for",
+            "benefits",
+            "risks_and_limitations",
+            "alternatives",
+            "process",
+            "timeline",
+            "aftercare",
+            "cost_fee_logic",
+            "local_shoreham_context",
+            "clinician_expertise",
+            "technology_used",
+            "faq",
+            "related_treatments_internal_links",
+            "last_reviewed_clinical_review",
+            "cta"
+          ],
+          "secondaryGeographyMentions": {},
+          "secondaryGeographyStuffing": false,
+          "errors": [
+            "answerSurface is missing"
+          ],
+          "warnings": []
+        }
+      },
+      {
+        "route": "/treatments/anti-wrinkle-treatments",
+        "pageId": "anti_wrinkle_treatments",
+        "label": "Anti-wrinkle treatments",
+        "validation": {
+          "frameworkPresent": false,
+          "valid": false,
+          "status": null,
+          "exampleSeed": false,
+          "presentSectionIds": [],
+          "missingSectionIds": [
+            "direct_answer",
+            "what_this_treatment_is",
+            "who_it_is_for",
+            "who_it_may_not_be_suitable_for",
+            "benefits",
+            "risks_and_limitations",
+            "alternatives",
+            "process",
+            "timeline",
+            "aftercare",
+            "cost_fee_logic",
+            "local_shoreham_context",
+            "clinician_expertise",
+            "technology_used",
+            "faq",
+            "related_treatments_internal_links",
+            "last_reviewed_clinical_review",
+            "cta"
+          ],
+          "secondaryGeographyMentions": {},
+          "secondaryGeographyStuffing": false,
+          "errors": [
+            "answerSurface is missing"
+          ],
+          "warnings": []
+        }
+      },
+      {
+        "route": "/treatments/dermal-fillers",
+        "pageId": "dermal_fillers",
+        "label": "Dermal fillers",
+        "validation": {
+          "frameworkPresent": false,
+          "valid": false,
+          "status": null,
+          "exampleSeed": false,
+          "presentSectionIds": [],
+          "missingSectionIds": [
+            "direct_answer",
+            "what_this_treatment_is",
+            "who_it_is_for",
+            "who_it_may_not_be_suitable_for",
+            "benefits",
+            "risks_and_limitations",
+            "alternatives",
+            "process",
+            "timeline",
+            "aftercare",
+            "cost_fee_logic",
+            "local_shoreham_context",
+            "clinician_expertise",
+            "technology_used",
+            "faq",
+            "related_treatments_internal_links",
+            "last_reviewed_clinical_review",
+            "cta"
+          ],
+          "secondaryGeographyMentions": {},
+          "secondaryGeographyStuffing": false,
+          "errors": [
+            "answerSurface is missing"
+          ],
+          "warnings": []
+        }
+      },
+      {
+        "route": "/treatments/skin-boosters",
+        "pageId": "skin_boosters",
+        "label": "Skin boosters (hydration and elasticity)",
+        "validation": {
+          "frameworkPresent": false,
+          "valid": false,
+          "status": null,
+          "exampleSeed": false,
+          "presentSectionIds": [],
+          "missingSectionIds": [
+            "direct_answer",
+            "what_this_treatment_is",
+            "who_it_is_for",
+            "who_it_may_not_be_suitable_for",
+            "benefits",
+            "risks_and_limitations",
+            "alternatives",
+            "process",
+            "timeline",
+            "aftercare",
+            "cost_fee_logic",
+            "local_shoreham_context",
+            "clinician_expertise",
+            "technology_used",
+            "faq",
+            "related_treatments_internal_links",
+            "last_reviewed_clinical_review",
+            "cta"
+          ],
+          "secondaryGeographyMentions": {},
+          "secondaryGeographyStuffing": false,
+          "errors": [
+            "answerSurface is missing"
+          ],
+          "warnings": []
+        }
+      },
+      {
+        "route": "/treatments/polynucleotides",
+        "pageId": "polynucleotides",
+        "label": "Polynucleotides (skin quality support)",
+        "validation": {
+          "frameworkPresent": false,
+          "valid": false,
+          "status": null,
+          "exampleSeed": false,
+          "presentSectionIds": [],
+          "missingSectionIds": [
+            "direct_answer",
+            "what_this_treatment_is",
+            "who_it_is_for",
+            "who_it_may_not_be_suitable_for",
+            "benefits",
+            "risks_and_limitations",
+            "alternatives",
+            "process",
+            "timeline",
+            "aftercare",
+            "cost_fee_logic",
+            "local_shoreham_context",
+            "clinician_expertise",
+            "technology_used",
+            "faq",
+            "related_treatments_internal_links",
+            "last_reviewed_clinical_review",
+            "cta"
+          ],
+          "secondaryGeographyMentions": {},
+          "secondaryGeographyStuffing": false,
+          "errors": [
+            "answerSurface is missing"
+          ],
+          "warnings": []
+        }
+      },
+      {
+        "route": "/treatments/mouthguards-and-retainers",
+        "pageId": "mouthguards_and_retainers",
+        "label": "Mouthguards and retainers",
+        "validation": {
+          "frameworkPresent": false,
+          "valid": false,
+          "status": null,
+          "exampleSeed": false,
+          "presentSectionIds": [],
+          "missingSectionIds": [
+            "direct_answer",
+            "what_this_treatment_is",
+            "who_it_is_for",
+            "who_it_may_not_be_suitable_for",
+            "benefits",
+            "risks_and_limitations",
+            "alternatives",
+            "process",
+            "timeline",
+            "aftercare",
+            "cost_fee_logic",
+            "local_shoreham_context",
+            "clinician_expertise",
+            "technology_used",
+            "faq",
+            "related_treatments_internal_links",
+            "last_reviewed_clinical_review",
+            "cta"
+          ],
+          "secondaryGeographyMentions": {},
+          "secondaryGeographyStuffing": false,
+          "errors": [
+            "answerSurface is missing"
+          ],
+          "warnings": []
+        }
+      }
+    ]
+  },
   "pageTextInventory": {
     "pageTruthFiles": 99,
     "pageContentTruthEntries": 5862,
@@ -7348,7 +12601,7 @@
     "missingPageTruthRoutes": []
   },
   "internalLinkInventory": {
-    "count": 758,
+    "count": 764,
     "links": [
       {
         "from": "/",
@@ -10781,6 +16034,42 @@
         "to": "/treatments/failed-implant-replacement",
         "source": "machine_manifest_page",
         "pointer": "/sections/12/definition/items/12/href"
+      },
+      {
+        "from": "/treatments/implants",
+        "to": "/treatments/dental-bridges",
+        "source": "machine_manifest_page",
+        "pointer": "/answerSurface/sections/6/links/0/href"
+      },
+      {
+        "from": "/treatments/implants",
+        "to": "/treatments/dentures",
+        "source": "machine_manifest_page",
+        "pointer": "/answerSurface/sections/6/links/1/href"
+      },
+      {
+        "from": "/treatments/implants",
+        "to": "/treatments/implants-consultation",
+        "source": "machine_manifest_page",
+        "pointer": "/answerSurface/sections/15/links/0/href"
+      },
+      {
+        "from": "/treatments/implants",
+        "to": "/treatments/cbct-3d-scanning",
+        "source": "machine_manifest_page",
+        "pointer": "/answerSurface/sections/15/links/1/href"
+      },
+      {
+        "from": "/treatments/implants",
+        "to": "/treatments/implants-aftercare",
+        "source": "machine_manifest_page",
+        "pointer": "/answerSurface/sections/15/links/2/href"
+      },
+      {
+        "from": "/treatments/implants",
+        "to": "/contact",
+        "source": "machine_manifest_page",
+        "pointer": "/answerSurface/sections/17/ctas/0/href"
       },
       {
         "from": "/treatments/implants-bone-grafting",

--- a/scripts/export-website-truth.mjs
+++ b/scripts/export-website-truth.mjs
@@ -203,6 +203,113 @@ const classifyRoute = (route, routeKind, manifestPage) => {
 
 const metadataSourceByFile = new Map();
 
+const treatmentAnswerSurfaceRequiredSectionIds = [
+  "direct_answer",
+  "what_this_treatment_is",
+  "who_it_is_for",
+  "who_it_may_not_be_suitable_for",
+  "benefits",
+  "risks_and_limitations",
+  "alternatives",
+  "process",
+  "timeline",
+  "aftercare",
+  "cost_fee_logic",
+  "local_shoreham_context",
+  "clinician_expertise",
+  "technology_used",
+  "faq",
+  "related_treatments_internal_links",
+  "last_reviewed_clinical_review",
+  "cta",
+];
+
+const defaultSecondaryGeographies = ["Brighton", "Worthing", "Lancing", "Southwick"];
+
+const flattenText = (value) => {
+  if (typeof value === "string") return value;
+  if (Array.isArray(value)) return value.map(flattenText).join(" ");
+  if (value && typeof value === "object") return Object.values(value).map(flattenText).join(" ");
+  return "";
+};
+
+const countNeedle = (haystack, needle) => {
+  const escaped = needle.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return (haystack.match(new RegExp(`\\b${escaped}\\b`, "gi")) ?? []).length;
+};
+
+const validateAnswerSurface = (answerSurface) => {
+  if (!answerSurface || typeof answerSurface !== "object") {
+    return {
+      frameworkPresent: false,
+      valid: false,
+      status: null,
+      exampleSeed: false,
+      presentSectionIds: [],
+      missingSectionIds: [...treatmentAnswerSurfaceRequiredSectionIds],
+      secondaryGeographyMentions: {},
+      secondaryGeographyStuffing: false,
+      errors: ["answerSurface is missing"],
+      warnings: [],
+    };
+  }
+
+  const errors = [];
+  const warnings = [];
+  const sections = Array.isArray(answerSurface.sections) ? answerSurface.sections : [];
+  const sectionIds = sections.map((section) => section?.id).filter(Boolean);
+  const presentSectionIds = treatmentAnswerSurfaceRequiredSectionIds.filter((sectionId) => sectionIds.includes(sectionId));
+  const missingSectionIds = treatmentAnswerSurfaceRequiredSectionIds.filter((sectionId) => !sectionIds.includes(sectionId));
+  const duplicateSectionIds = sectionIds.filter((sectionId, index) => sectionIds.indexOf(sectionId) !== index);
+  const unknownSectionIds = sectionIds.filter((sectionId) => !treatmentAnswerSurfaceRequiredSectionIds.includes(sectionId));
+  const emptySectionIds = sections
+    .filter((section) => section?.id && treatmentAnswerSurfaceRequiredSectionIds.includes(section.id))
+    .filter((section) => {
+      const hasContent = Boolean(
+        section.heading && (
+          section.body ||
+          section.items?.length ||
+          section.faqs?.length ||
+          section.links?.length ||
+          section.ctas?.length ||
+          section.review
+        ),
+      );
+      return !hasContent;
+    })
+    .map((section) => section.id);
+
+  if (answerSurface.version !== "TREATMENT_ANSWER_SURFACE_V1") errors.push("answerSurface.version must be TREATMENT_ANSWER_SURFACE_V1");
+  if (answerSurface.primaryGeography !== "Shoreham-by-Sea") errors.push("answerSurface.primaryGeography must remain Shoreham-by-Sea");
+  if (missingSectionIds.length > 0) errors.push(`Missing answerSurface sections: ${missingSectionIds.join(", ")}`);
+  if (duplicateSectionIds.length > 0) errors.push(`Duplicate answerSurface sections: ${Array.from(new Set(duplicateSectionIds)).join(", ")}`);
+  if (unknownSectionIds.length > 0) errors.push(`Unknown answerSurface sections: ${Array.from(new Set(unknownSectionIds)).join(", ")}`);
+  if (emptySectionIds.length > 0) errors.push(`Empty answerSurface sections: ${emptySectionIds.join(", ")}`);
+
+  const geographies = answerSurface.secondaryGeographies?.length ? answerSurface.secondaryGeographies : defaultSecondaryGeographies;
+  const allText = flattenText(sections);
+  const secondaryGeographyMentions = Object.fromEntries(geographies.map((geography) => [geography, countNeedle(allText, geography)]));
+  const totalSecondaryMentions = Object.values(secondaryGeographyMentions).reduce((total, count) => total + count, 0);
+  const secondaryGeographyStuffing = totalSecondaryMentions > 4 || Object.values(secondaryGeographyMentions).some((count) => count > 2);
+  if (secondaryGeographyStuffing) warnings.push("Secondary geography mentions exceed answer-surface stuffing threshold");
+
+  return {
+    frameworkPresent: true,
+    valid: errors.length === 0,
+    status: answerSurface.status ?? null,
+    exampleSeed: Boolean(answerSurface.exampleSeed),
+    presentSectionIds,
+    missingSectionIds,
+    duplicateSectionIds: Array.from(new Set(duplicateSectionIds)),
+    unknownSectionIds: Array.from(new Set(unknownSectionIds)),
+    emptySectionIds,
+    secondaryGeographyMentions,
+    secondaryGeographyStuffing,
+    errors,
+    warnings,
+  };
+};
+
 const main = async () => {
   const packageJson = await readJsonOptional("package.json", {});
   const liveRoutes = await readJsonOptional("content-scope/live-pages.json", []);
@@ -359,18 +466,63 @@ const main = async () => {
     weakness: robotsExists && robotsExplicitDisallows.length === 3 ? null : "Production robots does not explicitly disallow all internal/private launch-excluded paths.",
   };
 
+  const treatmentRoutesForAnswerSurface = manifestRoutes
+    .filter(({ route }) => route.startsWith("/treatments/"));
+
+  const answerSurfaceEntries = treatmentRoutesForAnswerSurface.map(({ pageId, page, route }) => ({
+    route,
+    pageId,
+    label: page.label ?? null,
+    validation: validateAnswerSurface(page.answerSurface),
+  }));
+
+  const answerSurfaceCoverage = {
+    framework: "TREATMENT_ANSWER_SURFACE_V1",
+    requiredSectionIds: treatmentAnswerSurfaceRequiredSectionIds,
+    treatmentRouteCount: treatmentRoutesForAnswerSurface.length,
+    frameworkPresentCount: answerSurfaceEntries.filter((entry) => entry.validation.frameworkPresent).length,
+    completeCount: answerSurfaceEntries.filter((entry) => entry.validation.valid).length,
+    exampleSeedRoutes: answerSurfaceEntries.filter((entry) => entry.validation.exampleSeed).map((entry) => entry.route),
+    routesMissingAnswerSurface: answerSurfaceEntries
+      .filter((entry) => !entry.validation.frameworkPresent)
+      .map((entry) => entry.route),
+    routesWithMissingSections: answerSurfaceEntries
+      .filter((entry) => entry.validation.frameworkPresent && entry.validation.missingSectionIds.length > 0)
+      .map((entry) => ({ route: entry.route, missingSectionIds: entry.validation.missingSectionIds })),
+    routesWithSecondaryGeographyStuffing: answerSurfaceEntries
+      .filter((entry) => entry.validation.secondaryGeographyStuffing)
+      .map((entry) => ({ route: entry.route, mentions: entry.validation.secondaryGeographyMentions })),
+    entries: answerSurfaceEntries,
+  };
+
   const treatmentManifestInventory = manifestRoutes
     .filter(({ route }) => route === "/treatments" || route.startsWith("/treatments/"))
-    .map(({ pageId, page, route }) => ({
-      route,
-      pageId,
-      label: page.label ?? null,
-      category: page.category ?? null,
-      hero: page.hero ?? null,
-      heroBinding: page.heroBinding ?? null,
-      sectionCount: Array.isArray(page.sections) ? page.sections.length : null,
-      surface: page.surface ?? null,
-    }));
+    .map(({ pageId, page, route }) => {
+      const answerSurfaceValidation = route.startsWith("/treatments/")
+        ? answerSurfaceEntries.find((entry) => entry.route === route)?.validation
+        : null;
+      return {
+        route,
+        pageId,
+        label: page.label ?? null,
+        category: page.category ?? null,
+        hero: page.hero ?? null,
+        heroBinding: page.heroBinding ?? null,
+        sectionCount: Array.isArray(page.sections) ? page.sections.length : null,
+        surface: page.surface ?? null,
+        answerSurface: answerSurfaceValidation
+          ? {
+              frameworkPresent: answerSurfaceValidation.frameworkPresent,
+              valid: answerSurfaceValidation.valid,
+              status: answerSurfaceValidation.status,
+              presentSectionCount: answerSurfaceValidation.presentSectionIds.length,
+              missingSectionIds: answerSurfaceValidation.missingSectionIds,
+              secondaryGeographyMentions: answerSurfaceValidation.secondaryGeographyMentions,
+              secondaryGeographyStuffing: answerSurfaceValidation.secondaryGeographyStuffing,
+            }
+          : null,
+      };
+    });
 
   const pageTextInventory = {
     pageTruthFiles: (await fs.readdir(path.join(rootDir, "page-truth")).catch(() => [])).filter((name) => name.endsWith(".txt")).length,
@@ -451,6 +603,7 @@ const main = async () => {
     sitemapStatus,
     robotsStatus,
     treatmentManifestInventory,
+    answerSurfaceCoverage,
     pageTextInventory,
     internalLinkInventory: {
       count: internalLinks.length,
@@ -499,6 +652,7 @@ const main = async () => {
       "sitemap status",
       "robots status",
       "treatment manifest inventory",
+      "treatment answer-surface coverage and validation",
       "page text/page truth inventory",
       "internal link inventory if discoverable",
       "FAQ block inventory if discoverable",
@@ -530,6 +684,7 @@ const main = async () => {
       sitemapStatus: "object",
       robotsStatus: "object",
       treatmentManifestInventory: "array",
+      answerSurfaceCoverage: "object",
       pageTextInventory: "object",
       launchBlockersDetected: "array",
       readyForLaunch: "boolean; expected false unless a separate launch audit proves otherwise",

--- a/scripts/guard-treatment-answer-surface.mjs
+++ b/scripts/guard-treatment-answer-surface.mjs
@@ -1,0 +1,74 @@
+import fs from "node:fs";
+
+const manifest = JSON.parse(fs.readFileSync("packages/champagne-manifests/data/champagne_machine_manifest_full.json", "utf8"));
+const requiredSectionIds = [
+  "direct_answer",
+  "what_this_treatment_is",
+  "who_it_is_for",
+  "who_it_may_not_be_suitable_for",
+  "benefits",
+  "risks_and_limitations",
+  "alternatives",
+  "process",
+  "timeline",
+  "aftercare",
+  "cost_fee_logic",
+  "local_shoreham_context",
+  "clinician_expertise",
+  "technology_used",
+  "faq",
+  "related_treatments_internal_links",
+  "last_reviewed_clinical_review",
+  "cta",
+];
+const secondaryGeographies = ["Brighton", "Worthing", "Lancing", "Southwick"];
+
+const flattenText = (value) => {
+  if (typeof value === "string") return value;
+  if (Array.isArray(value)) return value.map(flattenText).join(" ");
+  if (value && typeof value === "object") return Object.values(value).map(flattenText).join(" ");
+  return "";
+};
+
+const countNeedle = (haystack, needle) => {
+  const escaped = needle.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return (haystack.match(new RegExp(`\\b${escaped}\\b`, "gi")) ?? []).length;
+};
+
+const validate = (answerSurface) => {
+  const sectionIds = Array.isArray(answerSurface?.sections)
+    ? answerSurface.sections.map((section) => section?.id).filter(Boolean)
+    : [];
+  const missingSectionIds = requiredSectionIds.filter((id) => !sectionIds.includes(id));
+  const allText = flattenText(answerSurface?.sections ?? []);
+  const secondaryGeographyMentions = Object.fromEntries(
+    secondaryGeographies.map((geography) => [geography, countNeedle(allText, geography)]),
+  );
+  const totalSecondaryMentions = Object.values(secondaryGeographyMentions).reduce((total, count) => total + count, 0);
+  const secondaryGeographyStuffing = totalSecondaryMentions > 4 || Object.values(secondaryGeographyMentions).some((count) => count > 2);
+  return {
+    missingSectionIds,
+    secondaryGeographyMentions,
+    secondaryGeographyStuffing,
+    valid: Boolean(answerSurface) && answerSurface.version === "TREATMENT_ANSWER_SURFACE_V1" && answerSurface.primaryGeography === "Shoreham-by-Sea" && missingSectionIds.length === 0,
+  };
+};
+
+const treatmentPages = Object.entries(manifest.pages ?? {})
+  .filter(([, page]) => page?.path?.startsWith("/treatments/"));
+const entries = treatmentPages.map(([pageId, page]) => ({ pageId, route: page.path, validation: validate(page.answerSurface) }));
+const present = entries.filter((entry) => entry.validation.valid);
+const stuffing = entries.filter((entry) => entry.validation.secondaryGeographyStuffing);
+
+if (present.length === 0) {
+  console.error("❌ No treatment answerSurface framework examples were found.");
+  process.exit(1);
+}
+
+if (stuffing.length > 0) {
+  console.error("❌ Secondary geography stuffing detected in treatment answerSurface data.");
+  console.error(JSON.stringify(stuffing.map((entry) => ({ route: entry.route, mentions: entry.validation.secondaryGeographyMentions })), null, 2));
+  process.exit(1);
+}
+
+console.log(`✅ Treatment answer-surface guard passed. complete=${present.length} treatmentRoutes=${entries.length}`);


### PR DESCRIPTION
### Motivation
- Provide a reusable, manifest-driven treatment "answer-surface" framework to hold the canonical set of clinician-facing sections (direct answer, what it is, who for, risks, alternatives, timeline, aftercare, cost logic, local Shoreham context, clinician expertise, technology, FAQ, related links, review metadata, CTA, etc.) without mass-editing pages or touching hero/runtime sacred files. 
- Make answer-surface discoverable to tooling by adding a typed model, validation surface, and truth-export coverage so content work can be tracked and audited incrementally. 
- Seed exactly one safe example (dental implants) marked as framework-only/example seed to demonstrate the pattern while keeping the site route structure and hero behaviour unchanged.

### Description
- Added the answer-surface model and validator at `packages/champagne-manifests/src/answerSurface.ts` including required section ids, validation result shape, and secondary-geography stuffing detection ensuring `primaryGeography` remains `Shoreham-by-Sea`.
- Extended manifest types and helpers to carry and expose `answerSurface` (`ChampagnePageManifest.answerSurface` + `getTreatmentAnswerSurface`) and exported types from manifests index for consumers.
- Seeded one example `answerSurface` in `packages/champagne-manifests/data/champagne_machine_manifest_full.json` for `/treatments/implants` and marked it `frameworkOnly`/`exampleSeed`.
- Added a token-only renderer component `Section_TreatmentAnswerSurface` and registered a `treatment_answer_surface` kind in the sections registry so pages can render answer-surface content when present without changing existing hero or layout code: `packages/champagne-sections/src/Section_TreatmentAnswerSurface.tsx` and registry updates.
- Extended `scripts/export-website-truth.mjs` to validate per-treatment `answerSurface` instances, produce `answerSurfaceCoverage` and include it in the generated report and contract shape, and updated `ops/contracts/WEBSITE_TRUTH_EXPORT_CONTRACT_V1.json` accordingly.
- Added a lightweight guard `scripts/guard-treatment-answer-surface.mjs` and npm script `guard:treatment-answer-surface` to fail when no framework examples exist or when secondary geography stuffing is detected.
- Added focused unit tests `packages/champagne-manifests/src/__tests__/answerSurface.test.ts` (Vitest) covering required-section validation, missing-section detection and secondary-geography stuffing detection.
- Regenerated `reports/WEBSITE_TRUTH_EXPORT_REPORT_V1.json` to include coverage metadata; updated `package.json` scripts and minor index/helpers wiring; no sacred hero files were modified.

### Testing
- `pnpm exec vitest run packages/champagne-manifests/src/__tests__/answerSurface.test.ts` — tests passed (3/3).
- `pnpm run guard:treatment-answer-surface` — guard passed and reported `complete=1 treatmentRoutes=78` (seed present).
- `pnpm run export:website-truth` and `node --check scripts/export-website-truth.mjs` — export ran, wrote `reports/WEBSITE_TRUTH_EXPORT_REPORT_V1.json`, and `node -e 'JSON.parse(...)'` verified JSON parse success.
- `pnpm run guard:seo-launch-safety`, `pnpm run guard:canon`, `pnpm run guard:hero` — guards executed; `guard:seo-launch-safety` returned expected pre-existing warnings (content readiness POLISH/REWRITE), other guards passed.
- `pnpm --filter @champagne/manifests build` and `pnpm --filter @champagne/sections build` — TypeScript builds succeeded after pragmatic widening of some types to accept seed content; `pnpm run build:web` (Next build) completed successfully.

All automated checks listed above completed successfully; the truth export shows framework present only for `/treatments/implants` (example seed) and the repo still reports content readiness blockers (`POLISH: 39`, `REWRITE: 55`), so this is ready for PR review but not a launch-ready claim.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19963a79488332baefa0d244de2663)