### PR TITLE
Add SEO local identity, team registry and JSON-LD schema graph foundation

### DIFF
--- a/apps/web/app/(champagne)/about/page.tsx
+++ b/apps/web/app/(champagne)/about/page.tsx
@@ -1,5 +1,52 @@
+import type { Metadata } from "next";
+import {
+  buildWebPageNode,
+  getCanonicalOrigin,
+  getPageManifest,
+} from "@champagne/manifests";
+
 import ChampagnePageBuilder from "../_builder/ChampagnePageBuilder";
 
+const PAGE_PATH = "/about";
+const manifest = getPageManifest(PAGE_PATH) as
+  | { label?: string; description?: string; intro?: string }
+  | undefined;
+const title = manifest?.label ?? "About St Mary's House Dental Care";
+const description =
+  manifest?.description ?? manifest?.intro ?? "Learn about St Mary's House Dental Care in Shoreham-by-Sea.";
+
+export const metadata: Metadata = {
+  title,
+  description,
+  alternates: {
+    canonical: PAGE_PATH,
+  },
+  openGraph: {
+    title,
+    description,
+    url: PAGE_PATH,
+  },
+  twitter: {
+    card: "summary_large_image",
+    title,
+    description,
+  },
+};
+
 export default function Page() {
-  return <ChampagnePageBuilder slug="/about" />;
+  const pageJsonLd = {
+    "@context": "https://schema.org",
+    ...buildWebPageNode(PAGE_PATH, title, description),
+    url: `${getCanonicalOrigin()}${PAGE_PATH}`,
+  };
+
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(pageJsonLd) }}
+      />
+      <ChampagnePageBuilder slug={PAGE_PATH} />
+    </>
+  );
 }

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -7,12 +7,25 @@ import { Header } from "./components/layout/Header";
 import { HeroMount } from "./_components/HeroMount";
 import { isBrandHeroEnabled } from "./featureFlags";
 import { ConciergeLayer } from "./components/concierge/ConciergeLayer";
-import { getPageManifest } from "@champagne/manifests";
+import {
+  buildSiteSchemaGraph,
+  getDefaultSeoDescription,
+  getPageManifest,
+  getPracticeName,
+} from "@champagne/manifests";
 import type { HeroMode } from "@champagne/hero";
 
+type PageSeoManifest = {
+  label?: string;
+  title?: string;
+  description?: string;
+  intro?: string;
+  category?: string;
+};
+
 const PRODUCTION_CANONICAL_ORIGIN = "https://www.smhdental.co.uk";
-const PRACTICE_NAME = "St Mary's House Dental Care";
-const DEFAULT_DESCRIPTION = "Private dental care in Shoreham-by-Sea, with calm planning and clear patient guidance.";
+const PRACTICE_NAME = getPracticeName();
+const DEFAULT_DESCRIPTION = getDefaultSeoDescription();
 
 function isProductionIndexable() {
   return process.env.VERCEL_ENV === "production";
@@ -53,26 +66,10 @@ export default async function RootLayout({ children }: { children: ReactNode }) 
   const isPublicPage = !requestUrl.startsWith("/champagne/");
   const isHeroEnabled = isBrandHeroEnabled();
   const pathname = (requestUrl.split("?")[0] || "/") || "/";
-  const manifest = getPageManifest(pathname);
-  const siteUrl = PRODUCTION_CANONICAL_ORIGIN;
-
-  const dentistJsonLd = {
-    "@context": "https://schema.org",
-    "@type": ["Dentist", "LocalBusiness"],
-    "@id": `${siteUrl}/#dentist`,
-    name: PRACTICE_NAME,
-    url: siteUrl,
-    areaServed: "Shoreham-by-Sea",
-  };
-
-  const websiteJsonLd = {
-    "@context": "https://schema.org",
-    "@type": "WebSite",
-    "@id": `${siteUrl}/#website`,
-    name: PRACTICE_NAME,
-    url: siteUrl,
-    description: DEFAULT_DESCRIPTION,
-  };
+  const manifest = getPageManifest(pathname) as PageSeoManifest | undefined;
+  const pageTitle = manifest?.label ?? manifest?.title ?? PRACTICE_NAME;
+  const pageDescription = manifest?.description ?? manifest?.intro ?? DEFAULT_DESCRIPTION;
+  const siteSchemaGraph = buildSiteSchemaGraph(pathname, pageTitle, pageDescription);
 
   let pageCategory: string | undefined;
   let mode: HeroMode | undefined;
@@ -101,7 +98,7 @@ export default async function RootLayout({ children }: { children: ReactNode }) 
   } else if (pathname === "/") {
     pageCategory = "home";
   } else {
-    pageCategory = (manifest as { category?: string })?.category;
+    pageCategory = manifest?.category;
   }
 
   return (
@@ -109,11 +106,7 @@ export default async function RootLayout({ children }: { children: ReactNode }) 
       <body className="min-h-screen antialiased">
         <script
           type="application/ld+json"
-          dangerouslySetInnerHTML={{ __html: JSON.stringify(dentistJsonLd) }}
-        />
-        <script
-          type="application/ld+json"
-          dangerouslySetInnerHTML={{ __html: JSON.stringify(websiteJsonLd) }}
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(siteSchemaGraph) }}
         />
         <div className="flex min-h-screen flex-col">
           <div className="sticky top-0 z-50">

--- a/apps/web/app/team/[slug]/page.tsx
+++ b/apps/web/app/team/[slug]/page.tsx
@@ -1,10 +1,11 @@
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
-import { getPageManifestBySlug } from "@champagne/manifests";
+import {
+  buildTeamMemberProfileSchema,
+  getPageManifestBySlug,
+} from "@champagne/manifests";
 
 import ChampagnePageBuilder from "../../(champagne)/_builder/ChampagnePageBuilder";
-
-const PRODUCTION_CANONICAL_ORIGIN = "https://www.smhdental.co.uk";
 
 type PageParams = Promise<{ slug: string }>;
 
@@ -56,30 +57,13 @@ export default async function TeamMemberPage({ params }: { params: PageParams })
   }
 
   const name = manifest.label ?? manifest.title ?? "Team member";
-  const pageJsonLd = {
-    "@context": "https://schema.org",
-    "@type": "ProfilePage",
-    name,
-    url: `${PRODUCTION_CANONICAL_ORIGIN}${manifest.path}`,
-    isPartOf: {
-      "@id": `${PRODUCTION_CANONICAL_ORIGIN}/#website`,
-    },
-    mainEntity: {
-      "@type": "Person",
-      name,
-      url: `${PRODUCTION_CANONICAL_ORIGIN}${manifest.path}`,
-      worksFor: {
-        "@type": "Dentist",
-        name: "St Mary's House Dental Care",
-      },
-    },
-  };
+  const profileSchemaGraph = buildTeamMemberProfileSchema(manifest.path, name);
 
   return (
     <>
       <script
         type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(pageJsonLd) }}
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(profileSchemaGraph) }}
       />
       <ChampagnePageBuilder slug={manifestPath} />
     </>

--- a/apps/web/app/treatments/[slug]/page.tsx
+++ b/apps/web/app/treatments/[slug]/page.tsx
@@ -1,14 +1,16 @@
 import type { Metadata } from "next";
 import { notFound, permanentRedirect } from "next/navigation";
