### PR TITLE
Add Batch 2 treatment answerSurface data for implant-aftercare and composite-bonding

### DIFF
--- a/packages/champagne-manifests/data/champagne_machine_manifest_full.json
+++ b/packages/champagne-manifests/data/champagne_machine_manifest_full.json
@@ -5516,7 +5516,216 @@
         }
       ],
       "surface": "champagne/surface/treatment",
-      "heroFamily": "treatments.implants"
+      "heroFamily": "treatments.implants",
+      "answerSurface": {
+        "version": "TREATMENT_ANSWER_SURFACE_V1",
+        "status": "ready_for_clinical_review",
+        "primaryGeography": "Shoreham-by-Sea",
+        "secondaryGeographies": [
+          "Brighton",
+          "Worthing",
+          "Lancing",
+          "Southwick"
+        ],
+        "sections": [
+          {
+            "id": "direct_answer",
+            "heading": "Direct answer",
+            "body": "Implant aftercare is the planned support and maintenance that follows implant placement or restoration. It helps patients understand normal healing, review appointments, hygiene steps and risk factors, but it cannot diagnose individual problems remotely or guarantee that an implant will last for life."
+          },
+          {
+            "id": "what_this_treatment_is",
+            "heading": "What this treatment is",
+            "body": "This is follow-up care for dental implants and implant-supported teeth. It may include healing reviews, hygiene advice, bite checks, maintenance planning, and assessment if an implant, gum tissue or restoration feels uncomfortable or changes over time."
+          },
+          {
+            "id": "who_it_is_for",
+            "heading": "Who it is for",
+            "items": [
+              "Patients who have recently had implant surgery and need clear recovery guidance.",
+              "Patients with implant crowns, bridges or implant-retained dentures who need routine maintenance.",
+              "People with implant-related concerns who need a clinical review rather than online diagnosis."
+            ]
+          },
+          {
+            "id": "who_it_may_not_be_suitable_for",
+            "heading": "Who it may not be suitable for",
+            "items": [
+              "Patients with severe swelling, spreading infection, uncontrolled bleeding, trauma or acute pain may need urgent dental or medical advice first.",
+              "People seeking a remote diagnosis or a guaranteed reassurance without examination and appropriate tests.",
+              "Patients whose implants were placed elsewhere may still be reviewed, but records, imaging and a full assessment may be needed before advice is specific."
+            ]
+          },
+          {
+            "id": "benefits",
+            "heading": "Benefits",
+            "items": [
+              "Helps patients understand what is expected during healing and what should be checked.",
+              "Supports plaque control and gum health around implant surfaces.",
+              "Allows risk factors such as smoking, medical history, bite forces and maintenance access to be reviewed in general clinical context.",
+              "Can identify restorative issues such as loosening, wear or discomfort that need assessment."
+            ]
+          },
+          {
+            "id": "risks_and_limitations",
+            "heading": "Risks and limitations",
+            "items": [
+              "Implants need ongoing maintenance; no implant treatment can be promised to last for life.",
+              "Inflammation, infection, bone loss, loosening, fracture, bite overload or gum changes can occur and need clinical assessment.",
+              "Smoking, some medical factors, oral hygiene challenges and missed maintenance may increase risk in general terms.",
+              "Written guidance is not a substitute for diagnosis when symptoms are changing, severe or persistent."
+            ]
+          },
+          {
+            "id": "alternatives",
+            "heading": "Alternatives",
+            "items": [
+              "For a painful or failing implant, options depend on assessment and may include monitoring, hygiene therapy, restorative repair, removal, replacement planning or non-implant alternatives.",
+              "For missing teeth, bridges, removable dentures or leaving a space may be discussed where appropriate.",
+              "For urgent symptoms, an emergency dental appointment may be the safer first step."
+            ],
+            "links": [
+              {
+                "label": "Failed implant replacement",
+                "href": "/treatments/failed-implant-replacement",
+                "relationship": "related"
+              },
+              {
+                "label": "Dental bridges",
+                "href": "/treatments/dental-bridges",
+                "relationship": "alternative"
+              },
+              {
+                "label": "Dentures",
+                "href": "/treatments/dentures",
+                "relationship": "alternative"
+              }
+            ]
+          },
+          {
+            "id": "process",
+            "heading": "Process",
+            "items": [
+              "Review symptoms, healing stage, medical history and any instructions already given.",
+              "Examine the implant area, gum tissues, bite and restoration where clinically indicated.",
+              "Use radiographs, scans or hygiene measurements only where needed for assessment.",
+              "Agree maintenance, hygiene support, review timing or further treatment steps based on findings."
+            ]
+          },
+          {
+            "id": "timeline",
+            "heading": "Timeline",
+            "items": [
+              "Early recovery is usually reviewed according to the treatment plan and healing response.",
+              "Restoration timing varies depending on implant stability, bone/gum healing, grafting and the type of tooth replacement.",
+              "Long-term maintenance is ongoing and usually includes regular dental and hygiene reviews at intervals set after assessment."
+            ]
+          },
+          {
+            "id": "aftercare",
+            "heading": "Aftercare",
+            "items": [
+              "Follow the written instructions given for cleaning, diet, medication and activity after surgery.",
+              "Keep the implant area clean using the tools and technique recommended by the clinical team.",
+              "Attend planned reviews even if the area feels comfortable.",
+              "Seek assessment if swelling, bleeding, pain, looseness, bite changes or discharge are concerning or not settling."
+            ]
+          },
+          {
+            "id": "cost_fee_logic",
+            "heading": "Cost and fee logic",
+            "body": "Fees depend on the type of review, diagnostics, hygiene support, restoration repair, replacement components and whether further treatment is needed. Precise costs should only be confirmed after assessment and an agreed plan."
+          },
+          {
+            "id": "local_shoreham_context",
+            "heading": "Local Shoreham context",
+            "body": "Implant aftercare is provided from the Shoreham-by-Sea practice for local patients who need review, maintenance planning or reassurance after implant treatment. Patients from nearby areas can use the same assessment-led pathway without changing the clinical decision process."
+          },
+          {
+            "id": "clinician_expertise",
+            "heading": "Clinician expertise",
+            "body": "Implant aftercare is handled by the dental team with assessment of gum health, bite, restorations, hygiene access and relevant risk factors. Advice is kept specific to the findings recorded at the appointment rather than offered as remote diagnosis."
+          },
+          {
+            "id": "technology_used",
+            "heading": "Technology used",
+            "items": [
+              "Clinical examination and periodontal or implant maintenance measurements where appropriate.",
+              "Dental radiographs or CBCT referral/use only when indicated for implant assessment.",
+              "Digital records, photographs or scans may be used to monitor restorations, bite and soft-tissue changes."
+            ]
+          },
+          {
+            "id": "faq",
+            "heading": "FAQ",
+            "faqs": [
+              {
+                "question": "Do dental implants last for life?",
+                "answer": "No lifelong guarantee should be assumed. Implants can last for many years for some patients, but they need maintenance and can develop biological or mechanical complications."
+              },
+              {
+                "question": "Can you tell me online if my implant is failing?",
+                "answer": "No. Symptoms such as pain, swelling, looseness or bleeding need clinical assessment before a diagnosis or treatment plan can be given."
+              },
+              {
+                "question": "How often should implants be checked?",
+                "answer": "Review intervals depend on your risk factors, oral hygiene, gum health, restoration design and clinical findings. The dental team will advise after assessment."
+              },
+              {
+                "question": "Does smoking or medical history matter?",
+                "answer": "These factors can affect healing and long-term risk in general terms, so they should be discussed honestly during implant reviews."
+              }
+            ]
+          },
+          {
+            "id": "related_treatments_internal_links",
+            "heading": "Related treatments and internal links",
+            "links": [
+              {
+                "label": "Dental implants",
+                "href": "/treatments/implants",
+                "relationship": "related"
+              },
+              {
+                "label": "Implant consultation",
+                "href": "/treatments/implant-consultation",
+                "relationship": "next_step"
+              },
+              {
+                "label": "Failed implant replacement",
+                "href": "/treatments/failed-implant-replacement",
+                "relationship": "related"
+              },
+              {
+                "label": "Periodontal gum care",
+                "href": "/treatments/periodontal-gum-care",
+                "relationship": "maintenance"
+              }
+            ]
+          },
+          {
+            "id": "last_reviewed_clinical_review",
+            "heading": "Last reviewed and clinical review metadata",
+            "review": {
+              "lastReviewed": "2026-05-29",
+              "clinicalReviewer": "Clinical review required before publication",
+              "nextReviewDue": "2026-11-29"
+            }
+          },
+          {
+            "id": "cta",
+            "heading": "CTA metadata",
+            "body": "Use the existing treatment CTA surfaces for appointment requests. Patients with urgent or worsening symptoms should request an appropriate clinical assessment rather than relying on general aftercare information.",
+            "ctas": [
+              {
+                "label": "Request an implant aftercare review",
+                "href": "/contact",
+                "relationship": "next_step"
+              }
+            ]
+          }
+        ]
+      }
     },
     "surgically_guided_implants": {
       "id": "surgically_guided_implants",
@@ -5906,7 +6115,228 @@
           ]
         }
       ],
