### PR TITLE
SEC-008B: Fix Trivy action version tag

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run Trivy (filesystem)
-        uses: aquasecurity/trivy-action@0.31.0
+        uses: aquasecurity/trivy-action@v0.31.0
         with:
           scan-type: fs
           scan-ref: .


### PR DESCRIPTION
Hotfix for SEC-008 Trivy workflow. Corrects aquasecurity/trivy-action tag from 0.31.0 to v0.31.0. No runtime changes. No security readiness claims.