-import { getTreatmentManifest, resolveTreatmentPathAlias } from "@champagne/manifests";
+import {
+  buildTreatmentSchemaGraph,
+  getTreatmentManifest,
+  resolveTreatmentPathAlias,
+} from "@champagne/manifests";
 
 import ChampagnePageBuilder from "../../(champagne)/_builder/ChampagnePageBuilder";
 
 export const dynamic = "force-dynamic";
 
 type PageParams = { slug: string };
-
-const siteUrl = "https://www.smhdental.co.uk";
 
 async function resolveTreatment(params: Promise<PageParams>) {
   const resolved = await params;
@@ -74,63 +76,13 @@ export default async function TreatmentPage({
     (manifest as { description?: string; intro?: string }).description ??
     (manifest as { description?: string; intro?: string }).intro ??
     "Explore this treatment option.";
-  const canonicalUrl = `${siteUrl}${pageSlug}`;
-
-  const pageJsonLd = {
-    "@context": "https://schema.org",
-    "@type": "WebPage",
-    name: treatmentTitle,
-    url: canonicalUrl,
-    isPartOf: {
-      "@id": `${siteUrl}/#website`,
-    },
-  };
-
-  const serviceJsonLd = {
-    "@context": "https://schema.org",
-    "@type": "Service",
-    name: treatmentTitle,
-    description: treatmentDescription,
-    url: canonicalUrl,
-    provider: {
-      "@type": "Dentist",
-      name: "St Mary's House Dental Care",
-      url: siteUrl,
-    },
-  };
-
-  const breadcrumbJsonLd = {
-    "@context": "https://schema.org",
-    "@type": "BreadcrumbList",
-    itemListElement: [
-      {
-        "@type": "ListItem",
-        position: 1,
-        name: "Treatments",
-        item: `${siteUrl}/treatments`,
-      },
-      {
-        "@type": "ListItem",
-        position: 2,
-        name: treatmentTitle,
-        item: canonicalUrl,
-      },
-    ],
-  };
+  const treatmentSchemaGraph = buildTreatmentSchemaGraph(pageSlug, treatmentTitle, treatmentDescription);
 
   return (
     <>
       <script
         type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(pageJsonLd) }}
-      />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(serviceJsonLd) }}
-      />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbJsonLd) }}
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(treatmentSchemaGraph) }}
       />
       <ChampagnePageBuilder slug={pageSlug} />
     </>

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "guard:stock-proxy-no-phi": "node scripts/guard-stock-proxy-no-phi.mjs",
     "guard:concierge-contract": "node scripts/guard-concierge-engine-contract.mjs",
     "export:website-truth": "node scripts/export-website-truth.mjs",