-      "surface": "champagne/surface/treatment"
+      "surface": "champagne/surface/treatment",
+      "answerSurface": {
+        "version": "TREATMENT_ANSWER_SURFACE_V1",
+        "status": "ready_for_clinical_review",
+        "primaryGeography": "Shoreham-by-Sea",
+        "secondaryGeographies": [
+          "Brighton",
+          "Worthing",
+          "Lancing",
+          "Southwick"
+        ],
+        "sections": [
+          {
+            "id": "direct_answer",
+            "heading": "Direct answer",
+            "body": "Composite bonding is a conservative cosmetic dental treatment that adds tooth-coloured resin to improve shape, edges, small gaps or minor chips. Suitability depends on assessment of bite, enamel, gum health, habits and expectations; it is not suitable for everyone and does not guarantee a perfect smile."
+          },
+          {
+            "id": "what_this_treatment_is",
+            "heading": "What this treatment is",
+            "body": "Bonding uses layered composite resin placed directly onto teeth and polished to blend with the surrounding smile. It often involves little or no drilling, but the result depends on tooth condition, shade, bite forces and maintenance."
+          },
+          {
+            "id": "who_it_is_for",
+            "heading": "Who it is for",
+            "items": [
+              "Patients wanting measured refinement of tooth shape, small spaces, worn edges or minor chips.",
+              "People with stable gum health and enough suitable enamel for bonding after assessment.",
+              "Patients who understand that composite can stain, chip or wear and may need polishing, repair or replacement over time."
+            ]
+          },
+          {
+            "id": "who_it_may_not_be_suitable_for",
+            "heading": "Who it may not be suitable for",
+            "items": [
+              "Patients with active gum disease, untreated decay or unstable oral health until these are managed.",
+              "People with heavy bite forces, clenching, grinding, edge-to-edge bites or habits that make bonding less predictable unless protection or alternatives are planned.",
+              "Patients seeking major colour, position or shape changes that may be better served by whitening, orthodontics, veneers, crowns or onlays."
+            ]
+          },
+          {
+            "id": "benefits",
+            "heading": "Benefits",
+            "items": [
+              "Can refine shape and repair small defects with a tooth-preserving approach.",
+              "May be completed more quickly than laboratory-made restorations in suitable cases.",
+              "Can be repaired or polished when small chips, staining or surface roughness occur.",
+              "Can be combined with whitening or aligner planning when that creates a safer, more conservative result."
+            ]
+          },
+          {
+            "id": "risks_and_limitations",
+            "heading": "Risks and limitations",
+            "items": [
+              "Composite is not as stain-resistant or wear-resistant as porcelain and may need maintenance.",
+              "Chipping, debonding, staining, roughness or marginal changes can occur, especially with high bite forces or habits.",
+              "Bonding cannot reliably correct every crowding, bite, colour or tooth-structure problem.",
+              "Final shade and shape depend on assessment, material limits and realistic expectations rather than a guaranteed perfect result."
+            ]
+          },
+          {
+            "id": "alternatives",
+            "heading": "Alternatives",
+            "items": [
+              "Whitening may be recommended first when colour is the main concern.",
+              "Clear aligners or orthodontics may be safer when tooth position or bite is the main issue.",
+              "Porcelain veneers or 3D printed veneers may be considered for larger aesthetic changes where appropriate.",
+              "Crowns or onlays may be needed for weakened, heavily restored or fractured teeth rather than additive bonding alone."
+            ],
+            "links": [
+              {
+                "label": "Teeth whitening",
+                "href": "/treatments/teeth-whitening",
+                "relationship": "alternative"
+              },
+              {
+                "label": "Clear aligners",
+                "href": "/treatments/clear-aligners",
+                "relationship": "alternative"
+              },
+              {
+                "label": "Veneers",
+                "href": "/treatments/veneers",
+                "relationship": "alternative"
+              },
+              {
+                "label": "Dental crowns",
+                "href": "/treatments/dental-crowns",
+                "relationship": "alternative"
+              }
+            ]
+          },
+          {
+            "id": "process",
+            "heading": "Process",
+            "items": [
+              "Assess teeth, gums, bite, enamel, shade, habits and the changes requested.",
+              "Discuss whether whitening, orthodontics or stabilisation should happen before bonding.",
+              "Use photographs, scans, mock-ups or shade planning where helpful.",
+              "Place, shape and polish composite in controlled layers, then review maintenance advice."
+            ]
+          },
+          {
+            "id": "timeline",
+            "heading": "Timeline",
+            "items": [
+              "Assessment and planning happen before treatment is agreed.",
+              "Whitening, gum care or aligner treatment may add time if recommended first.",
+              "Simple bonding may be completed in one appointment or staged across appointments depending on tooth number and complexity.",
+              "Review, polishing or repair intervals depend on wear, staining and clinical findings."
+            ]
+          },
+          {
+            "id": "aftercare",
+            "heading": "Aftercare",
+            "items": [
+              "Maintain careful brushing, interdental cleaning and regular hygiene visits.",
+              "Limit habits that can chip or stain composite, such as biting hard objects or frequent staining drinks without cleaning routines.",
+              "Use a night guard if recommended for clenching or grinding.",
+              "Return for polishing or assessment if edges feel rough, stained, loose or chipped."
+            ]
+          },
+          {
+            "id": "cost_fee_logic",
+            "heading": "Cost and fee logic",
+            "body": "Fees depend on the number of teeth, complexity, planning records, mock-ups, whether whitening or aligners are needed first, and the level of finishing or review required. Precise pricing should be confirmed only after assessment and a written plan."
+          },
+          {
+            "id": "local_shoreham_context",
+            "heading": "Local Shoreham context",
+            "body": "Composite bonding is planned at the Shoreham-by-Sea practice with assessment-led advice for local patients considering conservative cosmetic dentistry. Nearby patients may also attend, but the primary pathway remains clinical suitability rather than location-based promotion."
+          },
+          {
+            "id": "clinician_expertise",
+            "heading": "Clinician expertise",
+            "body": "The clinical team assesses enamel, bite, gum health, shade, smile goals and maintenance risk before recommending bonding. Where another option is safer or more predictable, that should be explained before treatment is chosen."
+          },
+          {
+            "id": "technology_used",
+            "heading": "Technology used",
+            "items": [
+              "Clinical photographs and shade assessment to plan blending and finishing.",
+              "Digital scans or mock-ups where they help preview proposed changes.",
+              "Layered composite materials, curing lights and polishing systems selected according to the case."
+            ]
+          },
+          {
+            "id": "faq",
+            "heading": "FAQ",
+            "faqs": [
+              {
+                "question": "Is composite bonding suitable for everyone?",
+                "answer": "No. Suitability depends on bite, enamel, gum health, habits, tooth condition and expectations, all of which require assessment."
+              },
+              {
+                "question": "Will bonding give me a perfect smile?",
+                "answer": "No treatment should be promised as perfect. Bonding can improve selected concerns, but material limits, tooth position, bite and maintenance affect the result."
+              },
+              {
+                "question": "Should I whiten before composite bonding?",
+                "answer": "Sometimes. If you want a lighter shade, whitening may be recommended before bonding because composite does not whiten like natural enamel."
+              },
+              {
+                "question": "How long does composite bonding last?",
+                "answer": "Longevity varies. Composite can stain, chip or wear and may need polishing, repair or replacement depending on habits, bite and maintenance."
+              }
+            ]
+          },
+          {
+            "id": "related_treatments_internal_links",
+            "heading": "Related treatments and internal links",
+            "links": [
+              {
+                "label": "Injection moulded composite",
+                "href": "/treatments/injection-moulded-composite",
+                "relationship": "related"
+              },
+              {
+                "label": "Teeth whitening",
+                "href": "/treatments/teeth-whitening",
+                "relationship": "alternative"
+              },
+              {
+                "label": "Clear aligners",
+                "href": "/treatments/clear-aligners",
+                "relationship": "alternative"
+              },
+              {
+                "label": "Veneers",
+                "href": "/treatments/veneers",
+                "relationship": "alternative"
+              },
+              {
+                "label": "Tooth wear and broken teeth",
+                "href": "/treatments/tooth-wear-broken-teeth",
+                "relationship": "related"
+              }
+            ]
+          },
+          {
+            "id": "last_reviewed_clinical_review",
+            "heading": "Last reviewed and clinical review metadata",
+            "review": {
+              "lastReviewed": "2026-05-29",
+              "clinicalReviewer": "Clinical review required before publication",
+              "nextReviewDue": "2026-11-29"
+            }
+          },
+          {
+            "id": "cta",
+            "heading": "CTA metadata",
+            "body": "Use the existing treatment CTA surfaces for appointment requests. Treatment suitability, alternatives and fees should be confirmed after assessment before bonding is planned.",
+            "ctas": [
+              {
+                "label": "Request a composite bonding assessment",
+                "href": "/contact",
+                "relationship": "next_step"
+              }
+            ]
+          }
+        ]
+      }
     },
     "injection_moulded_composite": {
       "id": "injection_moulded_composite",

--- a/reports/WEBSITE_TRUTH_EXPORT_REPORT_V1.json
+++ b/reports/WEBSITE_TRUTH_EXPORT_REPORT_V1.json
@@ -1,6 +1,6 @@
 {
   "version": "WEBSITE_TRUTH_EXPORT_REPORT_V1",
-  "generatedAt": "2026-05-29T14:28:01.074Z",
+  "generatedAt": "2026-05-29T15:00:58.134Z",
   "contract": {
     "file": "ops/contracts/WEBSITE_TRUTH_EXPORT_CONTRACT_V1.json",
     "version": "CHAMPAGNE_WEBSITE_TRUTH_EXPORT_CONTRACT_V1"
@@ -6940,31 +6940,17 @@
       "sectionCount": 11,
       "surface": "champagne/surface/treatment",
       "answerSurface": {
-        "frameworkPresent": false,
-        "valid": false,
-        "status": null,
-        "presentSectionCount": 0,
-        "missingSectionIds": [
-          "direct_answer",
-          "what_this_treatment_is",
-          "who_it_is_for",
-          "who_it_may_not_be_suitable_for",
-          "benefits",
-          "risks_and_limitations",
-          "alternatives",
-          "process",
-          "timeline",
-          "aftercare",
-          "cost_fee_logic",
-          "local_shoreham_context",
-          "clinician_expertise",
-          "technology_used",
-          "faq",
-          "related_treatments_internal_links",
-          "last_reviewed_clinical_review",
-          "cta"
-        ],
-        "secondaryGeographyMentions": {},
+        "frameworkPresent": true,
+        "valid": true,
+        "status": "ready_for_clinical_review",
+        "presentSectionCount": 18,
+        "missingSectionIds": [],
+        "secondaryGeographyMentions": {
+          "Brighton": 0,
+          "Worthing": 0,
+          "Lancing": 0,
+          "Southwick": 0
+        },
         "secondaryGeographyStuffing": false
       }
     },
@@ -7104,31 +7090,17 @@
       "sectionCount": 12,
       "surface": "champagne/surface/treatment",
       "answerSurface": {
-        "frameworkPresent": false,
-        "valid": false,
-        "status": null,
-        "presentSectionCount": 0,
-        "missingSectionIds": [
-          "direct_answer",
-          "what_this_treatment_is",
-          "who_it_is_for",
-          "who_it_may_not_be_suitable_for",
-          "benefits",
-          "risks_and_limitations",
-          "alternatives",
-          "process",
-          "timeline",
-          "aftercare",
-          "cost_fee_logic",
-          "local_shoreham_context",
-          "clinician_expertise",
-          "technology_used",
-          "faq",
-          "related_treatments_internal_links",
-          "last_reviewed_clinical_review",
-          "cta"
-        ],
-        "secondaryGeographyMentions": {},
+        "frameworkPresent": true,
+        "valid": true,
+        "status": "ready_for_clinical_review",
+        "presentSectionCount": 18,
+        "missingSectionIds": [],
+        "secondaryGeographyMentions": {
+          "Brighton": 0,
+          "Worthing": 0,
+          "Lancing": 0,
+          "Southwick": 0
+        },
         "secondaryGeographyStuffing": false
       }
     },
@@ -9493,8 +9465,8 @@
       "cta"
     ],
     "treatmentRouteCount": 78,