-    "guard:treatment-answer-surface": "node scripts/guard-treatment-answer-surface.mjs"
+    "guard:treatment-answer-surface": "node scripts/guard-treatment-answer-surface.mjs",
+    "seo:schema-qa": "node scripts/seo-schema-graph-qa.mjs"
   },
   "dependencies": {
     "framer-motion": "^11.11.17",

--- a/packages/champagne-manifests/data/seo/approved-facts.smh.json
+++ b/packages/champagne-manifests/data/seo/approved-facts.smh.json
@@ -1,0 +1,48 @@
+{
+  "version": "SEO_PUBLIC_APPROVED_FACTS_V1",
+  "tenantId": "smh",
+  "scope": "public_non_phi_facts_only",
+  "practice": {
+    "publicBrand": "St Mary's House Dental Care",
+    "legalEntity": "Maxwell-Deen Dentistry Ltd",
+    "address": "St Mary's Road, Shoreham-by-Sea, West Sussex, BN43 5ZA",
+    "telephone": "01273 453109",
+    "email": "info@smhdental.co.uk",
+    "primaryMarket": "Shoreham-by-Sea",
+    "supportMarkets": ["Brighton", "Hove", "Lancing", "Worthing", "Steyning"]
+  },
+  "hours": {
+    "Monday": "08:30-17:00",
+    "Tuesday": "08:30-17:00",
+    "Wednesday": "08:30-17:00",
+    "Thursday": "08:30-17:00",
+    "Friday": "08:30-16:00",
+    "Saturday": "Closed",
+    "Sunday": "Closed"
+  },
+  "team": [
+    { "name": "Dr Nick Maxwell", "role": "Principal Dentist", "gdcNumber": "74877" },
+    { "name": "Dr Sylvia Krafft", "role": "Associate Dentist", "gdcNumber": "174528" },
+    { "name": "Kitty Ingarfield", "role": "Associate Dentist", "gdcNumber": "302160" },
+    { "name": "Sara Burden", "role": "Dental Hygienist", "gdcNumber": "3966" },
+    { "name": "Evgenia Georgieva (Jenny)", "role": "Dental Hygienist", "gdcNumber": "275874" }
+  ],
+  "priorityServices": [
+    "Private dentist",
+    "Emergency dentist",
+    "Dental implants",
+    "3D dentistry",
+    "Same-day crowns/veneers",
+    "Spark Aligners",
+    "Orthodontics",
+    "Sedation/anxiety dentistry",
+    "Cosmetic dentistry",
+    "Hygiene/recall",
+    "Examinations"
+  ],
+  "safetyNotes": [
+    "No diagnosis is provided from approved facts.",
+    "No PHI or patient-specific information is included.",
+    "Treatment advice requires a clinical assessment."
+  ]
+}

--- a/packages/champagne-manifests/data/seo/local-identity.smh.json
+++ b/packages/champagne-manifests/data/seo/local-identity.smh.json
@@ -1,0 +1,102 @@
+{
+  "version": "SEO_LOCAL_IDENTITY_V1",
+  "tenantId": "smh",
+  "canonicalOrigin": "https://www.smhdental.co.uk",
+  "publicBrand": {
+    "name": "St Mary's House Dental Care",
+    "alternateName": "SMH Dental Care",
+    "sources": [
+      {
+        "type": "user_prompt",
+        "url": "mission_prompt",
+        "evidence": "PUBLIC BRAND: St Mary’s House Dental Care."
+      },
+      {
+        "type": "live_site",
+        "url": "https://www.smhdental.co.uk/",
+        "evidence": "Homepage identifies the practice as St Mary’s House Dental Care."
+      }
+    ]
+  },
+  "legalEntity": {
+    "name": "Maxwell-Deen Dentistry Ltd",
+    "sources": [
+      {
+        "type": "user_prompt",
+        "url": "mission_prompt",
+        "evidence": "LEGAL ENTITY: Maxwell-Deen Dentistry Ltd."
+      }
+    ]
+  },
+  "address": {
+    "streetAddress": "St Mary's Road",
+    "addressLocality": "Shoreham-by-Sea",
+    "addressRegion": "West Sussex",
+    "postalCode": "BN43 5ZA",
+    "addressCountry": "GB",
+    "sources": [
+      {
+        "type": "live_site",
+        "url": "https://www.smhdental.co.uk/contact-us/",
+        "evidence": "Contact page lists St Mary's Road, Shoreham-by-Sea, West Sussex, BN43 5ZA."
+      }
+    ]
+  },
+  "contact": {
+    "telephone": "01273 453109",
+    "email": "info@smhdental.co.uk",
+    "contactUrl": "https://www.smhdental.co.uk/contact-us/",
+    "sources": [
+      {
+        "type": "live_site",
+        "url": "https://www.smhdental.co.uk/contact-us/",
+        "evidence": "Contact page lists info@smhdental.co.uk and 01273 453109."
+      }
+    ]
+  },
+  "openingHours": [
+    { "dayOfWeek": "Monday", "opens": "08:30", "closes": "17:00" },
+    { "dayOfWeek": "Tuesday", "opens": "08:30", "closes": "17:00" },
+    { "dayOfWeek": "Wednesday", "opens": "08:30", "closes": "17:00" },
+    { "dayOfWeek": "Thursday", "opens": "08:30", "closes": "17:00" },
+    { "dayOfWeek": "Friday", "opens": "08:30", "closes": "16:00" }
+  ],
+  "closedDays": ["Saturday", "Sunday"],
+  "openingHoursSources": [
+    {
+      "type": "live_site",
+      "url": "https://www.smhdental.co.uk/contact-us/",
+      "evidence": "Opening hours: Monday-Thursday 8:30am to 5:00pm, Friday 8:30am to 4:00pm, Saturday and Sunday closed."
+    }
+  ],
+  "primaryMarket": {
+    "name": "Shoreham-by-Sea",
+    "sources": [
+      {
+        "type": "user_prompt",
+        "url": "mission_prompt",
+        "evidence": "PRIMARY MARKET: Shoreham-by-Sea."
+      }
+    ]
+  },
+  "supportMarkets": [
+    { "name": "Brighton", "sources": [{ "type": "user_prompt", "url": "mission_prompt" }] },
+    { "name": "Hove", "sources": [{ "type": "user_prompt", "url": "mission_prompt" }] },
+    { "name": "Lancing", "sources": [{ "type": "user_prompt", "url": "mission_prompt" }] },
+    { "name": "Worthing", "sources": [{ "type": "user_prompt", "url": "mission_prompt" }] },
+    { "name": "Steyning", "sources": [{ "type": "user_prompt", "url": "mission_prompt" }] }
+  ],
+  "priorityServices": [
+    { "id": "private-dentist", "name": "Private dentist", "routePath": "/contact", "sources": [{ "type": "user_prompt", "url": "mission_prompt" }] },
+    { "id": "emergency-dentist", "name": "Emergency dentist", "routePath": "/treatments/emergency-dentistry", "sources": [{ "type": "user_prompt", "url": "mission_prompt" }, { "type": "live_site", "url": "https://www.smhdental.co.uk/contact-us/" }] },
+    { "id": "dental-implants", "name": "Dental implants", "routePath": "/treatments/implants", "sources": [{ "type": "user_prompt", "url": "mission_prompt" }, { "type": "live_site", "url": "https://www.smhdental.co.uk/" }] },
+    { "id": "3d-dentistry", "name": "3D dentistry", "routePath": "/treatments/3d-dentistry-and-technology", "sources": [{ "type": "user_prompt", "url": "mission_prompt" }] },
+    { "id": "same-day-crowns-veneers", "name": "Same-day crowns/veneers", "routePath": "/treatments/3d-digital-dentistry", "sources": [{ "type": "user_prompt", "url": "mission_prompt" }] },
+    { "id": "spark-aligners", "name": "Spark Aligners", "routePath": "/treatments/clear-aligners-spark", "sources": [{ "type": "user_prompt", "url": "mission_prompt" }] },
+    { "id": "orthodontics", "name": "Orthodontics", "routePath": "/treatments/orthodontics", "sources": [{ "type": "user_prompt", "url": "mission_prompt" }] },
+    { "id": "sedation-anxiety-dentistry", "name": "Sedation/anxiety dentistry", "routePath": "/treatments/sedation-dentistry", "sources": [{ "type": "user_prompt", "url": "mission_prompt" }] },
+    { "id": "cosmetic-dentistry", "name": "Cosmetic dentistry", "routePath": "/treatments/cosmetic-dentistry", "sources": [{ "type": "user_prompt", "url": "mission_prompt" }, { "type": "live_site", "url": "https://www.smhdental.co.uk/" }] },
+    { "id": "hygiene-recall", "name": "Hygiene/recall", "routePath": "/treatments/preventative-and-general-dentistry", "sources": [{ "type": "user_prompt", "url": "mission_prompt" }, { "type": "live_site", "url": "https://www.smhdental.co.uk/dental-hygienist/" }] },
+    { "id": "examinations", "name": "Examinations", "routePath": "/treatments/dental-checkups-oral-cancer-screening", "sources": [{ "type": "user_prompt", "url": "mission_prompt" }, { "type": "live_site", "url": "https://www.smhdental.co.uk/examination/" }] }
+  ]
+}

--- a/packages/champagne-manifests/data/seo/team-registry.smh.json
+++ b/packages/champagne-manifests/data/seo/team-registry.smh.json
@@ -1,0 +1,93 @@
+{
+  "version": "SEO_TEAM_REGISTRY_V1",
+  "tenantId": "smh",
+  "members": [
+    {
+      "id": "nick-maxwell",
+      "name": "Dr Nick Maxwell",
+      "role": "Principal Dentist",
+      "schemaRole": "Dentist",
+      "profilePath": "/team/nick-maxwell",
+      "gdcNumber": "74877",
+      "qualifications": [
+        "BDS King's College London 1998",
+        "MSc Restorative & Aesthetic Dentistry",
+        "PGDip Orthodontics & Facial Orthopaedics"
+      ],
+      "treatmentInterests": ["Restorative dentistry", "Aesthetic dentistry", "3D dentistry", "Orthodontics", "General dentistry"],
+      "verifiedForSchema": true,
+      "sources": [
+        { "type": "user_prompt", "url": "mission_prompt", "evidence": "Principal dentist Dr Nick Maxwell, GDC 74877, BDS King's College London 1998, MSc Restorative & Aesthetic Dentistry, PGDip Orthodontics & Facial Orthopaedics." },
+        { "type": "live_site", "url": "https://www.smhdental.co.uk/team/", "evidence": "Team page lists Dr Nick Maxwell as Principal Dentist, GDC 74877, qualifications and clinical interests." },
+        { "type": "repo", "url": "page-truth/team-nick-maxwell.txt", "evidence": "Existing page truth includes profile intro and credentials." }
+      ]
+    },
+    {
+      "id": "sylvia-krafft",
+      "name": "Dr Sylvia Krafft",
+      "alternateLiveSiteName": "Dr Sylvia Kraftt",
+      "role": "Associate Dentist",
+      "schemaRole": "Dentist",
+      "profilePath": "/team/sylvia-krafft",
+      "gdcNumber": "174528",
+      "qualifications": ["Zahnarzt (Dental Surgeon), University of Cologne"],
+      "treatmentInterests": ["General dentistry", "Preventative dentistry", "Minimally invasive dentistry", "Aesthetic dentistry"],
+      "verifiedForSchema": true,
+      "sources": [
+        { "type": "user_prompt", "url": "mission_prompt", "evidence": "Known associate: Dr Sylvia Krafft, dentist." },
+        { "type": "live_site", "url": "https://www.smhdental.co.uk/team/", "evidence": "Team page lists Dr Sylvia Kraftt as Dentist, GDC 174528, with preventative/minimally invasive focus." },
+        { "type": "repo", "url": "page-truth/team-sylvia-krafft.txt", "evidence": "Existing page truth lists Dr Sylvia Krafft as Associate Dentist and includes credentials/interests." }
+      ]
+    },
+    {
+      "id": "kitty-ingarfield",
+      "name": "Kitty Ingarfield",
+      "role": "Associate Dentist",
+      "schemaRole": "Dentist",
+      "gdcNumber": "302160",
+      "qualifications": ["University of Plymouth 2022"],
+      "treatmentInterests": ["Oral surgery", "Endodontics", "Paediatric dentistry", "Clear aligners", "Composite bonding", "Facial aesthetics"],
+      "verifiedForSchema": true,
+      "sources": [
+        { "type": "live_site", "url": "https://www.smhdental.co.uk/team/", "evidence": "Team page lists Kitty Ingarfield as Dentist, GDC 302160, University of Plymouth 2022, and clinical interests." }
+      ]
+    },
+    {
+      "id": "sara-burden",
+      "name": "Sara Burden",
+      "role": "Dental Hygienist",
+      "schemaRole": "Person",
+      "profilePath": "/team/sara-burden",
+      "gdcNumber": "3966",
+      "qualifications": ["Birmingham Dental School 1990"],
+      "treatmentInterests": ["Dental hygiene", "Periodontal care", "Gum health", "Preventative care"],
+      "verifiedForSchema": true,
+      "sources": [
+        { "type": "live_site", "url": "https://www.smhdental.co.uk/team/", "evidence": "Team page lists Sara Burden as Dental Hygienist, GDC 3966, qualified from Birmingham Dental School in 1990." },
+        { "type": "repo", "url": "page-truth/team-sara-burden.txt", "evidence": "Existing page truth lists Sara Burden as Dental Hygienist with credentials and care philosophy." }
+      ]
+    },
+    {
+      "id": "evgenia-georgieva-jenny",
+      "name": "Evgenia Georgieva (Jenny)",
+      "role": "Dental Hygienist",
+      "schemaRole": "Person",
+      "gdcNumber": "275874",
+      "qualifications": ["University of Portsmouth 2024"],
+      "treatmentInterests": ["Prevention", "Periodontal health", "Non-surgical periodontal therapy", "Personalised treatment planning"],
+      "verifiedForSchema": true,
+      "sources": [
+        { "type": "live_site", "url": "https://www.smhdental.co.uk/team/", "evidence": "Team page lists Evgenia Georgieva (Jenny) as Dental Hygienist, GDC 275874, University of Portsmouth 2024." }
+      ]
+    }
+  ],
+  "teamStructure": {
+    "principalDentists": 1,
+    "associateDentists": 2,
+    "hygienists": 2,
+    "sources": [
+      { "type": "user_prompt", "url": "mission_prompt", "evidence": "The practice has 1 principal dentist, 2 associate dentists and 2 hygienists." },
+      { "type": "live_site", "url": "https://www.smhdental.co.uk/team/", "evidence": "Current live team page verifies named clinicians in those groups." }
+    ]
+  }
+}

--- a/packages/champagne-manifests/src/index.ts
+++ b/packages/champagne-manifests/src/index.ts
@@ -109,3 +109,26 @@ export {
   type PageSurfaceEvidenceReviewMetadata,
   type PageSurfaceLaunchBlocker,
 } from "./pageSurface";
+
+export {
+  approvedPublicFacts,
+  buildBreadcrumbNode,
+  buildDentistNode,
+  buildOrganizationNode,
+  buildPersonNode,
+  buildPriorityServiceNodes,
+  buildServiceNode,
+  buildSiteSchemaGraph,
+  buildTeamMemberProfileSchema,
+  buildTreatmentSchemaGraph,
+  buildWebPageNode,
+  buildWebsiteNode,
+  getCanonicalOrigin,
+  getDefaultSeoDescription,
+  getPracticeName,
+  getTeamMemberByPath,
+  getVerifiedTeamMembers,
+  localIdentity,
+  teamRegistry,
+  type SchemaNode,
+} from "./seo";

--- a/packages/champagne-manifests/src/seo.ts
+++ b/packages/champagne-manifests/src/seo.ts
@@ -1,0 +1,239 @@
+import localIdentityData from "../data/seo/local-identity.smh.json";
+import teamRegistryData from "../data/seo/team-registry.smh.json";
+import approvedFactsData from "../data/seo/approved-facts.smh.json";
+import { getPageManifest, getTreatmentManifest } from "./helpers";
+
+export const localIdentity = localIdentityData;
+export const teamRegistry = teamRegistryData;
+export const approvedPublicFacts = approvedFactsData;
+
+const canonicalOrigin = localIdentity.canonicalOrigin;
+const practiceName = localIdentity.publicBrand.name;
+const legalEntityName = localIdentity.legalEntity.name;
+const defaultDescription = "Private dental care in Shoreham-by-Sea, with calm planning and clear patient guidance.";
+
+export type SchemaNode = Record<string, unknown>;
+
+function absoluteUrl(path = "/") {
+  if (path.startsWith("https://") || path.startsWith("http://")) return path;
+  const normalizedPath = path.startsWith("/") ? path : `/${path}`;
+  return `${canonicalOrigin}${normalizedPath}`;
+}
+
+function graphId(fragment: string) {
+  return `${canonicalOrigin}/#${fragment}`;
+}
+
+function stripUndefined<T extends SchemaNode>(node: T): T {
+  return Object.fromEntries(Object.entries(node).filter(([, value]) => value !== undefined && value !== null)) as T;
+}
+
+function personId(memberId: string) {
+  return graphId(`person-${memberId}`);
+}
+
+export function getCanonicalOrigin() {
+  return canonicalOrigin;
+}
+
+export function getPracticeName() {
+  return practiceName;
+}
+
+export function getDefaultSeoDescription() {
+  return defaultDescription;
+}
+
+export function getVerifiedTeamMembers() {
+  return teamRegistry.members.filter((member) => member.verifiedForSchema);
+}
+
+export function getTeamMemberByPath(path: string) {
+  return getVerifiedTeamMembers().find((member) => member.profilePath === path);
+}
+
+export function buildOrganizationNode(): SchemaNode {
+  return {
+    "@type": "Organization",
+    "@id": graphId("organization"),
+    name: legalEntityName,
+    legalName: legalEntityName,
+    url: canonicalOrigin,
+    brand: {
+      "@type": "Brand",
+      name: practiceName,
+    },
+  };
+}
+
+export function buildDentistNode(): SchemaNode {
+  return {
+    "@type": ["Dentist", "LocalBusiness"],
+    "@id": graphId("dentist"),
+    name: practiceName,
+    legalName: legalEntityName,
+    url: canonicalOrigin,
+    telephone: localIdentity.contact.telephone,
+    email: localIdentity.contact.email,
+    address: {
+      "@type": "PostalAddress",
+      streetAddress: localIdentity.address.streetAddress,
+      addressLocality: localIdentity.address.addressLocality,
+      addressRegion: localIdentity.address.addressRegion,
+      postalCode: localIdentity.address.postalCode,
+      addressCountry: localIdentity.address.addressCountry,
+    },
+    openingHoursSpecification: localIdentity.openingHours.map((entry) => ({
+      "@type": "OpeningHoursSpecification",
+      dayOfWeek: `https://schema.org/${entry.dayOfWeek}`,
+      opens: entry.opens,
+      closes: entry.closes,
+    })),
+    areaServed: [localIdentity.primaryMarket.name, ...localIdentity.supportMarkets.map((market) => market.name)],
+    parentOrganization: {
+      "@id": graphId("organization"),
+    },
+    employee: getVerifiedTeamMembers().map((member) => ({ "@id": personId(member.id) })),
+  };
+}
+
+export function buildWebsiteNode(): SchemaNode {
+  return {
+    "@type": "WebSite",
+    "@id": graphId("website"),
+    name: practiceName,
+    url: canonicalOrigin,
+    description: defaultDescription,
+    publisher: {
+      "@id": graphId("organization"),
+    },
+  };
+}
+
+export function buildWebPageNode(path: string, name: string, description?: string, type = "WebPage"): SchemaNode {
+  return stripUndefined({
+    "@type": type,
+    "@id": `${absoluteUrl(path)}#webpage`,
+    name,
+    description,
+    url: absoluteUrl(path),
+    isPartOf: {
+      "@id": graphId("website"),
+    },
+    about: {
+      "@id": graphId("dentist"),
+    },
+  });
+}
+
+export function buildPersonNode(member: (typeof teamRegistry.members)[number]): SchemaNode {
+  return stripUndefined({
+    "@type": member.schemaRole === "Dentist" ? ["Person", "Dentist"] : "Person",
+    "@id": personId(member.id),
+    name: member.name,
+    jobTitle: member.role,
+    identifier: member.gdcNumber
+      ? {
+          "@type": "PropertyValue",
+          propertyID: "GDC",
+          value: member.gdcNumber,
+        }
+      : undefined,
+    alumniOf: member.qualifications?.length ? member.qualifications.join("; ") : undefined,
+    knowsAbout: member.treatmentInterests,
+    url: member.profilePath ? absoluteUrl(member.profilePath) : undefined,
+    worksFor: {
+      "@id": graphId("dentist"),
+    },
+  });
+}
+
+export function buildServiceNode(service: (typeof localIdentity.priorityServices)[number]): SchemaNode | null {
+  const routePath = service.routePath;
+  if (!routePath) return null;
+
+  const treatmentSlug = routePath.startsWith("/treatments/") ? routePath.replace("/treatments/", "") : undefined;
+  const manifest = treatmentSlug ? getTreatmentManifest(treatmentSlug) : getPageManifest(routePath);
+  if (!manifest?.path) return null;
+
+  const name = manifest.label ?? service.name;
+  const description =
+    (manifest as { description?: string; intro?: string }).description ??
+    (manifest as { description?: string; intro?: string }).intro;
+
+  return stripUndefined({
+    "@type": "Service",
+    "@id": `${absoluteUrl(manifest.path)}#service`,
+    name,
+    description,
+    url: absoluteUrl(manifest.path),
+    areaServed: localIdentity.primaryMarket.name,
+    provider: {
+      "@id": graphId("dentist"),
+    },
+  });
+}
+
+export function buildPriorityServiceNodes(): SchemaNode[] {
+  return localIdentity.priorityServices.map(buildServiceNode).filter((node): node is SchemaNode => Boolean(node));
+}
+
+export function buildBreadcrumbNode(items: { name: string; path: string }[]): SchemaNode {
+  return {
+    "@type": "BreadcrumbList",
+    itemListElement: items.map((item, index) => ({
+      "@type": "ListItem",
+      position: index + 1,
+      name: item.name,
+      item: absoluteUrl(item.path),
+    })),
+  };
+}
+
+export function buildSiteSchemaGraph(path = "/", pageName = practiceName, pageDescription = defaultDescription): SchemaNode {
+  return {
+    "@context": "https://schema.org",
+    "@graph": [
+      buildOrganizationNode(),
+      buildDentistNode(),
+      buildWebsiteNode(),
+      buildWebPageNode(path, pageName, pageDescription),
+      ...getVerifiedTeamMembers().map(buildPersonNode),
+      ...buildPriorityServiceNodes(),
+    ],
+  };
+}
+
+export function buildTreatmentSchemaGraph(path: string, treatmentTitle: string, treatmentDescription: string): SchemaNode {
+  const service = buildServiceNode({
+    id: path.replace(/^\//, "").replaceAll("/", "-"),
+    name: treatmentTitle,
+    routePath: path,
+    sources: [],
+  });
+
+  return {
+    "@context": "https://schema.org",
+    "@graph": [
+      buildWebPageNode(path, treatmentTitle, treatmentDescription),
+      ...(service ? [service] : []),
+      buildBreadcrumbNode([
+        { name: "Treatments", path: "/treatments" },
+        { name: treatmentTitle, path },
+      ]),
+    ],
+  };
+}
+
+export function buildTeamMemberProfileSchema(path: string, fallbackName: string): SchemaNode {
+  const member = getTeamMemberByPath(path);
+  const name = member?.name ?? fallbackName;
+
+  return {
+    "@context": "https://schema.org",
+    "@graph": [
+      buildWebPageNode(path, name, `Profile for ${name}.`, "ProfilePage"),
+      ...(member ? [buildPersonNode(member)] : []),
+    ],
+  };
+}

--- a/scripts/seo-schema-graph-qa.mjs
+++ b/scripts/seo-schema-graph-qa.mjs
@@ -1,0 +1,107 @@
+import fs from "node:fs";
+import path from "node:path";
+
+const root = process.cwd();
+const identityPath = path.join(root, "packages/champagne-manifests/data/seo/local-identity.smh.json");
+const teamPath = path.join(root, "packages/champagne-manifests/data/seo/team-registry.smh.json");
+const approvedFactsPath = path.join(root, "packages/champagne-manifests/data/seo/approved-facts.smh.json");
+const outputPath = path.join(root, "tools/audits/seo-local-identity-team-schema-foundation/SEO_SCHEMA_GRAPH_QA_RESULTS_V1.json");
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, "utf8"));
+}
+
+const identity = readJson(identityPath);
+const team = readJson(teamPath);
+const approvedFacts = readJson(approvedFactsPath);
+const errors = [];
+const warnings = [];
+
+function assert(condition, message) {
+  if (!condition) errors.push(message);
+}
+
+function assertNoTodo(value, location) {
+  if (JSON.stringify(value).includes("TODO_REQUIRED_FACT")) {
+    errors.push(`${location} contains TODO_REQUIRED_FACT`);
+  }
+}
+
+for (const [location, value] of [
+  ["local identity", identity],
+  ["team registry", team],
+  ["approved facts", approvedFacts],
+]) {
+  assertNoTodo(value, location);
+}
+
+assert(identity.publicBrand.name === "St Mary's House Dental Care", "Public brand must remain St Mary's House Dental Care.");
+assert(identity.legalEntity.name === "Maxwell-Deen Dentistry Ltd", "Legal entity must remain Maxwell-Deen Dentistry Ltd.");
+assert(identity.publicBrand.name !== identity.legalEntity.name, "Public brand and legal entity must not be conflated.");
+assert(Boolean(identity.address.streetAddress), "Dentist/LocalBusiness address.streetAddress is required.");
+assert(Boolean(identity.address.postalCode), "Dentist/LocalBusiness address.postalCode is required.");
+assert(Boolean(identity.contact.telephone), "Dentist/LocalBusiness telephone is required.");
+assert(Array.isArray(identity.openingHours) && identity.openingHours.length === 5, "Five open weekdays should be represented.");
+assert(!JSON.stringify(identity).includes("aggregateRating"), "No invented aggregate ratings may appear.");
+assert(!JSON.stringify(identity).includes("priceRange"), "No invented price range may appear.");
+assert(!JSON.stringify(identity).includes("geo"), "No unverified geo coordinates may appear.");
+
+const verifiedMembers = team.members.filter((member) => member.verifiedForSchema);
+assert(verifiedMembers.some((member) => member.id === "nick-maxwell" && member.gdcNumber === "74877"), "Dr Nick Maxwell Person node source data is required.");
+assert(verifiedMembers.filter((member) => member.role === "Associate Dentist").length === 2, "Exactly two verified associate dentists should be present.");
+assert(verifiedMembers.filter((member) => member.role === "Dental Hygienist").length === 2, "Exactly two verified hygienists should be present.");
+for (const member of verifiedMembers) {
+  assert(Boolean(member.name), `Verified team member ${member.id} requires name.`);
+  assert(Boolean(member.role), `Verified team member ${member.id} requires role.`);
+  assert(Array.isArray(member.sources) && member.sources.length > 0, `Verified team member ${member.id} requires source evidence.`);
+}
+
+const requiredServiceIds = [
+  "private-dentist",
+  "emergency-dentist",
+  "dental-implants",
+  "3d-dentistry",
+  "same-day-crowns-veneers",
+  "spark-aligners",
+  "orthodontics",
+  "sedation-anxiety-dentistry",
+  "cosmetic-dentistry",
+  "hygiene-recall",
+  "examinations",
+];
+for (const serviceId of requiredServiceIds) {
+  assert(identity.priorityServices.some((service) => service.id === serviceId), `Missing priority service ${serviceId}.`);
+}
+
+const graphNodes = {
+  dentist: `${identity.canonicalOrigin}/#dentist`,
+  organization: `${identity.canonicalOrigin}/#organization`,
+  website: `${identity.canonicalOrigin}/#website`,
+  principalPerson: `${identity.canonicalOrigin}/#person-nick-maxwell`,
+};
+
+const result = {
+  version: "SEO_SCHEMA_GRAPH_QA_RESULTS_V1",
+  generatedAt: new Date().toISOString(),
+  status: errors.length ? "fail" : "pass",
+  checkedFiles: [
+    path.relative(root, identityPath),
+    path.relative(root, teamPath),
+    path.relative(root, approvedFactsPath),
+  ],
+  graphNodes,
+  verifiedTeamMemberCount: verifiedMembers.length,
+  priorityServiceCount: identity.priorityServices.length,
+  errors,
+  warnings,
+};
+
+fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+fs.writeFileSync(outputPath, `${JSON.stringify(result, null, 2)}\n`);
+
+if (errors.length) {
+  console.error(JSON.stringify(result, null, 2));
+  process.exit(1);
+}
+
+console.log(JSON.stringify(result, null, 2));

--- a/tools/audits/seo-local-identity-team-schema-foundation/SEO_LIVE_SITE_FACT_EXTRACTION_V1.json
+++ b/tools/audits/seo-local-identity-team-schema-foundation/SEO_LIVE_SITE_FACT_EXTRACTION_V1.json
@@ -1,0 +1,35 @@
+{
+  "version": "SEO_LIVE_SITE_FACT_EXTRACTION_V1",
+  "inspectedAt": "2026-06-02",
+  "urlsInspected": [
+    "https://www.smhdental.co.uk/",
+    "https://www.smhdental.co.uk/contact-us/",
+    "https://www.smhdental.co.uk/team/",
+    "https://www.smhdental.co.uk/about-us/",
+    "https://www.smhdental.co.uk/fees/",
+    "https://www.smhdental.co.uk/general-dentistry/",
+    "https://www.smhdental.co.uk/general-dentistry-west-sussex/",
+    "https://www.smhdental.co.uk/dental-hygienist/",
+    "https://www.smhdental.co.uk/examination/"
+  ],
+  "facts": [
+    { "field": "practice.name", "value": "St Mary's House Dental Care", "sourceUrl": "https://www.smhdental.co.uk/", "productionUse": true },
+    { "field": "practice.address", "value": "St Mary's Road, Shoreham-by-Sea, West Sussex, BN43 5ZA", "sourceUrl": "https://www.smhdental.co.uk/contact-us/", "productionUse": true },
+    { "field": "practice.telephone", "value": "01273 453109", "sourceUrl": "https://www.smhdental.co.uk/contact-us/", "productionUse": true },
+    { "field": "practice.email", "value": "info@smhdental.co.uk", "sourceUrl": "https://www.smhdental.co.uk/contact-us/", "productionUse": true },
+    { "field": "practice.openingHours", "value": "Monday-Thursday 8:30am-5:00pm; Friday 8:30am-4:00pm; Saturday-Sunday closed", "sourceUrl": "https://www.smhdental.co.uk/contact-us/", "productionUse": true },
+    { "field": "team.nickMaxwell", "value": "Dr Nick Maxwell; Principal Dentist; GDC 74877; MSc Master in Restorative and Aesthetic Dentistry; PG Dip (Merit) Diploma in Facial Orthopaedics & Orthodontics; BDS London", "sourceUrl": "https://www.smhdental.co.uk/team/", "productionUse": true },
+    { "field": "team.sylviaKrafft", "value": "Dr Sylvia Kraftt on live site; Dentist; GDC 174528; minimally invasive and preventative dentistry focus", "sourceUrl": "https://www.smhdental.co.uk/team/", "productionUse": true, "note": "Repo and user prompt spell surname Krafft; live page heading appears to spell Kraftt." },
+    { "field": "team.kittyIngarfield", "value": "Kitty Ingarfield; Dentist; GDC 302160; University of Plymouth 2022; interests include oral surgery, endodontics, paediatric dentistry, clear aligners, composite bonding and facial aesthetics", "sourceUrl": "https://www.smhdental.co.uk/team/", "productionUse": true },
+    { "field": "team.saraBurden", "value": "Sara Burden; Dental Hygienist; GDC 3966; Birmingham Dental School 1990; periodontal/gum health focus", "sourceUrl": "https://www.smhdental.co.uk/team/", "productionUse": true },
+    { "field": "team.evgeniaGeorgievaJenny", "value": "Evgenia Georgieva (Jenny); Dental Hygienist; GDC 275874; University of Portsmouth 2024; prevention and periodontal health focus", "sourceUrl": "https://www.smhdental.co.uk/team/", "productionUse": true },
+    { "field": "services.homepageTreatments", "value": "Dental implants, Invisalign braces, smile makeover, teeth whitening, straighter teeth, composite restoration, dental crown, dental bridges, dentures, dental veneers", "sourceUrl": "https://www.smhdental.co.uk/", "productionUse": "partial" },
+    { "field": "services.generalDentistry", "value": "Examination, emergency dentist, dental extraction, root canal treatment, inlays, bridges, dental crowns, dentures, fillings, dental hygienist, sealants, dental veneers, composite restoration, teeth whitening, Cfast, SmileTru, Inman Aligner", "sourceUrl": "https://www.smhdental.co.uk/general-dentistry/", "productionUse": "partial" },
+    { "field": "fees.sample", "value": "New patient consultation from £99, routine check-up from £75, hygiene from £85.50", "sourceUrl": "https://www.smhdental.co.uk/fees/", "productionUse": false, "note": "Prices intentionally not added to schema." }
+  ],
+  "notUsedInProductionSchema": [
+    "Testimonials/reviews from homepage and reviews page were not added because the mission forbids invented or unsupported ratings/review schema.",
+    "Fees were not added to schema because prices vary by case and production Service price schema was out of scope.",
+    "Map link/place details were not added because exact place ID/coordinates were not independently verified for production schema."
+  ]
+}