-    "frameworkPresentCount": 4,
-    "completeCount": 4,
+    "frameworkPresentCount": 6,
+    "completeCount": 6,
     "exampleSeedRoutes": [
       "/treatments/implants"
     ],
@@ -9511,11 +9483,9 @@
       "/treatments/teeth-in-a-day",
       "/treatments/sedation-for-implants",
       "/treatments/failed-implant-replacement",
-      "/treatments/implant-aftercare",
       "/treatments/surgically-guided-implants",
       "/treatments/3d-implant-restorations",
       "/treatments/3d-printed-veneers",
-      "/treatments/composite-bonding",
       "/treatments/injection-moulded-composite",
       "/treatments/dental-bridges",
       "/treatments/dental-crowns",
@@ -10214,12 +10184,11 @@
         "pageId": "implants_aftercare",
         "label": "Implant aftercare & recovery in Shoreham-by-Sea",
         "validation": {
-          "frameworkPresent": false,
-          "valid": false,
-          "status": null,
+          "frameworkPresent": true,
+          "valid": true,
+          "status": "ready_for_clinical_review",
           "exampleSeed": false,
-          "presentSectionIds": [],
-          "missingSectionIds": [
+          "presentSectionIds": [
             "direct_answer",
             "what_this_treatment_is",
             "who_it_is_for",
@@ -10239,11 +10208,18 @@
             "last_reviewed_clinical_review",
             "cta"
           ],
-          "secondaryGeographyMentions": {},
+          "missingSectionIds": [],
+          "duplicateSectionIds": [],
+          "unknownSectionIds": [],
+          "emptySectionIds": [],
+          "secondaryGeographyMentions": {
+            "Brighton": 0,
+            "Worthing": 0,
+            "Lancing": 0,
+            "Southwick": 0
+          },
           "secondaryGeographyStuffing": false,
-          "errors": [
-            "answerSurface is missing"
-          ],
+          "errors": [],
           "warnings": []
         }
       },