--- a/tools/audits/seo-local-identity-team-schema-foundation/SEO_LOCAL_IDENTITY_TEAM_SCHEMA_FOUNDATION_REPORT_V1.json
+++ b/tools/audits/seo-local-identity-team-schema-foundation/SEO_LOCAL_IDENTITY_TEAM_SCHEMA_FOUNDATION_REPORT_V1.json
@@ -1,0 +1,29 @@
+{
+  "version": "SEO_LOCAL_IDENTITY_TEAM_SCHEMA_FOUNDATION_REPORT_V1",
+  "status": "bounded_foundation_implemented_not_launch_certified",
+  "filesChangedCategories": [
+    "canonical local identity manifest",
+    "canonical team registry manifest",
+    "public approved-facts manifest",
+    "schema graph generation helpers",
+    "Next.js JSON-LD emission updates",
+    "schema graph QA script",
+    "audit outputs"
+  ],
+  "schemaNodesImplemented": [
+    "Dentist/LocalBusiness",
+    "Organization",
+    "WebSite",
+    "WebPage",
+    "ProfilePage",
+    "Person/Dentist for Dr Nick Maxwell",
+    "Person/Dentist for verified associates",
+    "Person for verified hygienists",
+    "BreadcrumbList for treatments",
+    "Service for priority services with route data"
+  ],
+  "launchCertificationClaimed": false,
+  "phiTouched": false,
+  "pmsOrBookingBackendTouched": false,
+  "deploymentSettingsTouched": false
+}

--- a/tools/audits/seo-local-identity-team-schema-foundation/SEO_LOCAL_IDENTITY_TEAM_SCHEMA_FOUNDATION_REPORT_V1.md
+++ b/tools/audits/seo-local-identity-team-schema-foundation/SEO_LOCAL_IDENTITY_TEAM_SCHEMA_FOUNDATION_REPORT_V1.md
@@ -1,0 +1,46 @@
+# SEO Local Identity, Team, and Schema Graph Foundation Report V1
+
+## Status
+
+Bounded foundation implemented. This is **not** a launch certification claim.
+
+## Primary Sources Used
+
+- Existing Champagne repo files and page-truth exports.
+- Current live website pages under `https://www.smhdental.co.uk`.
+- User-provided mission facts.
+
+## Public Facts Added to Canonical Sources
+
+- Public brand: St Mary's House Dental Care.
+- Legal entity: Maxwell-Deen Dentistry Ltd.
+- Address: St Mary's Road, Shoreham-by-Sea, West Sussex, BN43 5ZA.
+- Phone: 01273 453109.
+- Email: info@smhdental.co.uk.
+- Opening hours: Monday-Thursday 08:30-17:00; Friday 08:30-16:00; Saturday-Sunday closed.
+- Primary market: Shoreham-by-Sea.
+- Support markets: Brighton, Hove, Lancing, Worthing, Steyning.
+- Priority services from the mission prompt with route-backed Service schema where Champagne route data exists.
+
+## Verified Team Registry
+
+- Dr Nick Maxwell — Principal Dentist — GDC 74877.
+- Dr Sylvia Krafft — Associate Dentist — GDC 174528.
+- Kitty Ingarfield — Associate Dentist — GDC 302160.
+- Sara Burden — Dental Hygienist — GDC 3966.
+- Evgenia Georgieva (Jenny) — Dental Hygienist — GDC 275874.
+
+## Schema Foundation Implemented
+
+- Root graph foundation: Dentist/LocalBusiness, Organization, WebSite, current WebPage, verified Person nodes, and route-backed priority Service nodes.
+- Treatment graph foundation: WebPage, Service, and BreadcrumbList.
+- Team profile graph foundation: ProfilePage plus verified Person node when the profile path exists in the team registry.
+
+## Guardrails Observed
+
+- No redesign.
+- No style/token edits.
+- No PHI.
+- No PMS/Dentally/booking backend changes.
+- No secrets, deployment settings, or production workflow changes.
+- No reviews, ratings, prices, coordinates, social links, or unsupported claims added to production schema.