@@ -10366,12 +10342,11 @@
         "pageId": "composite_bonding",
         "label": "Composite bonding",
         "validation": {
-          "frameworkPresent": false,
-          "valid": false,
-          "status": null,
+          "frameworkPresent": true,
+          "valid": true,
+          "status": "ready_for_clinical_review",
           "exampleSeed": false,
-          "presentSectionIds": [],
-          "missingSectionIds": [
+          "presentSectionIds": [
             "direct_answer",
             "what_this_treatment_is",
             "who_it_is_for",
@@ -10391,11 +10366,18 @@
             "last_reviewed_clinical_review",
             "cta"
           ],
-          "secondaryGeographyMentions": {},
+          "missingSectionIds": [],
+          "duplicateSectionIds": [],
+          "unknownSectionIds": [],
+          "emptySectionIds": [],
+          "secondaryGeographyMentions": {
+            "Brighton": 0,
+            "Worthing": 0,
+            "Lancing": 0,
+            "Southwick": 0
+          },
           "secondaryGeographyStuffing": false,
-          "errors": [
-            "answerSurface is missing"
-          ],
+          "errors": [],
           "warnings": []
         }
       },
@@ -12574,7 +12556,7 @@
     "missingPageTruthRoutes": []
   },
   "internalLinkInventory": {
-    "count": 787,
+    "count": 805,
     "links": [
       {
         "from": "/",
@@ -14923,6 +14905,66 @@
         "pointer": "/sections/11/ctas/3/href"
       },
       {
+        "from": "/treatments/composite-bonding",
+        "to": "/treatments/teeth-whitening",
+        "source": "machine_manifest_page",
+        "pointer": "/answerSurface/sections/6/links/0/href"
+      },
+      {
+        "from": "/treatments/composite-bonding",
+        "to": "/treatments/clear-aligners",
+        "source": "machine_manifest_page",
+        "pointer": "/answerSurface/sections/6/links/1/href"
+      },
+      {
+        "from": "/treatments/composite-bonding",
+        "to": "/treatments/veneers",
+        "source": "machine_manifest_page",
+        "pointer": "/answerSurface/sections/6/links/2/href"
+      },
+      {
+        "from": "/treatments/composite-bonding",
+        "to": "/treatments/dental-crowns",
+        "source": "machine_manifest_page",
+        "pointer": "/answerSurface/sections/6/links/3/href"
+      },
+      {
+        "from": "/treatments/composite-bonding",
+        "to": "/treatments/injection-moulded-composite",
+        "source": "machine_manifest_page",
+        "pointer": "/answerSurface/sections/15/links/0/href"
+      },
+      {
+        "from": "/treatments/composite-bonding",
+        "to": "/treatments/teeth-whitening",
+        "source": "machine_manifest_page",
+        "pointer": "/answerSurface/sections/15/links/1/href"
+      },
+      {
+        "from": "/treatments/composite-bonding",
+        "to": "/treatments/clear-aligners",
+        "source": "machine_manifest_page",
+        "pointer": "/answerSurface/sections/15/links/2/href"
+      },
+      {
+        "from": "/treatments/composite-bonding",
+        "to": "/treatments/veneers",
+        "source": "machine_manifest_page",
+        "pointer": "/answerSurface/sections/15/links/3/href"
+      },
+      {
+        "from": "/treatments/composite-bonding",
+        "to": "/treatments/tooth-wear-broken-teeth",
+        "source": "machine_manifest_page",
+        "pointer": "/answerSurface/sections/15/links/4/href"
+      },
+      {
+        "from": "/treatments/composite-bonding",
+        "to": "/contact",
+        "source": "machine_manifest_page",
+        "pointer": "/answerSurface/sections/17/ctas/0/href"
+      },
+      {
         "from": "/treatments/cosmetic-dentistry",
         "to": "/treatments/cosmetic-dentistry",
         "source": "machine_manifest_page",
@@ -15761,6 +15803,54 @@
         "to": "/treatments/implant-retained-dentures",
         "source": "machine_manifest_page",
         "pointer": "/sections/10/ctas/2/href"
+      },
+      {
+        "from": "/treatments/implant-aftercare",
+        "to": "/treatments/failed-implant-replacement",
+        "source": "machine_manifest_page",
+        "pointer": "/answerSurface/sections/6/links/0/href"
+      },
+      {
+        "from": "/treatments/implant-aftercare",
+        "to": "/treatments/dental-bridges",
+        "source": "machine_manifest_page",
+        "pointer": "/answerSurface/sections/6/links/1/href"
+      },
+      {
+        "from": "/treatments/implant-aftercare",
+        "to": "/treatments/dentures",
+        "source": "machine_manifest_page",
+        "pointer": "/answerSurface/sections/6/links/2/href"
+      },
+      {
+        "from": "/treatments/implant-aftercare",
+        "to": "/treatments/implants",
+        "source": "machine_manifest_page",
+        "pointer": "/answerSurface/sections/15/links/0/href"
+      },
+      {
+        "from": "/treatments/implant-aftercare",
+        "to": "/treatments/implant-consultation",
+        "source": "machine_manifest_page",
+        "pointer": "/answerSurface/sections/15/links/1/href"
+      },
+      {
+        "from": "/treatments/implant-aftercare",
+        "to": "/treatments/failed-implant-replacement",
+        "source": "machine_manifest_page",
+        "pointer": "/answerSurface/sections/15/links/2/href"
+      },
+      {
+        "from": "/treatments/implant-aftercare",
+        "to": "/treatments/periodontal-gum-care",
+        "source": "machine_manifest_page",
+        "pointer": "/answerSurface/sections/15/links/3/href"
+      },
+      {
+        "from": "/treatments/implant-aftercare",
+        "to": "/contact",
+        "source": "machine_manifest_page",
+        "pointer": "/answerSurface/sections/17/ctas/0/href"
       },
       {
         "from": "/treatments/implant-consultation",


### PR DESCRIPTION
### Motivation
- Bring two Batch 2 treatment detail routes into the canonical answer-surface framework so the site export has structured clinical-safety metadata for `/treatments/implant-aftercare` and `/treatments/composite-bonding`.
- Improve answer-surface coverage (clinical guidance, risks, alternatives, CTA metadata) while preserving Shoreham-by-Sea as the primary geography and avoiding hero or visual changes.

### Description
- Added full `answerSurface` objects (all 18 required section IDs) for the canonical manifest pages `implants_aftercare` and `composite_bonding` in `packages/champagne-manifests/data/champagne_machine_manifest_full.json` with assessment-first language, safe risk/limitations, alternatives, clinician expertise, last-reviewed metadata, and CTA metadata.
- Regenerated the website truth export so `reports/WEBSITE_TRUTH_EXPORT_REPORT_V1.json` reflects the new coverage and internal link inventory derived from the new answer-surface content.
- Files changed: `packages/champagne-manifests/data/champagne_machine_manifest_full.json`, `reports/WEBSITE_TRUTH_EXPORT_REPORT_V1.json` (and incidental report/ops contract diffs produced by the export script but reverted where appropriate during the workflow).
- Exact canonical routes updated: `/treatments/implant-aftercare` → manifest `pageId: implants_aftercare` (no alias/slug change) and `/treatments/composite-bonding` → manifest `pageId: composite_bonding` (no alias/slug change).

### Testing
- Ran unit tests and guards: `pnpm exec vitest run packages/champagne-manifests/src/__tests__/answerSurface.test.ts` (passed), `pnpm run guard:treatment-answer-surface` (passed), `pnpm run guard:seo-launch-safety` (completed with expected warnings about unrelated layout gaps), `pnpm run guard:canon` (passed), and `pnpm run guard:hero` (passed).
- Export and validation: `pnpm run export:website-truth` produced updated `reports/WEBSITE_TRUTH_EXPORT_REPORT_V1.json`, `node --check scripts/export-website-truth.mjs` succeeded, and JSON parse validation of the report succeeded.
- Builds and verification: `pnpm --filter @champagne/manifests build`, `pnpm --filter @champagne/sections build`, `pnpm run build:web`, and `npm run verify` were executed and completed (no failing guards or errors related to these changes).
- Answer-surface coverage: `completeCount` increased from `4` to `6` and `frameworkPresentCount` increased from `4` to `6` after the change; both `/treatments/implant-aftercare` and `/treatments/composite-bonding` now validate with all required sections and no secondary-geography stuffing.
- Remaining automated blockers: `readyForLaunch` remains `false` (intentional; export is an evidence layer), `readyForPrReview` is `true`, and site-level content-readiness still reports `POLISH`/`REWRITE` items unrelated to these two answerSurface additions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19a9620ffc83329fcaa864c80bd482)