--- a/tools/audits/seo-local-identity-team-schema-foundation/SEO_NEXT_BUILD_RECOMMENDATION_V1.md
+++ b/tools/audits/seo-local-identity-team-schema-foundation/SEO_NEXT_BUILD_RECOMMENDATION_V1.md
@@ -1,0 +1,23 @@
+# SEO Next Build Recommendation V1
+
+## Recommended Next Mission
+
+`SEO_LOCAL_SCHEMA_VISIBLE_CONTENT_ALIGNMENT_V1`
+
+## Why
+
+The repository now has a bounded canonical identity/team/schema foundation. The next safe mission should align visible page content and route manifests with that foundation without redesigning pages.
+
+## Suggested Scope
+
+1. Confirm and visibly publish legal entity details on an approved legal/contact surface if the practice wants legal entity schema to be externally corroborated.
+2. Resolve the Sylvia Krafft/Kraftt spelling discrepancy across live site, repo truth, and future page content.
+3. Add or intentionally defer Champagne profile routes/page-truth for Kitty Ingarfield and Evgenia Georgieva (Jenny).
+4. Approve Google Business Profile URL/place ID and coordinates before adding `geo`, `hasMap`, or `sameAs` schema.
+5. Add a route-level schema snapshot test once the Next.js runtime graph is stable.
+
+## Not Recommended Yet
+
+- Do not add Review or AggregateRating schema until review source, consent, and display alignment are formally approved.
+- Do not add price schema until fee rules and per-treatment visible pricing are governed.
+- Do not wire chatbot runtime until approved-facts consumption has a separate safety packet.

--- a/tools/audits/seo-local-identity-team-schema-foundation/SEO_REMAINING_FACTS_TODO_V1.json
+++ b/tools/audits/seo-local-identity-team-schema-foundation/SEO_REMAINING_FACTS_TODO_V1.json
@@ -1,0 +1,12 @@
+{
+  "version": "SEO_REMAINING_FACTS_TODO_V1",
+  "todos": [
+    { "id": "TODO_REQUIRED_FACT_LEGAL_ENTITY_PUBLIC_PAGE", "fact": "Visible public/legal page confirmation of Maxwell-Deen Dentistry Ltd", "reason": "Legal entity is user-provided and used appropriately, but not found on inspected live pages." },
+    { "id": "TODO_REQUIRED_FACT_GOOGLE_BUSINESS_PROFILE", "fact": "Approved Google Business Profile URL/place ID and coordinates", "reason": "Map/location text was visible, but exact production-safe place ID/coordinates were not verified." },
+    { "id": "TODO_REQUIRED_FACT_OFFICIAL_SOCIAL_URLS", "fact": "Approved social/profile URLs", "reason": "No production social profile URLs were verified from primary sources during this mission." },
+    { "id": "TODO_REQUIRED_FACT_TEAM_PROFILE_ROUTES", "fact": "Current repo profile routes for Kitty Ingarfield and Evgenia Georgieva (Jenny), if desired", "reason": "Live site verifies both clinicians, but current Champagne repo only has profile truth pages for Nick Maxwell, Sylvia Krafft and Sara Burden." },
+    { "id": "TODO_REQUIRED_FACT_SYLVIA_SURNAME_SPELLING", "fact": "Confirm public canonical spelling for Dr Sylvia Krafft/Kraftt", "reason": "User prompt and repo use Krafft; live page heading appeared as Kraftt." },
+    { "id": "TODO_REQUIRED_FACT_BOOKING_URL_POLICY", "fact": "Approved production booking portal URL policy", "reason": "Live site exposes a dental portal link, but this mission did not wire booking schema or runtime behaviour." }
+  ],
+  "productionSchemaContainsTodoRequiredFact": false
+}

--- a/tools/audits/seo-local-identity-team-schema-foundation/SEO_SCHEMA_GRAPH_QA_RESULTS_V1.json
+++ b/tools/audits/seo-local-identity-team-schema-foundation/SEO_SCHEMA_GRAPH_QA_RESULTS_V1.json
@@ -1,0 +1,20 @@
+{
+  "version": "SEO_SCHEMA_GRAPH_QA_RESULTS_V1",
+  "generatedAt": "2026-06-02T03:53:41.747Z",
+  "status": "pass",
+  "checkedFiles": [
+    "packages/champagne-manifests/data/seo/local-identity.smh.json",
+    "packages/champagne-manifests/data/seo/team-registry.smh.json",
+    "packages/champagne-manifests/data/seo/approved-facts.smh.json"
+  ],
+  "graphNodes": {
+    "dentist": "https://www.smhdental.co.uk/#dentist",
+    "organization": "https://www.smhdental.co.uk/#organization",
+    "website": "https://www.smhdental.co.uk/#website",
+    "principalPerson": "https://www.smhdental.co.uk/#person-nick-maxwell"
+  },
+  "verifiedTeamMemberCount": 5,
+  "priorityServiceCount": 11,
+  "errors": [],
+  "warnings": []
+}

--- a/tools/audits/seo-local-identity-team-schema-foundation/SEO_TEAM_REGISTRY_FACT_AUDIT_V1.json
+++ b/tools/audits/seo-local-identity-team-schema-foundation/SEO_TEAM_REGISTRY_FACT_AUDIT_V1.json
@@ -1,0 +1,22 @@
+{
+  "version": "SEO_TEAM_REGISTRY_FACT_AUDIT_V1",
+  "status": "verified_bounded_foundation",
+  "verifiedForProductionSchema": [
+    { "name": "Dr Nick Maxwell", "role": "Principal Dentist", "gdcNumber": "74877", "sources": ["mission_prompt", "https://www.smhdental.co.uk/team/", "page-truth/team-nick-maxwell.txt"] },
+    { "name": "Dr Sylvia Krafft", "role": "Associate Dentist", "gdcNumber": "174528", "sources": ["mission_prompt", "https://www.smhdental.co.uk/team/", "page-truth/team-sylvia-krafft.txt"], "note": "Live site heading appears as Dr Sylvia Kraftt; canonical registry follows user prompt and repo spelling Krafft while recording alternate live spelling." },
+    { "name": "Kitty Ingarfield", "role": "Associate Dentist", "gdcNumber": "302160", "sources": ["https://www.smhdental.co.uk/team/"] },
+    { "name": "Sara Burden", "role": "Dental Hygienist", "gdcNumber": "3966", "sources": ["https://www.smhdental.co.uk/team/", "page-truth/team-sara-burden.txt"] },
+    { "name": "Evgenia Georgieva (Jenny)", "role": "Dental Hygienist", "gdcNumber": "275874", "sources": ["https://www.smhdental.co.uk/team/"] }
+  ],
+  "excludedFromProductionSchema": [
+    { "name": "Joanna Dobson", "reason": "Non-clinical support role; not needed for bounded clinician schema foundation." },
+    { "name": "Gillian Bentley", "reason": "Support/nursing staff outside requested dentist/hygienist production schema foundation." },
+    { "name": "Sophia Ball", "reason": "Support/nursing staff outside requested dentist/hygienist production schema foundation." },
+    { "name": "Caitlin Brown", "reason": "Support/nursing staff outside requested dentist/hygienist production schema foundation." },
+    { "name": "Marianne Fawbert", "reason": "Reception role outside requested dentist/hygienist production schema foundation." }
+  ],
+  "conflictsOrDrift": [
+    "Current repo page-truth/team.txt labels Sara Burden as Associate dentist in one routing-card block, while live site and profile page-truth/team-sara-burden.txt verify Sara Burden as Dental Hygienist. Registry uses Dental Hygienist and records the drift for future content cleanup.",
+    "Live site search cache showed older team names not present in the current opened team page. Registry uses current opened live page facts plus repo/user prompt facts only."
+  ]
+}


### PR DESCRIPTION
### Motivation

- Provide a single-source canonical local identity and verified team registry to unlock LocalBusiness/Dentist JSON-LD, Service graph linking, and a safe approved-facts export for future E‑E‑A‑T and chatbot usage.
- Surface only verified, non‑PHI public facts (repo page-truth + inspected live pages) and avoid inventing reviews, prices, geo coordinates, or other unverified items.
- Prepare guarded, manifest-driven schema emission and QA so the site can later be aligned with GBP/Maps and chatbot approved‑facts safely.

### Description

- Added canonical SEO manifests: `packages/champagne-manifests/data/seo/local-identity.smh.json`, `team-registry.smh.json`, and `approved-facts.smh.json` containing provenance for each fact. 
- Implemented schema graph builders in `packages/champagne-manifests/src/seo.ts` and re-exported helpers from the manifests index for: `Organization`, `Dentist/LocalBusiness`, `WebSite`, `WebPage/ProfilePage`, `Person` nodes, `Service`, and `BreadcrumbList` graphs.
- Updated Next.js JSON-LD emission to use the canonical graph in: `apps/web/app/layout.tsx` (root site graph), `apps/web/app/treatments/[slug]/page.tsx` (treatment WebPage/Service/Breadcrumb graph), `apps/web/app/team/[slug]/page.tsx` (ProfilePage + Person when verified), and added about page metadata/JSON-LD without changing page content.
- Added schema QA and audit tooling: `scripts/seo-schema-graph-qa.mjs`, `pnpm` script `seo:schema-qa`, and audit outputs under `tools/audits/seo-local-identity-team-schema-foundation/` recording live-site extractions, team audit, QA results, TODOs, and recommendations.

### Testing

- Ran `pnpm run seo:schema-qa`, which produced `SEO_SCHEMA_GRAPH_QA_RESULTS_V1.json` and returned status: pass.
- Ran guards: `pnpm run guard:canon` and `pnpm run guard:hero`, both completed successfully with no guard failures.
- Ran repository checks: `pnpm run lint` and `pnpm run typecheck`, both passed with no errors reported.
- Ran full verification `pnpm run verify` (includes token-purity, guard suite, lint, typecheck and `next build`), which completed successfully and produced a successful web build.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1e5238106083328696ec09bab1b27d)