### PR TITLE
Add Lighthouse CWV mobile accessibility rerun evidence for 8 routes

### DIFF
--- a/tools/audits/lighthouse-cwv-mobile-accessibility-evidence-rerun/ACCESSIBILITY_RESULTS_RERUN_V1.json
+++ b/tools/audits/lighthouse-cwv-mobile-accessibility-evidence-rerun/ACCESSIBILITY_RESULTS_RERUN_V1.json
@@ -1,0 +1,789 @@
+{
+  "generatedAt": "2026-06-02T17:19:58.990Z",
+  "routes": [
+    {
+      "route": "/",
+      "url": "http://localhost:3000/",
+      "status": "pass_basic_automated_checks",
+      "limitation": "axe-core is not installed in the repository; this run uses Lighthouse accessibility plus Playwright DOM/accessibility heuristics.",
+      "httpStatus": 200,
+      "criticalIssues": [],
+      "lighthouseAccessibilityScore": 96,
+      "checks": {
+        "htmlLangPresent": true,
+        "hasHeadings": true,
+        "hasMainLandmark": true,
+        "hasReadablePrimaryContent": true,
+        "answerSurfacesReadableHtml": true,
+        "linksButtonsNamedHeuristic": true,
+        "imagesAltHeuristic": true
+      },
+      "pageEvidence": {
+        "title": "Private Dental Care in Shoreham-by-Sea | St Mary's House Dental Care",
+        "h1": null,
+        "headingCount": 22,
+        "headings": [
+          {
+            "tag": "H2",
+            "text": "Dentistry planned carefully, delivered properly"
+          },
+          {
+            "tag": "H2",
+            "text": "Dentistry designed for clarity, comfort, and long-term confidence"
+          },
+          {
+            "tag": "H3",
+            "text": "Clinical depth with steady hands"
+          },
+          {
+            "tag": "H2",
+            "text": "Care that values planning as much as precision"
+          },
+          {
+            "tag": "H3",
+            "text": "Priority treatments at a glance"
+          },
+          {
+            "tag": "H3",
+            "text": "How care works here"
+          },
+          {
+            "tag": "H2",
+            "text": "Structured care for complex situations"
+          },
+          {
+            "tag": "H3",
+            "text": "Pick a treatment to explore"
+          },
+          {
+            "tag": "H3",
+            "text": "Need urgent or remote support?"
+          },
+          {
+            "tag": "H3",
+            "text": "Technology that keeps planning clear"
+          },
+          {
+            "tag": "H3",
+            "text": "Patient journeys"
+          },
+          {
+            "tag": "H2",
+            "text": "Google reviews"
+          }
+        ],
+        "landmarks": {
+          "main": 1,
+          "nav": 1,
+          "header": 1,
+          "footer": 1,
+          "aside": 0
+        },
+        "roleLandmarks": [
+          "presentation",
+          "presentation",
+          "presentation",
+          "presentation",
+          "presentation",
+          "presentation",
+          "presentation",
+          "presentation",
+          "presentation",
+          "presentation"
+        ],
+        "mainPresent": true,
+        "mainVisible": true,
+        "primaryContentVisible": true,
+        "navPresent": true,
+        "navUsableEvidence": true,
+        "answerSurfaceCount": 0,
+        "answerSurfaceVisible": false,
+        "answerSurfaceTextSample": null,
+        "horizontalOverflow": false,
+        "viewportWidth": 836,
+        "scrollWidth": 836,
+        "bodyScrollWidth": 836,
+        "visibleTextLength": 9169,
+        "interactiveCount": 48,
+        "inaccessibleInteractiveCount": 0,
+        "inaccessibleInteractive": [],
+        "imagesMissingAlt": 0,
+        "lang": "en"
+      }
+    },
+    {
+      "route": "/contact",
+      "url": "http://localhost:3000/contact",
+      "status": "pass_basic_automated_checks",
+      "limitation": "axe-core is not installed in the repository; this run uses Lighthouse accessibility plus Playwright DOM/accessibility heuristics.",
+      "httpStatus": 200,
+      "criticalIssues": [],
+      "lighthouseAccessibilityScore": 96,
+      "checks": {
+        "htmlLangPresent": true,
+        "hasHeadings": true,
+        "hasMainLandmark": true,
+        "hasReadablePrimaryContent": true,
+        "answerSurfacesReadableHtml": false,
+        "linksButtonsNamedHeuristic": true,
+        "imagesAltHeuristic": true
+      },
+      "pageEvidence": {
+        "title": "Contact",
+        "h1": null,
+        "headingCount": 8,
+        "headings": [
+          {
+            "tag": "H2",
+            "text": "Contact St Mary’s House Dental Care"
+          },
+          {
+            "tag": "H2",
+            "text": "What does a private dentist appointment include at St Mary’s House Dental Care?"
+          },
+          {
+            "tag": "H3",
+            "text": "Practice details"
+          },
+          {
+            "tag": "H3",
+            "text": "Contact methods"
+          },
+          {
+            "tag": "H3",
+            "text": "Need urgent help?"
+          },
+          {
+            "tag": "H2",
+            "text": "How to contact us"
+          },
+          {
+            "tag": "H3",
+            "text": "Finding the practice"
+          },
+          {
+            "tag": "H3",
+            "text": "Plan a visit"
+          }
+        ],
+        "landmarks": {
+          "main": 1,
+          "nav": 1,
+          "header": 1,
+          "footer": 1,
+          "aside": 0
+        },
+        "roleLandmarks": [],
+        "mainPresent": true,
+        "mainVisible": true,
+        "primaryContentVisible": true,
+        "navPresent": true,
+        "navUsableEvidence": true,
+        "answerSurfaceCount": 0,
+        "answerSurfaceVisible": false,
+        "answerSurfaceTextSample": null,
+        "horizontalOverflow": false,
+        "viewportWidth": 836,
+        "scrollWidth": 836,
+        "bodyScrollWidth": 836,
+        "visibleTextLength": 4748,
+        "interactiveCount": 35,
+        "inaccessibleInteractiveCount": 0,
+        "inaccessibleInteractive": [],
+        "imagesMissingAlt": 0,
+        "lang": "en"
+      }
+    },
+    {
+      "route": "/treatments/emergency-dentistry",
+      "url": "http://localhost:3000/treatments/emergency-dentistry",
+      "status": "pass_basic_automated_checks",
+      "limitation": "axe-core is not installed in the repository; this run uses Lighthouse accessibility plus Playwright DOM/accessibility heuristics.",
+      "httpStatus": 200,
+      "criticalIssues": [],
+      "lighthouseAccessibilityScore": 96,
+      "checks": {
+        "htmlLangPresent": true,
+        "hasHeadings": true,
+        "hasMainLandmark": true,
+        "hasReadablePrimaryContent": true,
+        "answerSurfacesReadableHtml": false,
+        "linksButtonsNamedHeuristic": true,
+        "imagesAltHeuristic": true
+      },
+      "pageEvidence": {
+        "title": "Emergency dentistry",
+        "h1": null,
+        "headingCount": 10,
+        "headings": [
+          {
+            "tag": "H2",
+            "text": "Emergency dentistry"
+          },
+          {
+            "tag": "H2",
+            "text": "What should I do if I need an emergency dentist in Shoreham-by-Sea?"
+          },
+          {
+            "tag": "H2",
+            "text": "How we handle dental emergencies"
+          },
+          {
+            "tag": "H3",
+            "text": "Common reasons people contact us urgently"
+          },
+          {
+            "tag": "H3",
+            "text": "What to do right now"
+          },
+          {
+            "tag": "H3",
+            "text": "Urgent care and follow-up"
+          },
+          {
+            "tag": "H3",
+            "text": "What you can expect at an emergency visit"
+          },
+          {
+            "tag": "H3",
+            "text": "When urgent care may not be necessary"
+          },
+          {
+            "tag": "H3",
+            "text": "Call for emergency dental care"
+          },
+          {
+            "tag": "H3",
+            "text": "Emergency Dentistry — full treatment list"
+          }
+        ],
+        "landmarks": {
+          "main": 1,
+          "nav": 2,
+          "header": 1,
+          "footer": 1,
+          "aside": 0
+        },
+        "roleLandmarks": [
+          "presentation",
+          "presentation",
+          "presentation",
+          "presentation",
+          "presentation",
+          "presentation",
+          "presentation",
+          "presentation"
+        ],
+        "mainPresent": true,
+        "mainVisible": true,
+        "primaryContentVisible": true,
+        "navPresent": true,
+        "navUsableEvidence": true,
+        "answerSurfaceCount": 0,
+        "answerSurfaceVisible": false,
+        "answerSurfaceTextSample": null,
+        "horizontalOverflow": false,
+        "viewportWidth": 836,
+        "scrollWidth": 836,
+        "bodyScrollWidth": 836,
+        "visibleTextLength": 6020,
+        "interactiveCount": 47,
+        "inaccessibleInteractiveCount": 0,
+        "inaccessibleInteractive": [],
+        "imagesMissingAlt": 0,
+        "lang": "en"
+      }
+    },
+    {
+      "route": "/treatments/implants",
+      "url": "http://localhost:3000/treatments/implants",
+      "status": "pass_basic_automated_checks",
+      "limitation": "axe-core is not installed in the repository; this run uses Lighthouse accessibility plus Playwright DOM/accessibility heuristics.",
+      "httpStatus": 200,
+      "criticalIssues": [],
+      "lighthouseAccessibilityScore": 100,
+      "checks": {
+        "htmlLangPresent": true,
+        "hasHeadings": true,
+        "hasMainLandmark": true,
+        "hasReadablePrimaryContent": true,
+        "answerSurfacesReadableHtml": false,
+        "linksButtonsNamedHeuristic": true,
+        "imagesAltHeuristic": true
+      },
+      "pageEvidence": {
+        "title": "Dental Implants in Shoreham-by-Sea",
+        "h1": null,
+        "headingCount": 15,
+        "headings": [
+          {
+            "tag": "H2",
+            "text": "Planning first, surgery second"
+          },
+          {
+            "tag": "H3",
+            "text": "Implants Mid Cta"
+          },
+          {
+            "tag": "H2",
+            "text": "What are dental implants and who may they help?"
+          },
+          {
+            "tag": "H3",
+            "text": "Why patients trust us"
+          },
+          {
+            "tag": "H2",
+            "text": "A step-by-step approach"
+          },
+          {
+            "tag": "H3",
+            "text": "What is a dental implant?"
+          },
+          {
+            "tag": "H3",
+            "text": "Suitability and case selection"
+          },
+          {
+            "tag": "H3",
+            "text": "Implant treatment, step by step"
+          },
+          {
+            "tag": "H3",
+            "text": "CBCT + digital scanning"
+          },
+          {
+            "tag": "H3",
+            "text": "Important risks we discuss"
+          },
+          {
+            "tag": "H3",
+            "text": "Long-term success depends on care"
+          },
+          {
+            "tag": "H3",
+            "text": "Common questions about implants"
+          }
+        ],
+        "landmarks": {
+          "main": 1,
+          "nav": 2,
+          "header": 1,
+          "footer": 1,
+          "aside": 0
+        },
+        "roleLandmarks": [],
+        "mainPresent": true,
+        "mainVisible": true,
+        "primaryContentVisible": true,
+        "navPresent": true,
+        "navUsableEvidence": true,
+        "answerSurfaceCount": 0,
+        "answerSurfaceVisible": false,
+        "answerSurfaceTextSample": null,
+        "horizontalOverflow": false,
+        "viewportWidth": 836,
+        "scrollWidth": 836,
+        "bodyScrollWidth": 836,
+        "visibleTextLength": 9091,
+        "interactiveCount": 39,
+        "inaccessibleInteractiveCount": 0,
+        "inaccessibleInteractive": [],
+        "imagesMissingAlt": 0,
+        "lang": "en"
+      }
+    },
+    {
+      "route": "/treatments/clear-aligners-spark",
+      "url": "http://localhost:3000/treatments/clear-aligners-spark",
+      "status": "pass_basic_automated_checks",
+      "limitation": "axe-core is not installed in the repository; this run uses Lighthouse accessibility plus Playwright DOM/accessibility heuristics.",
+      "httpStatus": 200,
+      "criticalIssues": [],
+      "lighthouseAccessibilityScore": 100,
+      "checks": {
+        "htmlLangPresent": true,
+        "hasHeadings": true,
+        "hasMainLandmark": true,
+        "hasReadablePrimaryContent": true,
+        "answerSurfacesReadableHtml": false,
+        "linksButtonsNamedHeuristic": true,
+        "imagesAltHeuristic": true
+      },
+      "pageEvidence": {
+        "title": "Spark clear aligners in Shoreham-by-Sea",
+        "h1": null,
+        "headingCount": 17,
+        "headings": [
+          {
+            "tag": "H2",
+            "text": "Spark clear aligners in Shoreham-by-Sea"
+          },
+          {
+            "tag": "H2",
+            "text": "Can I get Spark Aligners in Shoreham-by-Sea?"
+          },
+          {
+            "tag": "H3",
+            "text": "Transparent, clinician-led aligner care"
+          },
+          {
+            "tag": "H2",
+            "text": "Discreet trays planned for comfort and predictability"
+          },
+          {
+            "tag": "H3",
+            "text": "Clear Aligners Spark Mid Cta"
+          },
+          {
+            "tag": "H3",
+            "text": "Digital Spark planning with bite checks and stability in mind"
+          },
+          {
+            "tag": "H3",
+            "text": "Clear guidance on suitability"
+          },
+          {
+            "tag": "H3",
+            "text": "Steady steps with ongoing support"
+          },
+          {
+            "tag": "H3",
+            "text": "Set review intervals with options if teeth don’t track"
+          },
+          {
+            "tag": "H3",
+            "text": "Digital scans meet Spark clarity"
+          },
+          {
+            "tag": "H3",
+            "text": "Comfort-focused guidance with clear expectations"
+          },
+          {
+            "tag": "H3",
+            "text": "Fixed and removable retainers with long-term guidance"
+          }
+        ],
+        "landmarks": {
+          "main": 1,
+          "nav": 2,
+          "header": 1,
+          "footer": 1,
+          "aside": 0
+        },
+        "roleLandmarks": [],
+        "mainPresent": true,
+        "mainVisible": true,
+        "primaryContentVisible": true,
+        "navPresent": true,
+        "navUsableEvidence": true,
+        "answerSurfaceCount": 0,
+        "answerSurfaceVisible": false,
+        "answerSurfaceTextSample": null,
+        "horizontalOverflow": false,
+        "viewportWidth": 836,
+        "scrollWidth": 836,
+        "bodyScrollWidth": 836,
+        "visibleTextLength": 9302,
+        "interactiveCount": 40,
+        "inaccessibleInteractiveCount": 0,
+        "inaccessibleInteractive": [],
+        "imagesMissingAlt": 0,
+        "lang": "en"
+      }
+    },
+    {
+      "route": "/treatments/3d-dentistry-and-technology",
+      "url": "http://localhost:3000/treatments/3d-dentistry-and-technology",
+      "status": "pass_basic_automated_checks",
+      "limitation": "axe-core is not installed in the repository; this run uses Lighthouse accessibility plus Playwright DOM/accessibility heuristics.",
+      "httpStatus": 200,
+      "criticalIssues": [],
+      "lighthouseAccessibilityScore": 100,
+      "checks": {
+        "htmlLangPresent": true,
+        "hasHeadings": true,
+        "hasMainLandmark": true,
+        "hasReadablePrimaryContent": true,
+        "answerSurfacesReadableHtml": false,
+        "linksButtonsNamedHeuristic": true,
+        "imagesAltHeuristic": true
+      },
+      "pageEvidence": {
+        "title": "3D dentistry & technology",
+        "h1": null,
+        "headingCount": 12,
+        "headings": [
+          {
+            "tag": "H2",
+            "text": "3D dentistry & technology in Shoreham-by-Sea"
+          },
+          {
+            "tag": "H2",
+            "text": "What is 3D dentistry at St Mary’s House Dental Care?"
+          },
+          {
+            "tag": "H3",
+            "text": "Calm, clinician-led control"
+          },
+          {
+            "tag": "H2",
+            "text": "Scan → Design → Print/Mill → Fit"
+          },
+          {
+            "tag": "H3",
+            "text": "Patients who want predictable, visual planning"
+          },
+          {
+            "tag": "H3",
+            "text": "3d Dentistry And Technology Mid Cta"
+          },
+          {
+            "tag": "H3",
+            "text": "Clear checkpoints from scan to maintenance"
+          },
+          {
+            "tag": "H3",
+            "text": "Precision outputs, clinician-reviewed"
+          },
+          {
+            "tag": "H3",
+            "text": "Long-term fit backed by maintenance"
+          },
+          {
+            "tag": "H3",
+            "text": "Answers before you choose"
+          },
+          {
+            "tag": "H2",
+            "text": "When this fits and what else to consider"
+          },
+          {
+            "tag": "H3",
+            "text": "See your options digitally before you commit"
+          }
+        ],
+        "landmarks": {
+          "main": 1,
+          "nav": 2,
+          "header": 1,
+          "footer": 1,
+          "aside": 0
+        },
+        "roleLandmarks": [],
+        "mainPresent": true,
+        "mainVisible": true,
+        "primaryContentVisible": true,
+        "navPresent": true,
+        "navUsableEvidence": true,
+        "answerSurfaceCount": 0,
+        "answerSurfaceVisible": false,
+        "answerSurfaceTextSample": null,
+        "horizontalOverflow": false,
+        "viewportWidth": 836,
+        "scrollWidth": 836,
+        "bodyScrollWidth": 836,
+        "visibleTextLength": 6801,
+        "interactiveCount": 38,
+        "inaccessibleInteractiveCount": 0,
+        "inaccessibleInteractive": [],
+        "imagesMissingAlt": 0,
+        "lang": "en"
+      }
+    },
+    {
+      "route": "/treatments/sedation-dentistry",
+      "url": "http://localhost:3000/treatments/sedation-dentistry",
+      "status": "pass_basic_automated_checks",
+      "limitation": "axe-core is not installed in the repository; this run uses Lighthouse accessibility plus Playwright DOM/accessibility heuristics.",
+      "httpStatus": 200,
+      "criticalIssues": [],
+      "lighthouseAccessibilityScore": 100,
+      "checks": {
+        "htmlLangPresent": true,
+        "hasHeadings": true,
+        "hasMainLandmark": true,
+        "hasReadablePrimaryContent": true,
+        "answerSurfacesReadableHtml": false,
+        "linksButtonsNamedHeuristic": true,
+        "imagesAltHeuristic": true
+      },
+      "pageEvidence": {
+        "title": "Sedation dentistry",
+        "h1": null,
+        "headingCount": 11,
+        "headings": [
+          {
+            "tag": "H2",
+            "text": "Sedation support for calmer dental visits"
+          },
+          {
+            "tag": "H2",
+            "text": "Can sedation help if I feel anxious about dental treatment?"
+          },
+          {
+            "tag": "H3",
+            "text": "Clinician-led, safety-first sedation"
+          },
+          {
+            "tag": "H2",
+            "text": "Consultation, suitability, then a tailored plan"
+          },
+          {
+            "tag": "H3",
+            "text": "Sedation Dentistry Mid Cta"
+          },
+          {
+            "tag": "H3",
+            "text": "Suitable for specific needs"
+          },
+          {
+            "tag": "H3",
+            "text": "Clear steps from consult to recovery"
+          },
+          {
+            "tag": "H3",
+            "text": "Recover with clear guidance"
+          },
+          {
+            "tag": "H3",
+            "text": "Common questions answered"
+          },
+          {
+            "tag": "H2",
+            "text": "When this fits and what else to consider"
+          },
+          {
+            "tag": "H3",
+            "text": "Talk through sedation calmly first"
+          }
+        ],
+        "landmarks": {
+          "main": 1,
+          "nav": 2,
+          "header": 1,
+          "footer": 1,
+          "aside": 0
+        },
+        "roleLandmarks": [],
+        "mainPresent": true,
+        "mainVisible": true,
+        "primaryContentVisible": true,
+        "navPresent": true,
+        "navUsableEvidence": true,
+        "answerSurfaceCount": 0,
+        "answerSurfaceVisible": false,
+        "answerSurfaceTextSample": null,
+        "horizontalOverflow": false,
+        "viewportWidth": 836,
+        "scrollWidth": 836,
+        "bodyScrollWidth": 836,
+        "visibleTextLength": 7129,
+        "interactiveCount": 38,
+        "inaccessibleInteractiveCount": 0,
+        "inaccessibleInteractive": [],
+        "imagesMissingAlt": 0,
+        "lang": "en"
+      }
+    },
+    {
+      "route": "/treatments/preventative-and-general-dentistry",
+      "url": "http://localhost:3000/treatments/preventative-and-general-dentistry",
+      "status": "pass_basic_automated_checks",
+      "limitation": "axe-core is not installed in the repository; this run uses Lighthouse accessibility plus Playwright DOM/accessibility heuristics.",
+      "httpStatus": 200,
+      "criticalIssues": [],
+      "lighthouseAccessibilityScore": 100,
+      "checks": {
+        "htmlLangPresent": true,
+        "hasHeadings": true,
+        "hasMainLandmark": true,
+        "hasReadablePrimaryContent": true,
+        "answerSurfacesReadableHtml": false,
+        "linksButtonsNamedHeuristic": true,
+        "imagesAltHeuristic": true
+      },
+      "pageEvidence": {
+        "title": "Preventative & general dentistry",
+        "h1": null,
+        "headingCount": 13,
+        "headings": [
+          {
+            "tag": "H2",
+            "text": "Prevention-first dentistry that keeps teeth for life"
+          },
+          {
+            "tag": "H2",
+            "text": "Do you offer dental hygiene and recall appointments in Shoreham-by-Sea?"
+          },
+          {
+            "tag": "H3",
+            "text": "Protect teeth before problems arise"
+          },
+          {
+            "tag": "H2",
+            "text": "Every check-up is detailed and documented"
+          },
+          {
+            "tag": "H3",
+            "text": "Professional hygiene that supports home care"
+          },
+          {
+            "tag": "H2",
+            "text": "Simple, science-led guidance you can follow"
+          },
+          {
+            "tag": "H3",
+            "text": "Preventative And General Dentistry Mid Cta"
+          },
+          {
+            "tag": "H3",
+            "text": "Early detection keeps treatment simpler"
+          },
+          {
+            "tag": "H3",
+            "text": "Care tailored to every stage"
+          },
+          {
+            "tag": "H3",
+            "text": "What patients ask most"
+          },
+          {
+            "tag": "H3",
+            "text": "Keep your routine care on track"
+          },
+          {
+            "tag": "H2",
+            "text": "When this fits and what else to consider"
+          }
+        ],
+        "landmarks": {
+          "main": 1,
+          "nav": 2,
+          "header": 1,
+          "footer": 1,
+          "aside": 0
+        },
+        "roleLandmarks": [],
+        "mainPresent": true,
+        "mainVisible": true,
+        "primaryContentVisible": true,
+        "navPresent": true,
+        "navUsableEvidence": true,
+        "answerSurfaceCount": 0,
+        "answerSurfaceVisible": false,
+        "answerSurfaceTextSample": null,
+        "horizontalOverflow": false,
+        "viewportWidth": 836,
+        "scrollWidth": 836,
+        "bodyScrollWidth": 836,
+        "visibleTextLength": 7878,
+        "interactiveCount": 39,
+        "inaccessibleInteractiveCount": 0,
+        "inaccessibleInteractive": [],
+        "imagesMissingAlt": 0,
+        "lang": "en"
+      }
+    }
+  ]
+}

--- a/tools/audits/lighthouse-cwv-mobile-accessibility-evidence-rerun/FINAL_CERTIFICATION_RECHECK_RECOMMENDATION_RERUN_V1.md
+++ b/tools/audits/lighthouse-cwv-mobile-accessibility-evidence-rerun/FINAL_CERTIFICATION_RECHECK_RECOMMENDATION_RERUN_V1.md
@@ -1,0 +1,26 @@
+# Final Certification Recheck Recommendation — Rerun V1
+
+Generated: 2026-06-02T17:19:58.990Z
+
+## Recommendation
+
+READY_FOR_FINAL_CERTIFICATION_RECHECK
+
+## Basis
+
+- Route availability: 8/8 required routes returned HTTP 200.
+- Lighthouse/CWV lab evidence: 8/8 routes measured.
+- Mobile readiness evidence: 8/8 routes passed automated mobile readiness heuristics.
+- Accessibility evidence: 8/8 routes passed basic automated accessibility heuristics; Lighthouse accessibility scores are included in the JSON report.
+- Remaining performance risks: 16 open risk entries, primarily lab Total Blocking Time/INP-proxy and LCP threshold observations.
+
+## Required route status
+
+- /: HTTP 200
+- /contact: HTTP 200
+- /treatments/emergency-dentistry: HTTP 200
+- /treatments/implants: HTTP 200
+- /treatments/clear-aligners-spark: HTTP 200
+- /treatments/3d-dentistry-and-technology: HTTP 200
+- /treatments/sedation-dentistry: HTTP 200
+- /treatments/preventative-and-general-dentistry: HTTP 200

--- a/tools/audits/lighthouse-cwv-mobile-accessibility-evidence-rerun/LIGHTHOUSE_CWV_MOBILE_ACCESSIBILITY_RERUN_REPORT_V1.json
+++ b/tools/audits/lighthouse-cwv-mobile-accessibility-evidence-rerun/LIGHTHOUSE_CWV_MOBILE_ACCESSIBILITY_RERUN_REPORT_V1.json
@@ -1,0 +1,1120 @@
+{
+  "generatedAt": "2026-06-02T17:19:58.990Z",
+  "role": "CHAMPAGNE_LIGHTHOUSE_CWV_MOBILE_ACCESSIBILITY_EVIDENCE_RERUN_V1",
+  "classification": "READY_FOR_FINAL_CERTIFICATION_RECHECK",
+  "baseUrl": "http://localhost:3000",
+  "routes": [
+    "/",
+    "/contact",
+    "/treatments/emergency-dentistry",
+    "/treatments/implants",
+    "/treatments/clear-aligners-spark",
+    "/treatments/3d-dentistry-and-technology",
+    "/treatments/sedation-dentistry",
+    "/treatments/preventative-and-general-dentistry"
+  ],
+  "tooling": {
+    "buildCommand": "pnpm run build:web",
+    "productionServeCommand": "cd apps/web && pnpm exec next start -p 3000",
+    "routeStatusCommand": "curl -sS -o /tmp/route.out -w %{http_code} http://localhost:3000<route>",
+    "lighthouseCommandPattern": "CHROME_PATH=$(node -e \"const{chromium}=require('playwright');process.stdout.write(chromium.executablePath())\") pnpm dlx lighthouse <url> --output=json --output-path=/tmp/champagne-lh-rerun/<route>.json --chrome-flags='--headless --no-sandbox --disable-gpu --disable-dev-shm-usage' --quiet",
+    "mobileAccessibilityEvidence": "Playwright Chromium mobile viewport 390x844 DOM/readiness/a11y heuristic checks",
+    "axeStatus": "axe-core not present; no dependency added. Lighthouse accessibility plus Playwright heuristics captured instead."
+  },
+  "summary": {
+    "lighthouseMeasuredRoutes": 8,
+    "lighthouseRequestedRoutes": 8,
+    "routeHttp200": 8,
+    "mobilePassRoutes": 8,
+    "accessibilityBasicPassRoutes": 8,
+    "performanceScores": {
+      "/": 75,
+      "/contact": 75,
+      "/treatments/emergency-dentistry": 75,
+      "/treatments/implants": 74,
+      "/treatments/clear-aligners-spark": 70,
+      "/treatments/3d-dentistry-and-technology": 76,
+      "/treatments/sedation-dentistry": 77,
+      "/treatments/preventative-and-general-dentistry": 75
+    },
+    "accessibilityScores": {
+      "/": 96,
+      "/contact": 96,
+      "/treatments/emergency-dentistry": 96,
+      "/treatments/implants": 100,
+      "/treatments/clear-aligners-spark": 100,
+      "/treatments/3d-dentistry-and-technology": 100,
+      "/treatments/sedation-dentistry": 100,
+      "/treatments/preventative-and-general-dentistry": 100
+    },
+    "remainingRiskCount": 16
+  },
+  "routeStatusResults": [
+    {
+      "route": "/",
+      "url": "http://localhost:3000/",
+      "status": 200,
+      "ok": true,
+      "checkedBy": "curl and Playwright production server verification"
+    },
+    {
+      "route": "/contact",
+      "url": "http://localhost:3000/contact",
+      "status": 200,
+      "ok": true,
+      "checkedBy": "curl and Playwright production server verification"
+    },
+    {
+      "route": "/treatments/emergency-dentistry",
+      "url": "http://localhost:3000/treatments/emergency-dentistry",
+      "status": 200,
+      "ok": true,
+      "checkedBy": "curl and Playwright production server verification"
+    },
+    {
+      "route": "/treatments/implants",
+      "url": "http://localhost:3000/treatments/implants",
+      "status": 200,
+      "ok": true,
+      "checkedBy": "curl and Playwright production server verification"
+    },
+    {
+      "route": "/treatments/clear-aligners-spark",
+      "url": "http://localhost:3000/treatments/clear-aligners-spark",
+      "status": 200,
+      "ok": true,
+      "checkedBy": "curl and Playwright production server verification"
+    },
+    {
+      "route": "/treatments/3d-dentistry-and-technology",
+      "url": "http://localhost:3000/treatments/3d-dentistry-and-technology",
+      "status": 200,
+      "ok": true,
+      "checkedBy": "curl and Playwright production server verification"
+    },
+    {
+      "route": "/treatments/sedation-dentistry",
+      "url": "http://localhost:3000/treatments/sedation-dentistry",
+      "status": 200,
+      "ok": true,
+      "checkedBy": "curl and Playwright production server verification"
+    },
+    {
+      "route": "/treatments/preventative-and-general-dentistry",
+      "url": "http://localhost:3000/treatments/preventative-and-general-dentistry",
+      "status": 200,
+      "ok": true,
+      "checkedBy": "curl and Playwright production server verification"
+    }
+  ],
+  "lighthouseResults": [
+    {
+      "route": "/",
+      "url": "http://localhost:3000/",
+      "status": "measured",
+      "reason": null,
+      "lighthouseVersion": "13.3.0",
+      "fetchTime": "2026-06-02T17:15:30.148Z",
+      "requestedUrl": "http://localhost:3000/",
+      "finalDisplayedUrl": "http://localhost:3000/",
+      "userAgent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/143.0.0.0 Safari/537.36",
+      "formFactor": "mobile",
+      "throttlingMethod": "simulate",
+      "screenEmulation": {
+        "mobile": true,
+        "width": 412,
+        "height": 823,
+        "deviceScaleFactor": 1.75,
+        "disabled": false
+      },
+      "scores": {
+        "performance": 75,
+        "accessibility": 96,
+        "bestPractices": 100,
+        "seo": 54
+      },
+      "coreWebVitalsLab": {
+        "fcpMs": 1336.9295,
+        "fcpDisplay": "1.3 s",
+        "lcpMs": 2333.8589999999995,
+        "lcpDisplay": "2.3 s",
+        "cls": 0,
+        "clsDisplay": "0",
+        "tbtMs": 1119.9999999999995,
+        "tbtDisplay": "1,120 ms",
+        "inpProxy": "TBT captured as lab proxy; INP is a field metric and was not available in this local lab run.",
+        "speedIndexMs": 1473.0147065946535,
+        "speedIndexDisplay": "1.5 s"
+      },
+      "networkAndWeight": {
+        "totalByteWeight": 473019,
+        "totalByteWeightDisplay": "Total size was 462 KiB",
+        "numRequests": 14,
+        "totalByteWeightDiagnostic": 473019,
+        "mainDocumentTransferSize": 39947
+      },
+      "topActionableAudits": [
+        {
+          "id": "first-contentful-paint",
+          "title": "First Contentful Paint",
+          "score": 0.98,
+          "displayValue": "1.3 s"
+        },
+        {
+          "id": "largest-contentful-paint",
+          "title": "Largest Contentful Paint",
+          "score": 0.93,
+          "displayValue": "2.3 s"
+        },
+        {
+          "id": "speed-index",
+          "title": "Speed Index",
+          "score": 1,
+          "displayValue": "1.5 s"
+        },
+        {
+          "id": "total-blocking-time",
+          "title": "Total Blocking Time",
+          "score": 0.23,
+          "displayValue": "1,120 ms"
+        },
+        {
+          "id": "max-potential-fid",
+          "title": "Max Potential First Input Delay",
+          "score": 0.03,
+          "displayValue": "650 ms"
+        },
+        {
+          "id": "interactive",
+          "title": "Time to Interactive",
+          "score": 0.85,
+          "displayValue": "4.2 s"
+        },
+        {
+          "id": "mainthread-work-breakdown",
+          "title": "Minimize main-thread work",
+          "score": 0,
+          "displayValue": "3.5 s"
+        },
+        {
+          "id": "bootup-time",
+          "title": "Reduce JavaScript execution time",
+          "score": 0,
+          "displayValue": "1.3 s"
+        },
+        {
+          "id": "valid-source-maps",
+          "title": "Missing source maps for large first-party JavaScript",
+          "score": 0,
+          "displayValue": null
+        },
+        {
+          "id": "color-contrast",
+          "title": "Background and foreground colors do not have a sufficient contrast ratio.",
+          "score": 0,
+          "displayValue": null
+        },
+        {
+          "id": "label-content-name-mismatch",
+          "title": "Elements with visible text labels do not have matching accessible names.",
+          "score": 0,
+          "displayValue": null
+        },
+        {
+          "id": "unused-javascript",
+          "title": "Reduce unused JavaScript",
+          "score": 0.5,
+          "displayValue": "Est savings of 21 KiB"
+        },
+        {
+          "id": "meta-description",
+          "title": "Document does not have a meta description",
+          "score": 0,
+          "displayValue": null
+        }
+      ]
+    },
+    {
+      "route": "/contact",
+      "url": "http://localhost:3000/contact",
+      "status": "measured",
+      "reason": null,
+      "lighthouseVersion": "13.3.0",
+      "fetchTime": "2026-06-02T17:15:49.138Z",
+      "requestedUrl": "http://localhost:3000/contact",
+      "finalDisplayedUrl": "http://localhost:3000/contact",
+      "userAgent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/143.0.0.0 Safari/537.36",
+      "formFactor": "mobile",
+      "throttlingMethod": "simulate",
+      "screenEmulation": {
+        "mobile": true,
+        "width": 412,
+        "height": 823,
+        "deviceScaleFactor": 1.75,
+        "disabled": false
+      },
+      "scores": {
+        "performance": 75,
+        "accessibility": 96,
+        "bestPractices": 100,
+        "seo": 54
+      },
+      "coreWebVitalsLab": {
+        "fcpMs": 1268.5819999999999,
+        "fcpDisplay": "1.3 s",
+        "lcpMs": 2469.164,
+        "lcpDisplay": "2.5 s",
+        "cls": 0,
+        "clsDisplay": "0",
+        "tbtMs": 1068,
+        "tbtDisplay": "1,070 ms",
+        "inpProxy": "TBT captured as lab proxy; INP is a field metric and was not available in this local lab run.",
+        "speedIndexMs": 1338.662251997444,
+        "speedIndexDisplay": "1.3 s"
+      },
+      "networkAndWeight": {
+        "totalByteWeight": 455473,
+        "totalByteWeightDisplay": "Total size was 445 KiB",
+        "numRequests": 14,
+        "totalByteWeightDiagnostic": 455473,
+        "mainDocumentTransferSize": 22401
+      },
+      "topActionableAudits": [
+        {
+          "id": "first-contentful-paint",
+          "title": "First Contentful Paint",
+          "score": 0.98,
+          "displayValue": "1.3 s"
+        },
+        {
+          "id": "largest-contentful-paint",
+          "title": "Largest Contentful Paint",
+          "score": 0.9,
+          "displayValue": "2.5 s"
+        },
+        {
+          "id": "speed-index",
+          "title": "Speed Index",
+          "score": 1,
+          "displayValue": "1.3 s"
+        },
+        {
+          "id": "total-blocking-time",
+          "title": "Total Blocking Time",
+          "score": 0.25,
+          "displayValue": "1,070 ms"
+        },
+        {
+          "id": "max-potential-fid",
+          "title": "Max Potential First Input Delay",
+          "score": 0.02,
+          "displayValue": "670 ms"
+        },
+        {
+          "id": "interactive",
+          "title": "Time to Interactive",
+          "score": 0.87,
+          "displayValue": "4.1 s"
+        },
+        {
+          "id": "mainthread-work-breakdown",
+          "title": "Minimize main-thread work",
+          "score": 0,
+          "displayValue": "2.8 s"
+        },
+        {
+          "id": "bootup-time",
+          "title": "JavaScript execution time",
+          "score": 1,
+          "displayValue": "1.2 s"
+        },
+        {
+          "id": "valid-source-maps",
+          "title": "Missing source maps for large first-party JavaScript",
+          "score": 0,
+          "displayValue": null
+        },
+        {
+          "id": "color-contrast",
+          "title": "Background and foreground colors do not have a sufficient contrast ratio.",
+          "score": 0,
+          "displayValue": null
+        },
+        {
+          "id": "label-content-name-mismatch",
+          "title": "Elements with visible text labels do not have matching accessible names.",
+          "score": 0,
+          "displayValue": null
+        },
+        {
+          "id": "unused-javascript",
+          "title": "Reduce unused JavaScript",
+          "score": 0.5,
+          "displayValue": "Est savings of 21 KiB"
+        },
+        {
+          "id": "meta-description",
+          "title": "Document does not have a meta description",
+          "score": 0,
+          "displayValue": null
+        }
+      ]
+    },
+    {
+      "route": "/treatments/emergency-dentistry",
+      "url": "http://localhost:3000/treatments/emergency-dentistry",
+      "status": "measured",
+      "reason": null,
+      "lighthouseVersion": "13.3.0",
+      "fetchTime": "2026-06-02T17:16:06.632Z",
+      "requestedUrl": "http://localhost:3000/treatments/emergency-dentistry",
+      "finalDisplayedUrl": "http://localhost:3000/treatments/emergency-dentistry",
+      "userAgent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/143.0.0.0 Safari/537.36",
+      "formFactor": "mobile",
+      "throttlingMethod": "simulate",
+      "screenEmulation": {
+        "mobile": true,
+        "width": 412,
+        "height": 823,
+        "deviceScaleFactor": 1.75,
+        "disabled": false
+      },
+      "scores": {
+        "performance": 75,
+        "accessibility": 96,
+        "bestPractices": 100,
+        "seo": 54
+      },
+      "coreWebVitalsLab": {
+        "fcpMs": 1215.6437,
+        "fcpDisplay": "1.2 s",
+        "lcpMs": 2517.2874,
+        "lcpDisplay": "2.5 s",
+        "cls": 0,
+        "clsDisplay": "0",
+        "tbtMs": 1032.9999999999995,
+        "tbtDisplay": "1,030 ms",
+        "inpProxy": "TBT captured as lab proxy; INP is a field metric and was not available in this local lab run.",
+        "speedIndexMs": 1460.4925300053615,
+        "speedIndexDisplay": "1.5 s"
+      },
+      "networkAndWeight": {
+        "totalByteWeight": 462564,
+        "totalByteWeightDisplay": "Total size was 452 KiB",
+        "numRequests": 14,
+        "totalByteWeightDiagnostic": 462564,
+        "mainDocumentTransferSize": 29492
+      },
+      "topActionableAudits": [
+        {
+          "id": "first-contentful-paint",
+          "title": "First Contentful Paint",
+          "score": 0.99,
+          "displayValue": "1.2 s"
+        },
+        {
+          "id": "largest-contentful-paint",
+          "title": "Largest Contentful Paint",
+          "score": 0.89,
+          "displayValue": "2.5 s"
+        },
+        {
+          "id": "speed-index",
+          "title": "Speed Index",
+          "score": 1,
+          "displayValue": "1.5 s"
+        },
+        {
+          "id": "total-blocking-time",
+          "title": "Total Blocking Time",
+          "score": 0.26,
+          "displayValue": "1,030 ms"
+        },
+        {
+          "id": "max-potential-fid",
+          "title": "Max Potential First Input Delay",
+          "score": 0.04,
+          "displayValue": "590 ms"
+        },
+        {
+          "id": "interactive",
+          "title": "Time to Interactive",
+          "score": 0.86,
+          "displayValue": "4.2 s"
+        },
+        {
+          "id": "mainthread-work-breakdown",
+          "title": "Minimize main-thread work",
+          "score": 0,
+          "displayValue": "2.8 s"
+        },
+        {
+          "id": "bootup-time",
+          "title": "JavaScript execution time",
+          "score": 1,
+          "displayValue": "1.2 s"
+        },
+        {
+          "id": "valid-source-maps",
+          "title": "Missing source maps for large first-party JavaScript",
+          "score": 0,
+          "displayValue": null
+        },
+        {
+          "id": "color-contrast",
+          "title": "Background and foreground colors do not have a sufficient contrast ratio.",
+          "score": 0,
+          "displayValue": null
+        },
+        {
+          "id": "label-content-name-mismatch",
+          "title": "Elements with visible text labels do not have matching accessible names.",
+          "score": 0,
+          "displayValue": null
+        },
+        {
+          "id": "unused-javascript",
+          "title": "Reduce unused JavaScript",
+          "score": 0.5,
+          "displayValue": "Est savings of 21 KiB"
+        },
+        {
+          "id": "meta-description",
+          "title": "Document does not have a meta description",
+          "score": 0,
+          "displayValue": null
+        }
+      ]
+    },
+    {
+      "route": "/treatments/implants",
+      "url": "http://localhost:3000/treatments/implants",
+      "status": "measured",
+      "reason": null,
+      "lighthouseVersion": "13.3.0",
+      "fetchTime": "2026-06-02T17:16:24.209Z",
+      "requestedUrl": "http://localhost:3000/treatments/implants",
+      "finalDisplayedUrl": "http://localhost:3000/treatments/implants",
+      "userAgent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/143.0.0.0 Safari/537.36",
+      "formFactor": "mobile",
+      "throttlingMethod": "simulate",
+      "screenEmulation": {
+        "mobile": true,
+        "width": 412,
+        "height": 823,
+        "deviceScaleFactor": 1.75,
+        "disabled": false
+      },
+      "scores": {
+        "performance": 74,
+        "accessibility": 100,
+        "bestPractices": 100,
+        "seo": 54
+      },
+      "coreWebVitalsLab": {
+        "fcpMs": 1205.3182000000002,
+        "fcpDisplay": "1.2 s",
+        "lcpMs": 2529.6364000000003,
+        "lcpDisplay": "2.5 s",
+        "cls": 0,
+        "clsDisplay": "0",
+        "tbtMs": 1104,
+        "tbtDisplay": "1,100 ms",
+        "inpProxy": "TBT captured as lab proxy; INP is a field metric and was not available in this local lab run.",
+        "speedIndexMs": 1510.3246139970413,
+        "speedIndexDisplay": "1.5 s"
+      },
+      "networkAndWeight": {
+        "totalByteWeight": 468834,
+        "totalByteWeightDisplay": "Total size was 458 KiB",
+        "numRequests": 14,
+        "totalByteWeightDiagnostic": 468834,
+        "mainDocumentTransferSize": 35762
+      },
+      "topActionableAudits": [
+        {
+          "id": "first-contentful-paint",
+          "title": "First Contentful Paint",
+          "score": 0.99,
+          "displayValue": "1.2 s"
+        },
+        {
+          "id": "largest-contentful-paint",
+          "title": "Largest Contentful Paint",
+          "score": 0.89,
+          "displayValue": "2.5 s"
+        },
+        {
+          "id": "speed-index",
+          "title": "Speed Index",
+          "score": 1,
+          "displayValue": "1.5 s"
+        },
+        {
+          "id": "total-blocking-time",
+          "title": "Total Blocking Time",
+          "score": 0.23,
+          "displayValue": "1,100 ms"
+        },
+        {
+          "id": "max-potential-fid",
+          "title": "Max Potential First Input Delay",
+          "score": 0.04,
+          "displayValue": "610 ms"
+        },
+        {
+          "id": "interactive",
+          "title": "Time to Interactive",
+          "score": 0.85,
+          "displayValue": "4.2 s"
+        },
+        {
+          "id": "mainthread-work-breakdown",
+          "title": "Minimize main-thread work",
+          "score": 0,
+          "displayValue": "2.8 s"
+        },
+        {
+          "id": "bootup-time",
+          "title": "Reduce JavaScript execution time",
+          "score": 0,
+          "displayValue": "1.3 s"
+        },
+        {
+          "id": "valid-source-maps",
+          "title": "Missing source maps for large first-party JavaScript",
+          "score": 0,
+          "displayValue": null
+        },
+        {
+          "id": "color-contrast",
+          "title": "Background and foreground colors have a sufficient contrast ratio",
+          "score": 1,
+          "displayValue": null
+        },
+        {
+          "id": "label-content-name-mismatch",
+          "title": "Elements with visible text labels do not have matching accessible names.",
+          "score": 0,
+          "displayValue": null
+        },
+        {
+          "id": "unused-javascript",
+          "title": "Reduce unused JavaScript",
+          "score": 0.5,
+          "displayValue": "Est savings of 21 KiB"
+        },
+        {
+          "id": "meta-description",
+          "title": "Document does not have a meta description",
+          "score": 0,
+          "displayValue": null
+        }
+      ]
+    },
+    {
+      "route": "/treatments/clear-aligners-spark",
+      "url": "http://localhost:3000/treatments/clear-aligners-spark",
+      "status": "measured",
+      "reason": null,
+      "lighthouseVersion": "13.3.0",
+      "fetchTime": "2026-06-02T17:16:41.907Z",
+      "requestedUrl": "http://localhost:3000/treatments/clear-aligners-spark",
+      "finalDisplayedUrl": "http://localhost:3000/treatments/clear-aligners-spark",
+      "userAgent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/143.0.0.0 Safari/537.36",
+      "formFactor": "mobile",
+      "throttlingMethod": "simulate",
+      "screenEmulation": {
+        "mobile": true,
+        "width": 412,
+        "height": 823,
+        "deviceScaleFactor": 1.75,
+        "disabled": false
+      },
+      "scores": {
+        "performance": 70,
+        "accessibility": 100,
+        "bestPractices": 100,
+        "seo": 54
+      },
+      "coreWebVitalsLab": {
+        "fcpMs": 1238.067,
+        "fcpDisplay": "1.2 s",
+        "lcpMs": 2738.134,
+        "lcpDisplay": "2.7 s",
+        "cls": 0,
+        "clsDisplay": "0",
+        "tbtMs": 1526,
+        "tbtDisplay": "1,530 ms",
+        "inpProxy": "TBT captured as lab proxy; INP is a field metric and was not available in this local lab run.",
+        "speedIndexMs": 1747.9014979561498,
+        "speedIndexDisplay": "1.7 s"
+      },
+      "networkAndWeight": {
+        "totalByteWeight": 470392,
+        "totalByteWeightDisplay": "Total size was 459 KiB",
+        "numRequests": 14,
+        "totalByteWeightDiagnostic": 470392,
+        "mainDocumentTransferSize": 37320
+      },
+      "topActionableAudits": [
+        {
+          "id": "first-contentful-paint",
+          "title": "First Contentful Paint",
+          "score": 0.99,
+          "displayValue": "1.2 s"
+        },
+        {
+          "id": "largest-contentful-paint",
+          "title": "Largest Contentful Paint",
+          "score": 0.84,
+          "displayValue": "2.7 s"
+        },
+        {
+          "id": "speed-index",
+          "title": "Speed Index",
+          "score": 1,
+          "displayValue": "1.7 s"
+        },
+        {
+          "id": "total-blocking-time",
+          "title": "Total Blocking Time",
+          "score": 0.13,
+          "displayValue": "1,530 ms"
+        },
+        {
+          "id": "max-potential-fid",
+          "title": "Max Potential First Input Delay",
+          "score": 0.03,
+          "displayValue": "640 ms"
+        },
+        {
+          "id": "interactive",
+          "title": "Time to Interactive",
+          "score": 0.84,
+          "displayValue": "4.4 s"
+        },
+        {
+          "id": "mainthread-work-breakdown",
+          "title": "Minimize main-thread work",
+          "score": 0,
+          "displayValue": "3.5 s"
+        },
+        {
+          "id": "bootup-time",
+          "title": "Reduce JavaScript execution time",
+          "score": 0,
+          "displayValue": "1.5 s"
+        },
+        {
+          "id": "valid-source-maps",
+          "title": "Missing source maps for large first-party JavaScript",
+          "score": 0,
+          "displayValue": null
+        },
+        {
+          "id": "color-contrast",
+          "title": "Background and foreground colors have a sufficient contrast ratio",
+          "score": 1,
+          "displayValue": null
+        },
+        {
+          "id": "label-content-name-mismatch",
+          "title": "Elements with visible text labels do not have matching accessible names.",
+          "score": 0,
+          "displayValue": null
+        },
+        {
+          "id": "unused-javascript",
+          "title": "Reduce unused JavaScript",
+          "score": 0.5,
+          "displayValue": "Est savings of 21 KiB"
+        },
+        {
+          "id": "meta-description",
+          "title": "Document does not have a meta description",
+          "score": 0,
+          "displayValue": null
+        }
+      ]
+    },
+    {
+      "route": "/treatments/3d-dentistry-and-technology",
+      "url": "http://localhost:3000/treatments/3d-dentistry-and-technology",
+      "status": "measured",
+      "reason": null,
+      "lighthouseVersion": "13.3.0",
+      "fetchTime": "2026-06-02T17:17:00.661Z",
+      "requestedUrl": "http://localhost:3000/treatments/3d-dentistry-and-technology",
+      "finalDisplayedUrl": "http://localhost:3000/treatments/3d-dentistry-and-technology",
+      "userAgent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/143.0.0.0 Safari/537.36",
+      "formFactor": "mobile",
+      "throttlingMethod": "simulate",
+      "screenEmulation": {
+        "mobile": true,
+        "width": 412,
+        "height": 823,
+        "deviceScaleFactor": 1.75,
+        "disabled": false
+      },
+      "scores": {
+        "performance": 76,
+        "accessibility": 100,
+        "bestPractices": 100,
+        "seo": 54
+      },
+      "coreWebVitalsLab": {
+        "fcpMs": 1304.0844,
+        "fcpDisplay": "1.3 s",
+        "lcpMs": 2579.1687999999995,
+        "lcpDisplay": "2.6 s",
+        "cls": 0,
+        "clsDisplay": "0",
+        "tbtMs": 931.9577999999995,
+        "tbtDisplay": "930 ms",
+        "inpProxy": "TBT captured as lab proxy; INP is a field metric and was not available in this local lab run.",
+        "speedIndexMs": 1396.1644800042309,
+        "speedIndexDisplay": "1.4 s"
+      },
+      "networkAndWeight": {
+        "totalByteWeight": 463786,
+        "totalByteWeightDisplay": "Total size was 453 KiB",
+        "numRequests": 14,
+        "totalByteWeightDiagnostic": 463786,
+        "mainDocumentTransferSize": 30714
+      },
+      "topActionableAudits": [
+        {
+          "id": "first-contentful-paint",
+          "title": "First Contentful Paint",
+          "score": 0.98,
+          "displayValue": "1.3 s"
+        },
+        {
+          "id": "largest-contentful-paint",
+          "title": "Largest Contentful Paint",
+          "score": 0.88,
+          "displayValue": "2.6 s"
+        },
+        {
+          "id": "speed-index",
+          "title": "Speed Index",
+          "score": 1,
+          "displayValue": "1.4 s"
+        },
+        {
+          "id": "total-blocking-time",
+          "title": "Total Blocking Time",
+          "score": 0.3,
+          "displayValue": "930 ms"
+        },
+        {
+          "id": "max-potential-fid",
+          "title": "Max Potential First Input Delay",
+          "score": 0.04,
+          "displayValue": "600 ms"
+        },
+        {
+          "id": "interactive",
+          "title": "Time to Interactive",
+          "score": 0.86,
+          "displayValue": "4.2 s"
+        },
+        {
+          "id": "mainthread-work-breakdown",
+          "title": "Minimize main-thread work",
+          "score": 0,
+          "displayValue": "2.8 s"
+        },
+        {
+          "id": "bootup-time",
+          "title": "JavaScript execution time",
+          "score": 1,
+          "displayValue": "1.3 s"
+        },
+        {
+          "id": "valid-source-maps",
+          "title": "Missing source maps for large first-party JavaScript",
+          "score": 0,
+          "displayValue": null
+        },
+        {
+          "id": "color-contrast",
+          "title": "Background and foreground colors have a sufficient contrast ratio",
+          "score": 1,
+          "displayValue": null
+        },
+        {
+          "id": "label-content-name-mismatch",
+          "title": "Elements with visible text labels do not have matching accessible names.",
+          "score": 0,
+          "displayValue": null
+        },
+        {
+          "id": "unused-javascript",
+          "title": "Reduce unused JavaScript",
+          "score": 0.5,
+          "displayValue": "Est savings of 21 KiB"
+        },
+        {
+          "id": "meta-description",
+          "title": "Document does not have a meta description",
+          "score": 0,
+          "displayValue": null
+        }
+      ]
+    },
+    {
+      "route": "/treatments/sedation-dentistry",
+      "url": "http://localhost:3000/treatments/sedation-dentistry",
+      "status": "measured",
+      "reason": null,
+      "lighthouseVersion": "13.3.0",
+      "fetchTime": "2026-06-02T17:17:18.494Z",
+      "requestedUrl": "http://localhost:3000/treatments/sedation-dentistry",
+      "finalDisplayedUrl": "http://localhost:3000/treatments/sedation-dentistry",
+      "userAgent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/143.0.0.0 Safari/537.36",
+      "formFactor": "mobile",
+      "throttlingMethod": "simulate",
+      "screenEmulation": {
+        "mobile": true,
+        "width": 412,
+        "height": 823,
+        "deviceScaleFactor": 1.75,
+        "disabled": false
+      },
+      "scores": {
+        "performance": 77,
+        "accessibility": 100,
+        "bestPractices": 100,
+        "seo": 54
+      },
+      "coreWebVitalsLab": {
+        "fcpMs": 1328.1695499999998,
+        "fcpDisplay": "1.3 s",
+        "lcpMs": 2495.3390999999997,
+        "lcpDisplay": "2.5 s",
+        "cls": 0,
+        "clsDisplay": "0",
+        "tbtMs": 875.9999999999998,
+        "tbtDisplay": "880 ms",
+        "inpProxy": "TBT captured as lab proxy; INP is a field metric and was not available in this local lab run.",
+        "speedIndexMs": 1414.036400004886,
+        "speedIndexDisplay": "1.4 s"
+      },
+      "networkAndWeight": {
+        "totalByteWeight": 463107,
+        "totalByteWeightDisplay": "Total size was 452 KiB",
+        "numRequests": 14,
+        "totalByteWeightDiagnostic": 463107,
+        "mainDocumentTransferSize": 30035
+      },
+      "topActionableAudits": [
+        {
+          "id": "first-contentful-paint",
+          "title": "First Contentful Paint",
+          "score": 0.98,
+          "displayValue": "1.3 s"
+        },
+        {
+          "id": "largest-contentful-paint",
+          "title": "Largest Contentful Paint",
+          "score": 0.9,
+          "displayValue": "2.5 s"
+        },
+        {
+          "id": "speed-index",
+          "title": "Speed Index",
+          "score": 1,
+          "displayValue": "1.4 s"
+        },
+        {
+          "id": "total-blocking-time",
+          "title": "Total Blocking Time",
+          "score": 0.32,
+          "displayValue": "880 ms"
+        },
+        {
+          "id": "max-potential-fid",
+          "title": "Max Potential First Input Delay",
+          "score": 0.04,
+          "displayValue": "600 ms"
+        },
+        {
+          "id": "interactive",
+          "title": "Time to Interactive",
+          "score": 0.85,
+          "displayValue": "4.3 s"
+        },
+        {
+          "id": "mainthread-work-breakdown",
+          "title": "Minimize main-thread work",
+          "score": 0,
+          "displayValue": "2.8 s"
+        },
+        {
+          "id": "bootup-time",
+          "title": "JavaScript execution time",
+          "score": 1,
+          "displayValue": "1.2 s"
+        },
+        {
+          "id": "valid-source-maps",
+          "title": "Missing source maps for large first-party JavaScript",
+          "score": 0,
+          "displayValue": null
+        },
+        {
+          "id": "color-contrast",
+          "title": "Background and foreground colors have a sufficient contrast ratio",
+          "score": 1,
+          "displayValue": null
+        },
+        {
+          "id": "label-content-name-mismatch",
+          "title": "Elements with visible text labels do not have matching accessible names.",
+          "score": 0,
+          "displayValue": null
+        },
+        {
+          "id": "unused-javascript",
+          "title": "Reduce unused JavaScript",
+          "score": 0.5,
+          "displayValue": "Est savings of 21 KiB"
+        },
+        {
+          "id": "meta-description",
+          "title": "Document does not have a meta description",
+          "score": 0,
+          "displayValue": null
+        }
+      ]
+    },
+    {
+      "route": "/treatments/preventative-and-general-dentistry",
+      "url": "http://localhost:3000/treatments/preventative-and-general-dentistry",
+      "status": "measured",
+      "reason": null,
+      "lighthouseVersion": "13.3.0",
+      "fetchTime": "2026-06-02T17:17:36.291Z",
+      "requestedUrl": "http://localhost:3000/treatments/preventative-and-general-dentistry",
+      "finalDisplayedUrl": "http://localhost:3000/treatments/preventative-and-general-dentistry",
+      "userAgent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/143.0.0.0 Safari/537.36",
+      "formFactor": "mobile",
+      "throttlingMethod": "simulate",
+      "screenEmulation": {
+        "mobile": true,
+        "width": 412,
+        "height": 823,
+        "deviceScaleFactor": 1.75,
+        "disabled": false
+      },
+      "scores": {
+        "performance": 75,
+        "accessibility": 100,
+        "bestPractices": 100,
+        "seo": 54
+      },
+      "coreWebVitalsLab": {
+        "fcpMs": 1300.9270999999999,
+        "fcpDisplay": "1.3 s",
+        "lcpMs": 2566.3542,
+        "lcpDisplay": "2.6 s",
+        "cls": 0,
+        "clsDisplay": "0",
+        "tbtMs": 1016.9999999999998,
+        "tbtDisplay": "1,020 ms",
+        "inpProxy": "TBT captured as lab proxy; INP is a field metric and was not available in this local lab run.",
+        "speedIndexMs": 1441.7798499932696,
+        "speedIndexDisplay": "1.4 s"
+      },
+      "networkAndWeight": {
+        "totalByteWeight": 465575,
+        "totalByteWeightDisplay": "Total size was 455 KiB",
+        "numRequests": 14,
+        "totalByteWeightDiagnostic": 465575,
+        "mainDocumentTransferSize": 32503
+      },
+      "topActionableAudits": [
+        {
+          "id": "first-contentful-paint",
+          "title": "First Contentful Paint",
+          "score": 0.98,
+          "displayValue": "1.3 s"
+        },
+        {
+          "id": "largest-contentful-paint",
+          "title": "Largest Contentful Paint",
+          "score": 0.88,
+          "displayValue": "2.6 s"
+        },
+        {
+          "id": "speed-index",
+          "title": "Speed Index",
+          "score": 1,
+          "displayValue": "1.4 s"
+        },
+        {
+          "id": "total-blocking-time",
+          "title": "Total Blocking Time",
+          "score": 0.26,
+          "displayValue": "1,020 ms"
+        },
+        {
+          "id": "max-potential-fid",
+          "title": "Max Potential First Input Delay",
+          "score": 0.04,
+          "displayValue": "610 ms"
+        },
+        {
+          "id": "interactive",
+          "title": "Time to Interactive",
+          "score": 0.85,
+          "displayValue": "4.2 s"
+        },
+        {
+          "id": "mainthread-work-breakdown",
+          "title": "Minimize main-thread work",
+          "score": 0,
+          "displayValue": "2.9 s"
+        },
+        {
+          "id": "bootup-time",
+          "title": "Reduce JavaScript execution time",
+          "score": 0,
+          "displayValue": "1.4 s"
+        },
+        {
+          "id": "valid-source-maps",
+          "title": "Missing source maps for large first-party JavaScript",
+          "score": 0,
+          "displayValue": null
+        },
+        {
+          "id": "color-contrast",
+          "title": "Background and foreground colors have a sufficient contrast ratio",
+          "score": 1,
+          "displayValue": null
+        },
+        {
+          "id": "label-content-name-mismatch",
+          "title": "Elements with visible text labels do not have matching accessible names.",
+          "score": 0,
+          "displayValue": null
+        },
+        {
+          "id": "unused-javascript",
+          "title": "Reduce unused JavaScript",
+          "score": 0,
+          "displayValue": "Est savings of 21 KiB"
+        },
+        {
+          "id": "meta-description",
+          "title": "Document does not have a meta description",
+          "score": 0,
+          "displayValue": null
+        }
+      ]
+    }
+  ]
+}

--- a/tools/audits/lighthouse-cwv-mobile-accessibility-evidence-rerun/LIGHTHOUSE_CWV_MOBILE_ACCESSIBILITY_RERUN_REPORT_V1.md
+++ b/tools/audits/lighthouse-cwv-mobile-accessibility-evidence-rerun/LIGHTHOUSE_CWV_MOBILE_ACCESSIBILITY_RERUN_REPORT_V1.md
@@ -1,0 +1,66 @@
+# Lighthouse / CWV / Mobile / Accessibility Evidence Rerun Report V1
+
+Generated: 2026-06-02T17:19:58.990Z
+
+## Classification
+
+READY_FOR_FINAL_CERTIFICATION_RECHECK
+
+## Route availability
+
+8/8 required routes returned HTTP 200 in the local production server rerun.
+
+- /: HTTP 200
+- /contact: HTTP 200
+- /treatments/emergency-dentistry: HTTP 200
+- /treatments/implants: HTTP 200
+- /treatments/clear-aligners-spark: HTTP 200
+- /treatments/3d-dentistry-and-technology: HTTP 200
+- /treatments/sedation-dentistry: HTTP 200
+- /treatments/preventative-and-general-dentistry: HTTP 200
+
+## Lighthouse / CWV-style lab evidence
+
+8/8 routes produced Lighthouse JSON under mobile form-factor lab settings. INP is unavailable in local Lighthouse lab evidence, so Total Blocking Time is recorded as the INP proxy.
+
+| Route | Perf | A11y | FCP | LCP | CLS | TBT |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| / | 75 | 96 | 1.3 s | 2.3 s | 0 | 1,120 ms |
+| /contact | 75 | 96 | 1.3 s | 2.5 s | 0 | 1,070 ms |
+| /treatments/emergency-dentistry | 75 | 96 | 1.2 s | 2.5 s | 0 | 1,030 ms |
+| /treatments/implants | 74 | 100 | 1.2 s | 2.5 s | 0 | 1,100 ms |
+| /treatments/clear-aligners-spark | 70 | 100 | 1.2 s | 2.7 s | 0 | 1,530 ms |
+| /treatments/3d-dentistry-and-technology | 76 | 100 | 1.3 s | 2.6 s | 0 | 930 ms |
+| /treatments/sedation-dentistry | 77 | 100 | 1.3 s | 2.5 s | 0 | 880 ms |
+| /treatments/preventative-and-general-dentistry | 75 | 100 | 1.3 s | 2.6 s | 0 | 1,020 ms |
+
+## Mobile readiness evidence
+
+8/8 routes passed the Playwright mobile viewport evidence checks at 390x844.
+
+## Accessibility evidence
+
+8/8 routes passed basic automated accessibility heuristics. axe-core was not installed, so no dependency was added; Lighthouse accessibility scores and DOM heuristics are recorded.
+
+## Remaining performance risks
+
+- /: high_total_blocking_time_inp_proxy (medium) — 1,120 ms
+- /: lighthouse_accessibility_below_100 (low) — 96
+- /contact: high_total_blocking_time_inp_proxy (medium) — 1,070 ms
+- /contact: lighthouse_accessibility_below_100 (low) — 96
+- /treatments/emergency-dentistry: high_total_blocking_time_inp_proxy (medium) — 1,030 ms
+- /treatments/emergency-dentistry: lcp_above_good_lab_threshold (medium) — 2.5 s
+- /treatments/emergency-dentistry: lighthouse_accessibility_below_100 (low) — 96
+- /treatments/implants: high_total_blocking_time_inp_proxy (medium) — 1,100 ms
+- /treatments/implants: lcp_above_good_lab_threshold (medium) — 2.5 s
+- /treatments/clear-aligners-spark: high_total_blocking_time_inp_proxy (medium) — 1,530 ms
+- /treatments/clear-aligners-spark: lcp_above_good_lab_threshold (medium) — 2.7 s
+- /treatments/3d-dentistry-and-technology: high_total_blocking_time_inp_proxy (medium) — 930 ms
+- /treatments/3d-dentistry-and-technology: lcp_above_good_lab_threshold (medium) — 2.6 s
+- /treatments/sedation-dentistry: high_total_blocking_time_inp_proxy (medium) — 880 ms
+- /treatments/preventative-and-general-dentistry: high_total_blocking_time_inp_proxy (medium) — 1,020 ms
+- /treatments/preventative-and-general-dentistry: lcp_above_good_lab_threshold (medium) — 2.6 s
+
+## Recommendation
+
+READY_FOR_FINAL_CERTIFICATION_RECHECK

--- a/tools/audits/lighthouse-cwv-mobile-accessibility-evidence-rerun/LIGHTHOUSE_ROUTE_RESULTS_RERUN_V1.json
+++ b/tools/audits/lighthouse-cwv-mobile-accessibility-evidence-rerun/LIGHTHOUSE_ROUTE_RESULTS_RERUN_V1.json
@@ -1,0 +1,1072 @@
+{
+  "generatedAt": "2026-06-02T17:19:58.990Z",
+  "baseUrl": "http://localhost:3000",
+  "routes": [
+    {
+      "route": "/",
+      "url": "http://localhost:3000/",
+      "status": 200,
+      "ok": true,
+      "checkedBy": "curl and Playwright production server verification"
+    },
+    {
+      "route": "/contact",
+      "url": "http://localhost:3000/contact",
+      "status": 200,
+      "ok": true,
+      "checkedBy": "curl and Playwright production server verification"
+    },
+    {
+      "route": "/treatments/emergency-dentistry",
+      "url": "http://localhost:3000/treatments/emergency-dentistry",
+      "status": 200,
+      "ok": true,
+      "checkedBy": "curl and Playwright production server verification"
+    },
+    {
+      "route": "/treatments/implants",
+      "url": "http://localhost:3000/treatments/implants",
+      "status": 200,
+      "ok": true,
+      "checkedBy": "curl and Playwright production server verification"
+    },
+    {
+      "route": "/treatments/clear-aligners-spark",
+      "url": "http://localhost:3000/treatments/clear-aligners-spark",
+      "status": 200,
+      "ok": true,
+      "checkedBy": "curl and Playwright production server verification"
+    },
+    {
+      "route": "/treatments/3d-dentistry-and-technology",
+      "url": "http://localhost:3000/treatments/3d-dentistry-and-technology",
+      "status": 200,
+      "ok": true,
+      "checkedBy": "curl and Playwright production server verification"
+    },
+    {
+      "route": "/treatments/sedation-dentistry",
+      "url": "http://localhost:3000/treatments/sedation-dentistry",
+      "status": 200,
+      "ok": true,
+      "checkedBy": "curl and Playwright production server verification"
+    },
+    {
+      "route": "/treatments/preventative-and-general-dentistry",
+      "url": "http://localhost:3000/treatments/preventative-and-general-dentistry",
+      "status": 200,
+      "ok": true,
+      "checkedBy": "curl and Playwright production server verification"
+    }
+  ],
+  "lighthouseResults": [
+    {
+      "route": "/",
+      "url": "http://localhost:3000/",
+      "status": "measured",
+      "reason": null,
+      "lighthouseVersion": "13.3.0",
+      "fetchTime": "2026-06-02T17:15:30.148Z",
+      "requestedUrl": "http://localhost:3000/",
+      "finalDisplayedUrl": "http://localhost:3000/",
+      "userAgent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/143.0.0.0 Safari/537.36",
+      "formFactor": "mobile",
+      "throttlingMethod": "simulate",
+      "screenEmulation": {
+        "mobile": true,
+        "width": 412,
+        "height": 823,
+        "deviceScaleFactor": 1.75,
+        "disabled": false
+      },
+      "scores": {
+        "performance": 75,
+        "accessibility": 96,
+        "bestPractices": 100,
+        "seo": 54
+      },
+      "coreWebVitalsLab": {
+        "fcpMs": 1336.9295,
+        "fcpDisplay": "1.3 s",
+        "lcpMs": 2333.8589999999995,
+        "lcpDisplay": "2.3 s",
+        "cls": 0,
+        "clsDisplay": "0",
+        "tbtMs": 1119.9999999999995,
+        "tbtDisplay": "1,120 ms",
+        "inpProxy": "TBT captured as lab proxy; INP is a field metric and was not available in this local lab run.",
+        "speedIndexMs": 1473.0147065946535,
+        "speedIndexDisplay": "1.5 s"
+      },
+      "networkAndWeight": {
+        "totalByteWeight": 473019,
+        "totalByteWeightDisplay": "Total size was 462 KiB",
+        "numRequests": 14,
+        "totalByteWeightDiagnostic": 473019,
+        "mainDocumentTransferSize": 39947
+      },
+      "topActionableAudits": [
+        {
+          "id": "first-contentful-paint",
+          "title": "First Contentful Paint",
+          "score": 0.98,
+          "displayValue": "1.3 s"
+        },
+        {
+          "id": "largest-contentful-paint",
+          "title": "Largest Contentful Paint",
+          "score": 0.93,
+          "displayValue": "2.3 s"
+        },
+        {
+          "id": "speed-index",
+          "title": "Speed Index",
+          "score": 1,
+          "displayValue": "1.5 s"
+        },
+        {
+          "id": "total-blocking-time",
+          "title": "Total Blocking Time",
+          "score": 0.23,
+          "displayValue": "1,120 ms"
+        },
+        {
+          "id": "max-potential-fid",
+          "title": "Max Potential First Input Delay",
+          "score": 0.03,
+          "displayValue": "650 ms"
+        },
+        {
+          "id": "interactive",
+          "title": "Time to Interactive",
+          "score": 0.85,
+          "displayValue": "4.2 s"
+        },
+        {
+          "id": "mainthread-work-breakdown",
+          "title": "Minimize main-thread work",
+          "score": 0,
+          "displayValue": "3.5 s"
+        },
+        {
+          "id": "bootup-time",
+          "title": "Reduce JavaScript execution time",
+          "score": 0,
+          "displayValue": "1.3 s"
+        },
+        {
+          "id": "valid-source-maps",
+          "title": "Missing source maps for large first-party JavaScript",
+          "score": 0,
+          "displayValue": null
+        },
+        {
+          "id": "color-contrast",
+          "title": "Background and foreground colors do not have a sufficient contrast ratio.",
+          "score": 0,
+          "displayValue": null
+        },
+        {
+          "id": "label-content-name-mismatch",
+          "title": "Elements with visible text labels do not have matching accessible names.",
+          "score": 0,
+          "displayValue": null
+        },
+        {
+          "id": "unused-javascript",
+          "title": "Reduce unused JavaScript",
+          "score": 0.5,
+          "displayValue": "Est savings of 21 KiB"
+        },
+        {
+          "id": "meta-description",
+          "title": "Document does not have a meta description",
+          "score": 0,
+          "displayValue": null
+        }
+      ]
+    },
+    {
+      "route": "/contact",
+      "url": "http://localhost:3000/contact",
+      "status": "measured",
+      "reason": null,
+      "lighthouseVersion": "13.3.0",
+      "fetchTime": "2026-06-02T17:15:49.138Z",
+      "requestedUrl": "http://localhost:3000/contact",
+      "finalDisplayedUrl": "http://localhost:3000/contact",
+      "userAgent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/143.0.0.0 Safari/537.36",
+      "formFactor": "mobile",
+      "throttlingMethod": "simulate",
+      "screenEmulation": {
+        "mobile": true,
+        "width": 412,
+        "height": 823,
+        "deviceScaleFactor": 1.75,
+        "disabled": false
+      },
+      "scores": {
+        "performance": 75,
+        "accessibility": 96,
+        "bestPractices": 100,
+        "seo": 54
+      },
+      "coreWebVitalsLab": {
+        "fcpMs": 1268.5819999999999,
+        "fcpDisplay": "1.3 s",
+        "lcpMs": 2469.164,
+        "lcpDisplay": "2.5 s",
+        "cls": 0,
+        "clsDisplay": "0",
+        "tbtMs": 1068,
+        "tbtDisplay": "1,070 ms",
+        "inpProxy": "TBT captured as lab proxy; INP is a field metric and was not available in this local lab run.",
+        "speedIndexMs": 1338.662251997444,
+        "speedIndexDisplay": "1.3 s"
+      },
+      "networkAndWeight": {
+        "totalByteWeight": 455473,
+        "totalByteWeightDisplay": "Total size was 445 KiB",
+        "numRequests": 14,
+        "totalByteWeightDiagnostic": 455473,
+        "mainDocumentTransferSize": 22401
+      },
+      "topActionableAudits": [
+        {
+          "id": "first-contentful-paint",
+          "title": "First Contentful Paint",
+          "score": 0.98,
+          "displayValue": "1.3 s"
+        },
+        {
+          "id": "largest-contentful-paint",
+          "title": "Largest Contentful Paint",
+          "score": 0.9,
+          "displayValue": "2.5 s"
+        },
+        {
+          "id": "speed-index",
+          "title": "Speed Index",
+          "score": 1,
+          "displayValue": "1.3 s"
+        },
+        {
+          "id": "total-blocking-time",
+          "title": "Total Blocking Time",
+          "score": 0.25,
+          "displayValue": "1,070 ms"
+        },
+        {
+          "id": "max-potential-fid",
+          "title": "Max Potential First Input Delay",
+          "score": 0.02,
+          "displayValue": "670 ms"
+        },
+        {
+          "id": "interactive",
+          "title": "Time to Interactive",
+          "score": 0.87,
+          "displayValue": "4.1 s"
+        },
+        {
+          "id": "mainthread-work-breakdown",
+          "title": "Minimize main-thread work",
+          "score": 0,
+          "displayValue": "2.8 s"
+        },
+        {
+          "id": "bootup-time",
+          "title": "JavaScript execution time",
+          "score": 1,
+          "displayValue": "1.2 s"
+        },
+        {
+          "id": "valid-source-maps",
+          "title": "Missing source maps for large first-party JavaScript",
+          "score": 0,
+          "displayValue": null
+        },
+        {
+          "id": "color-contrast",
+          "title": "Background and foreground colors do not have a sufficient contrast ratio.",
+          "score": 0,
+          "displayValue": null
+        },
+        {
+          "id": "label-content-name-mismatch",
+          "title": "Elements with visible text labels do not have matching accessible names.",
+          "score": 0,
+          "displayValue": null
+        },
+        {
+          "id": "unused-javascript",
+          "title": "Reduce unused JavaScript",
+          "score": 0.5,
+          "displayValue": "Est savings of 21 KiB"
+        },
+        {
+          "id": "meta-description",
+          "title": "Document does not have a meta description",
+          "score": 0,
+          "displayValue": null
+        }
+      ]
+    },
+    {
+      "route": "/treatments/emergency-dentistry",
+      "url": "http://localhost:3000/treatments/emergency-dentistry",
+      "status": "measured",
+      "reason": null,
+      "lighthouseVersion": "13.3.0",
+      "fetchTime": "2026-06-02T17:16:06.632Z",
+      "requestedUrl": "http://localhost:3000/treatments/emergency-dentistry",
+      "finalDisplayedUrl": "http://localhost:3000/treatments/emergency-dentistry",
+      "userAgent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/143.0.0.0 Safari/537.36",
+      "formFactor": "mobile",
+      "throttlingMethod": "simulate",
+      "screenEmulation": {
+        "mobile": true,
+        "width": 412,
+        "height": 823,
+        "deviceScaleFactor": 1.75,
+        "disabled": false
+      },
+      "scores": {
+        "performance": 75,
+        "accessibility": 96,
+        "bestPractices": 100,
+        "seo": 54
+      },
+      "coreWebVitalsLab": {
+        "fcpMs": 1215.6437,
+        "fcpDisplay": "1.2 s",
+        "lcpMs": 2517.2874,
+        "lcpDisplay": "2.5 s",
+        "cls": 0,
+        "clsDisplay": "0",
+        "tbtMs": 1032.9999999999995,
+        "tbtDisplay": "1,030 ms",
+        "inpProxy": "TBT captured as lab proxy; INP is a field metric and was not available in this local lab run.",
+        "speedIndexMs": 1460.4925300053615,
+        "speedIndexDisplay": "1.5 s"
+      },
+      "networkAndWeight": {
+        "totalByteWeight": 462564,
+        "totalByteWeightDisplay": "Total size was 452 KiB",
+        "numRequests": 14,
+        "totalByteWeightDiagnostic": 462564,
+        "mainDocumentTransferSize": 29492
+      },
+      "topActionableAudits": [
+        {
+          "id": "first-contentful-paint",
+          "title": "First Contentful Paint",
+          "score": 0.99,
+          "displayValue": "1.2 s"
+        },
+        {
+          "id": "largest-contentful-paint",
+          "title": "Largest Contentful Paint",
+          "score": 0.89,
+          "displayValue": "2.5 s"
+        },
+        {
+          "id": "speed-index",
+          "title": "Speed Index",
+          "score": 1,
+          "displayValue": "1.5 s"
+        },
+        {
+          "id": "total-blocking-time",
+          "title": "Total Blocking Time",
+          "score": 0.26,
+          "displayValue": "1,030 ms"
+        },
+        {
+          "id": "max-potential-fid",
+          "title": "Max Potential First Input Delay",
+          "score": 0.04,
+          "displayValue": "590 ms"
+        },
+        {
+          "id": "interactive",
+          "title": "Time to Interactive",
+          "score": 0.86,
+          "displayValue": "4.2 s"
+        },
+        {
+          "id": "mainthread-work-breakdown",
+          "title": "Minimize main-thread work",
+          "score": 0,
+          "displayValue": "2.8 s"
+        },
+        {
+          "id": "bootup-time",
+          "title": "JavaScript execution time",
+          "score": 1,
+          "displayValue": "1.2 s"
+        },
+        {
+          "id": "valid-source-maps",
+          "title": "Missing source maps for large first-party JavaScript",
+          "score": 0,
+          "displayValue": null
+        },
+        {
+          "id": "color-contrast",
+          "title": "Background and foreground colors do not have a sufficient contrast ratio.",
+          "score": 0,
+          "displayValue": null
+        },
+        {
+          "id": "label-content-name-mismatch",
+          "title": "Elements with visible text labels do not have matching accessible names.",
+          "score": 0,
+          "displayValue": null
+        },
+        {
+          "id": "unused-javascript",
+          "title": "Reduce unused JavaScript",
+          "score": 0.5,
+          "displayValue": "Est savings of 21 KiB"
+        },
+        {
+          "id": "meta-description",
+          "title": "Document does not have a meta description",
+          "score": 0,
+          "displayValue": null
+        }
+      ]
+    },
+    {
+      "route": "/treatments/implants",
+      "url": "http://localhost:3000/treatments/implants",
+      "status": "measured",
+      "reason": null,
+      "lighthouseVersion": "13.3.0",
+      "fetchTime": "2026-06-02T17:16:24.209Z",
+      "requestedUrl": "http://localhost:3000/treatments/implants",
+      "finalDisplayedUrl": "http://localhost:3000/treatments/implants",
+      "userAgent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/143.0.0.0 Safari/537.36",
+      "formFactor": "mobile",
+      "throttlingMethod": "simulate",
+      "screenEmulation": {
+        "mobile": true,
+        "width": 412,
+        "height": 823,
+        "deviceScaleFactor": 1.75,
+        "disabled": false
+      },
+      "scores": {
+        "performance": 74,
+        "accessibility": 100,
+        "bestPractices": 100,
+        "seo": 54
+      },
+      "coreWebVitalsLab": {
+        "fcpMs": 1205.3182000000002,
+        "fcpDisplay": "1.2 s",
+        "lcpMs": 2529.6364000000003,
+        "lcpDisplay": "2.5 s",
+        "cls": 0,
+        "clsDisplay": "0",
+        "tbtMs": 1104,
+        "tbtDisplay": "1,100 ms",
+        "inpProxy": "TBT captured as lab proxy; INP is a field metric and was not available in this local lab run.",
+        "speedIndexMs": 1510.3246139970413,
+        "speedIndexDisplay": "1.5 s"
+      },
+      "networkAndWeight": {
+        "totalByteWeight": 468834,
+        "totalByteWeightDisplay": "Total size was 458 KiB",
+        "numRequests": 14,
+        "totalByteWeightDiagnostic": 468834,
+        "mainDocumentTransferSize": 35762
+      },
+      "topActionableAudits": [
+        {
+          "id": "first-contentful-paint",
+          "title": "First Contentful Paint",
+          "score": 0.99,
+          "displayValue": "1.2 s"
+        },
+        {
+          "id": "largest-contentful-paint",
+          "title": "Largest Contentful Paint",
+          "score": 0.89,
+          "displayValue": "2.5 s"
+        },
+        {
+          "id": "speed-index",
+          "title": "Speed Index",
+          "score": 1,
+          "displayValue": "1.5 s"
+        },
+        {
+          "id": "total-blocking-time",
+          "title": "Total Blocking Time",
+          "score": 0.23,
+          "displayValue": "1,100 ms"
+        },
+        {
+          "id": "max-potential-fid",
+          "title": "Max Potential First Input Delay",
+          "score": 0.04,
+          "displayValue": "610 ms"
+        },
+        {
+          "id": "interactive",
+          "title": "Time to Interactive",
+          "score": 0.85,
+          "displayValue": "4.2 s"
+        },
+        {
+          "id": "mainthread-work-breakdown",
+          "title": "Minimize main-thread work",
+          "score": 0,
+          "displayValue": "2.8 s"
+        },
+        {
+          "id": "bootup-time",
+          "title": "Reduce JavaScript execution time",
+          "score": 0,
+          "displayValue": "1.3 s"
+        },
+        {
+          "id": "valid-source-maps",
+          "title": "Missing source maps for large first-party JavaScript",
+          "score": 0,
+          "displayValue": null
+        },
+        {
+          "id": "color-contrast",
+          "title": "Background and foreground colors have a sufficient contrast ratio",
+          "score": 1,
+          "displayValue": null
+        },
+        {
+          "id": "label-content-name-mismatch",
+          "title": "Elements with visible text labels do not have matching accessible names.",
+          "score": 0,
+          "displayValue": null
+        },
+        {
+          "id": "unused-javascript",
+          "title": "Reduce unused JavaScript",
+          "score": 0.5,
+          "displayValue": "Est savings of 21 KiB"
+        },
+        {
+          "id": "meta-description",
+          "title": "Document does not have a meta description",
+          "score": 0,
+          "displayValue": null
+        }
+      ]
+    },
+    {
+      "route": "/treatments/clear-aligners-spark",
+      "url": "http://localhost:3000/treatments/clear-aligners-spark",
+      "status": "measured",
+      "reason": null,
+      "lighthouseVersion": "13.3.0",
+      "fetchTime": "2026-06-02T17:16:41.907Z",
+      "requestedUrl": "http://localhost:3000/treatments/clear-aligners-spark",
+      "finalDisplayedUrl": "http://localhost:3000/treatments/clear-aligners-spark",
+      "userAgent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/143.0.0.0 Safari/537.36",
+      "formFactor": "mobile",
+      "throttlingMethod": "simulate",
+      "screenEmulation": {
+        "mobile": true,
+        "width": 412,
+        "height": 823,
+        "deviceScaleFactor": 1.75,
+        "disabled": false
+      },
+      "scores": {
+        "performance": 70,
+        "accessibility": 100,
+        "bestPractices": 100,
+        "seo": 54
+      },
+      "coreWebVitalsLab": {
+        "fcpMs": 1238.067,
+        "fcpDisplay": "1.2 s",
+        "lcpMs": 2738.134,
+        "lcpDisplay": "2.7 s",
+        "cls": 0,
+        "clsDisplay": "0",
+        "tbtMs": 1526,
+        "tbtDisplay": "1,530 ms",
+        "inpProxy": "TBT captured as lab proxy; INP is a field metric and was not available in this local lab run.",
+        "speedIndexMs": 1747.9014979561498,
+        "speedIndexDisplay": "1.7 s"
+      },
+      "networkAndWeight": {
+        "totalByteWeight": 470392,
+        "totalByteWeightDisplay": "Total size was 459 KiB",
+        "numRequests": 14,
+        "totalByteWeightDiagnostic": 470392,
+        "mainDocumentTransferSize": 37320
+      },
+      "topActionableAudits": [
+        {
+          "id": "first-contentful-paint",
+          "title": "First Contentful Paint",
+          "score": 0.99,
+          "displayValue": "1.2 s"
+        },
+        {
+          "id": "largest-contentful-paint",
+          "title": "Largest Contentful Paint",
+          "score": 0.84,
+          "displayValue": "2.7 s"
+        },
+        {
+          "id": "speed-index",
+          "title": "Speed Index",
+          "score": 1,
+          "displayValue": "1.7 s"
+        },
+        {
+          "id": "total-blocking-time",
+          "title": "Total Blocking Time",
+          "score": 0.13,
+          "displayValue": "1,530 ms"
+        },
+        {
+          "id": "max-potential-fid",
+          "title": "Max Potential First Input Delay",
+          "score": 0.03,
+          "displayValue": "640 ms"
+        },
+        {
+          "id": "interactive",
+          "title": "Time to Interactive",
+          "score": 0.84,
+          "displayValue": "4.4 s"
+        },
+        {
+          "id": "mainthread-work-breakdown",
+          "title": "Minimize main-thread work",
+          "score": 0,
+          "displayValue": "3.5 s"
+        },
+        {
+          "id": "bootup-time",
+          "title": "Reduce JavaScript execution time",
+          "score": 0,
+          "displayValue": "1.5 s"
+        },
+        {
+          "id": "valid-source-maps",
+          "title": "Missing source maps for large first-party JavaScript",
+          "score": 0,
+          "displayValue": null
+        },
+        {
+          "id": "color-contrast",
+          "title": "Background and foreground colors have a sufficient contrast ratio",
+          "score": 1,
+          "displayValue": null
+        },
+        {
+          "id": "label-content-name-mismatch",
+          "title": "Elements with visible text labels do not have matching accessible names.",
+          "score": 0,
+          "displayValue": null
+        },
+        {
+          "id": "unused-javascript",
+          "title": "Reduce unused JavaScript",
+          "score": 0.5,
+          "displayValue": "Est savings of 21 KiB"
+        },
+        {
+          "id": "meta-description",
+          "title": "Document does not have a meta description",
+          "score": 0,
+          "displayValue": null
+        }
+      ]
+    },
+    {
+      "route": "/treatments/3d-dentistry-and-technology",
+      "url": "http://localhost:3000/treatments/3d-dentistry-and-technology",
+      "status": "measured",
+      "reason": null,
+      "lighthouseVersion": "13.3.0",
+      "fetchTime": "2026-06-02T17:17:00.661Z",
+      "requestedUrl": "http://localhost:3000/treatments/3d-dentistry-and-technology",
+      "finalDisplayedUrl": "http://localhost:3000/treatments/3d-dentistry-and-technology",
+      "userAgent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/143.0.0.0 Safari/537.36",
+      "formFactor": "mobile",
+      "throttlingMethod": "simulate",
+      "screenEmulation": {
+        "mobile": true,
+        "width": 412,
+        "height": 823,
+        "deviceScaleFactor": 1.75,
+        "disabled": false
+      },
+      "scores": {
+        "performance": 76,
+        "accessibility": 100,
+        "bestPractices": 100,
+        "seo": 54
+      },
+      "coreWebVitalsLab": {
+        "fcpMs": 1304.0844,
+        "fcpDisplay": "1.3 s",
+        "lcpMs": 2579.1687999999995,
+        "lcpDisplay": "2.6 s",
+        "cls": 0,
+        "clsDisplay": "0",
+        "tbtMs": 931.9577999999995,
+        "tbtDisplay": "930 ms",
+        "inpProxy": "TBT captured as lab proxy; INP is a field metric and was not available in this local lab run.",
+        "speedIndexMs": 1396.1644800042309,
+        "speedIndexDisplay": "1.4 s"
+      },
+      "networkAndWeight": {
+        "totalByteWeight": 463786,
+        "totalByteWeightDisplay": "Total size was 453 KiB",
+        "numRequests": 14,
+        "totalByteWeightDiagnostic": 463786,
+        "mainDocumentTransferSize": 30714
+      },
+      "topActionableAudits": [
+        {
+          "id": "first-contentful-paint",
+          "title": "First Contentful Paint",
+          "score": 0.98,
+          "displayValue": "1.3 s"
+        },
+        {
+          "id": "largest-contentful-paint",
+          "title": "Largest Contentful Paint",
+          "score": 0.88,
+          "displayValue": "2.6 s"
+        },
+        {
+          "id": "speed-index",
+          "title": "Speed Index",
+          "score": 1,
+          "displayValue": "1.4 s"
+        },
+        {
+          "id": "total-blocking-time",
+          "title": "Total Blocking Time",
+          "score": 0.3,
+          "displayValue": "930 ms"
+        },
+        {
+          "id": "max-potential-fid",
+          "title": "Max Potential First Input Delay",
+          "score": 0.04,
+          "displayValue": "600 ms"
+        },
+        {
+          "id": "interactive",
+          "title": "Time to Interactive",
+          "score": 0.86,
+          "displayValue": "4.2 s"
+        },
+        {
+          "id": "mainthread-work-breakdown",
+          "title": "Minimize main-thread work",
+          "score": 0,
+          "displayValue": "2.8 s"
+        },
+        {
+          "id": "bootup-time",
+          "title": "JavaScript execution time",
+          "score": 1,
+          "displayValue": "1.3 s"
+        },
+        {
+          "id": "valid-source-maps",
+          "title": "Missing source maps for large first-party JavaScript",
+          "score": 0,
+          "displayValue": null
+        },
+        {
+          "id": "color-contrast",
+          "title": "Background and foreground colors have a sufficient contrast ratio",
+          "score": 1,
+          "displayValue": null
+        },
+        {
+          "id": "label-content-name-mismatch",
+          "title": "Elements with visible text labels do not have matching accessible names.",
+          "score": 0,
+          "displayValue": null
+        },
+        {
+          "id": "unused-javascript",
+          "title": "Reduce unused JavaScript",
+          "score": 0.5,
+          "displayValue": "Est savings of 21 KiB"
+        },
+        {
+          "id": "meta-description",
+          "title": "Document does not have a meta description",
+          "score": 0,
+          "displayValue": null
+        }
+      ]
+    },
+    {
+      "route": "/treatments/sedation-dentistry",
+      "url": "http://localhost:3000/treatments/sedation-dentistry",
+      "status": "measured",
+      "reason": null,
+      "lighthouseVersion": "13.3.0",
+      "fetchTime": "2026-06-02T17:17:18.494Z",
+      "requestedUrl": "http://localhost:3000/treatments/sedation-dentistry",
+      "finalDisplayedUrl": "http://localhost:3000/treatments/sedation-dentistry",
+      "userAgent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/143.0.0.0 Safari/537.36",
+      "formFactor": "mobile",
+      "throttlingMethod": "simulate",
+      "screenEmulation": {
+        "mobile": true,
+        "width": 412,
+        "height": 823,
+        "deviceScaleFactor": 1.75,
+        "disabled": false
+      },
+      "scores": {
+        "performance": 77,
+        "accessibility": 100,
+        "bestPractices": 100,
+        "seo": 54
+      },
+      "coreWebVitalsLab": {
+        "fcpMs": 1328.1695499999998,
+        "fcpDisplay": "1.3 s",
+        "lcpMs": 2495.3390999999997,
+        "lcpDisplay": "2.5 s",
+        "cls": 0,
+        "clsDisplay": "0",
+        "tbtMs": 875.9999999999998,
+        "tbtDisplay": "880 ms",
+        "inpProxy": "TBT captured as lab proxy; INP is a field metric and was not available in this local lab run.",
+        "speedIndexMs": 1414.036400004886,
+        "speedIndexDisplay": "1.4 s"
+      },
+      "networkAndWeight": {
+        "totalByteWeight": 463107,
+        "totalByteWeightDisplay": "Total size was 452 KiB",
+        "numRequests": 14,
+        "totalByteWeightDiagnostic": 463107,
+        "mainDocumentTransferSize": 30035
+      },
+      "topActionableAudits": [
+        {
+          "id": "first-contentful-paint",
+          "title": "First Contentful Paint",
+          "score": 0.98,
+          "displayValue": "1.3 s"
+        },
+        {
+          "id": "largest-contentful-paint",
+          "title": "Largest Contentful Paint",
+          "score": 0.9,
+          "displayValue": "2.5 s"
+        },
+        {
+          "id": "speed-index",
+          "title": "Speed Index",
+          "score": 1,
+          "displayValue": "1.4 s"
+        },
+        {
+          "id": "total-blocking-time",
+          "title": "Total Blocking Time",
+          "score": 0.32,
+          "displayValue": "880 ms"
+        },
+        {
+          "id": "max-potential-fid",
+          "title": "Max Potential First Input Delay",
+          "score": 0.04,
+          "displayValue": "600 ms"
+        },
+        {
+          "id": "interactive",
+          "title": "Time to Interactive",
+          "score": 0.85,
+          "displayValue": "4.3 s"
+        },
+        {
+          "id": "mainthread-work-breakdown",
+          "title": "Minimize main-thread work",
+          "score": 0,
+          "displayValue": "2.8 s"
+        },
+        {
+          "id": "bootup-time",
+          "title": "JavaScript execution time",
+          "score": 1,
+          "displayValue": "1.2 s"
+        },
+        {
+          "id": "valid-source-maps",
+          "title": "Missing source maps for large first-party JavaScript",
+          "score": 0,
+          "displayValue": null
+        },
+        {
+          "id": "color-contrast",
+          "title": "Background and foreground colors have a sufficient contrast ratio",
+          "score": 1,
+          "displayValue": null
+        },
+        {
+          "id": "label-content-name-mismatch",
+          "title": "Elements with visible text labels do not have matching accessible names.",
+          "score": 0,
+          "displayValue": null
+        },
+        {
+          "id": "unused-javascript",
+          "title": "Reduce unused JavaScript",
+          "score": 0.5,
+          "displayValue": "Est savings of 21 KiB"
+        },
+        {
+          "id": "meta-description",
+          "title": "Document does not have a meta description",
+          "score": 0,
+          "displayValue": null
+        }
+      ]
+    },
+    {
+      "route": "/treatments/preventative-and-general-dentistry",
+      "url": "http://localhost:3000/treatments/preventative-and-general-dentistry",
+      "status": "measured",
+      "reason": null,
+      "lighthouseVersion": "13.3.0",
+      "fetchTime": "2026-06-02T17:17:36.291Z",
+      "requestedUrl": "http://localhost:3000/treatments/preventative-and-general-dentistry",
+      "finalDisplayedUrl": "http://localhost:3000/treatments/preventative-and-general-dentistry",
+      "userAgent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/143.0.0.0 Safari/537.36",
+      "formFactor": "mobile",
+      "throttlingMethod": "simulate",
+      "screenEmulation": {
+        "mobile": true,
+        "width": 412,
+        "height": 823,
+        "deviceScaleFactor": 1.75,
+        "disabled": false
+      },
+      "scores": {
+        "performance": 75,
+        "accessibility": 100,
+        "bestPractices": 100,
+        "seo": 54
+      },
+      "coreWebVitalsLab": {
+        "fcpMs": 1300.9270999999999,
+        "fcpDisplay": "1.3 s",
+        "lcpMs": 2566.3542,
+        "lcpDisplay": "2.6 s",
+        "cls": 0,
+        "clsDisplay": "0",
+        "tbtMs": 1016.9999999999998,
+        "tbtDisplay": "1,020 ms",
+        "inpProxy": "TBT captured as lab proxy; INP is a field metric and was not available in this local lab run.",
+        "speedIndexMs": 1441.7798499932696,
+        "speedIndexDisplay": "1.4 s"
+      },
+      "networkAndWeight": {
+        "totalByteWeight": 465575,
+        "totalByteWeightDisplay": "Total size was 455 KiB",
+        "numRequests": 14,
+        "totalByteWeightDiagnostic": 465575,
+        "mainDocumentTransferSize": 32503
+      },
+      "topActionableAudits": [
+        {
+          "id": "first-contentful-paint",
+          "title": "First Contentful Paint",
+          "score": 0.98,
+          "displayValue": "1.3 s"
+        },
+        {
+          "id": "largest-contentful-paint",
+          "title": "Largest Contentful Paint",
+          "score": 0.88,
+          "displayValue": "2.6 s"
+        },
+        {
+          "id": "speed-index",
+          "title": "Speed Index",
+          "score": 1,
+          "displayValue": "1.4 s"
+        },
+        {
+          "id": "total-blocking-time",
+          "title": "Total Blocking Time",
+          "score": 0.26,
+          "displayValue": "1,020 ms"
+        },
+        {
+          "id": "max-potential-fid",
+          "title": "Max Potential First Input Delay",
+          "score": 0.04,
+          "displayValue": "610 ms"
+        },
+        {
+          "id": "interactive",
+          "title": "Time to Interactive",
+          "score": 0.85,
+          "displayValue": "4.2 s"
+        },
+        {
+          "id": "mainthread-work-breakdown",
+          "title": "Minimize main-thread work",
+          "score": 0,
+          "displayValue": "2.9 s"
+        },
+        {
+          "id": "bootup-time",
+          "title": "Reduce JavaScript execution time",
+          "score": 0,
+          "displayValue": "1.4 s"
+        },
+        {
+          "id": "valid-source-maps",
+          "title": "Missing source maps for large first-party JavaScript",
+          "score": 0,
+          "displayValue": null
+        },
+        {
+          "id": "color-contrast",
+          "title": "Background and foreground colors have a sufficient contrast ratio",
+          "score": 1,
+          "displayValue": null
+        },
+        {
+          "id": "label-content-name-mismatch",
+          "title": "Elements with visible text labels do not have matching accessible names.",
+          "score": 0,
+          "displayValue": null
+        },
+        {
+          "id": "unused-javascript",
+          "title": "Reduce unused JavaScript",
+          "score": 0,
+          "displayValue": "Est savings of 21 KiB"
+        },
+        {
+          "id": "meta-description",
+          "title": "Document does not have a meta description",
+          "score": 0,
+          "displayValue": null
+        }
+      ]
+    }
+  ]
+}

--- a/tools/audits/lighthouse-cwv-mobile-accessibility-evidence-rerun/MOBILE_READINESS_RESULTS_RERUN_V1.json
+++ b/tools/audits/lighthouse-cwv-mobile-accessibility-evidence-rerun/MOBILE_READINESS_RESULTS_RERUN_V1.json
@@ -1,0 +1,803 @@
+{
+  "generatedAt": "2026-06-02T17:19:58.990Z",
+  "viewport": {
+    "width": 390,
+    "height": 844,
+    "isMobile": true,
+    "deviceScaleFactor": 3
+  },
+  "routes": [
+    {
+      "route": "/",
+      "url": "http://localhost:3000/",
+      "status": "pass",
+      "httpStatus": 200,
+      "loadMs": 916,
+      "gotoError": null,
+      "fatalConsoleErrors": [],
+      "consoleWarningsAndErrors": [],
+      "checks": {
+        "routeLoads": true,
+        "noFatalConsoleErrors": true,
+        "primaryContentVisible": true,
+        "answerSurfacesVisible": true,
+        "navigationUsableEnoughForEvidence": true,
+        "noHorizontalOverflow": true,
+        "noSsrHydrationCrash": true
+      },
+      "pageEvidence": {
+        "title": "Private Dental Care in Shoreham-by-Sea | St Mary's House Dental Care",
+        "h1": null,
+        "headingCount": 22,
+        "headings": [
+          {
+            "tag": "H2",
+            "text": "Dentistry planned carefully, delivered properly"
+          },
+          {
+            "tag": "H2",
+            "text": "Dentistry designed for clarity, comfort, and long-term confidence"
+          },
+          {
+            "tag": "H3",
+            "text": "Clinical depth with steady hands"
+          },
+          {
+            "tag": "H2",
+            "text": "Care that values planning as much as precision"
+          },
+          {
+            "tag": "H3",
+            "text": "Priority treatments at a glance"
+          },
+          {
+            "tag": "H3",
+            "text": "How care works here"
+          },
+          {
+            "tag": "H2",
+            "text": "Structured care for complex situations"
+          },
+          {
+            "tag": "H3",
+            "text": "Pick a treatment to explore"
+          },
+          {
+            "tag": "H3",
+            "text": "Need urgent or remote support?"
+          },
+          {
+            "tag": "H3",
+            "text": "Technology that keeps planning clear"
+          },
+          {
+            "tag": "H3",
+            "text": "Patient journeys"
+          },
+          {
+            "tag": "H2",
+            "text": "Google reviews"
+          }
+        ],
+        "landmarks": {
+          "main": 1,
+          "nav": 1,
+          "header": 1,
+          "footer": 1,
+          "aside": 0
+        },
+        "roleLandmarks": [
+          "presentation",
+          "presentation",
+          "presentation",
+          "presentation",
+          "presentation",
+          "presentation",
+          "presentation",
+          "presentation",
+          "presentation",
+          "presentation"
+        ],
+        "mainPresent": true,
+        "mainVisible": true,
+        "primaryContentVisible": true,
+        "navPresent": true,
+        "navUsableEvidence": true,
+        "answerSurfaceCount": 0,
+        "answerSurfaceVisible": false,
+        "answerSurfaceTextSample": null,
+        "horizontalOverflow": false,
+        "viewportWidth": 836,
+        "scrollWidth": 836,
+        "bodyScrollWidth": 836,
+        "visibleTextLength": 9169,
+        "interactiveCount": 48,
+        "inaccessibleInteractiveCount": 0,
+        "inaccessibleInteractive": [],
+        "imagesMissingAlt": 0,
+        "lang": "en"
+      }
+    },
+    {
+      "route": "/contact",
+      "url": "http://localhost:3000/contact",
+      "status": "pass",
+      "httpStatus": 200,
+      "loadMs": 996,
+      "gotoError": null,
+      "fatalConsoleErrors": [],
+      "consoleWarningsAndErrors": [],
+      "checks": {
+        "routeLoads": true,
+        "noFatalConsoleErrors": true,
+        "primaryContentVisible": true,
+        "answerSurfacesVisible": false,
+        "navigationUsableEnoughForEvidence": true,
+        "noHorizontalOverflow": true,
+        "noSsrHydrationCrash": true
+      },
+      "pageEvidence": {
+        "title": "Contact",
+        "h1": null,
+        "headingCount": 8,
+        "headings": [
+          {
+            "tag": "H2",
+            "text": "Contact St Mary’s House Dental Care"
+          },
+          {
+            "tag": "H2",
+            "text": "What does a private dentist appointment include at St Mary’s House Dental Care?"
+          },
+          {
+            "tag": "H3",
+            "text": "Practice details"
+          },
+          {
+            "tag": "H3",
+            "text": "Contact methods"
+          },
+          {
+            "tag": "H3",
+            "text": "Need urgent help?"
+          },
+          {
+            "tag": "H2",
+            "text": "How to contact us"
+          },
+          {
+            "tag": "H3",
+            "text": "Finding the practice"
+          },
+          {
+            "tag": "H3",
+            "text": "Plan a visit"
+          }
+        ],
+        "landmarks": {
+          "main": 1,
+          "nav": 1,
+          "header": 1,
+          "footer": 1,
+          "aside": 0
+        },
+        "roleLandmarks": [],
+        "mainPresent": true,
+        "mainVisible": true,
+        "primaryContentVisible": true,
+        "navPresent": true,
+        "navUsableEvidence": true,
+        "answerSurfaceCount": 0,
+        "answerSurfaceVisible": false,
+        "answerSurfaceTextSample": null,
+        "horizontalOverflow": false,
+        "viewportWidth": 836,
+        "scrollWidth": 836,
+        "bodyScrollWidth": 836,
+        "visibleTextLength": 4748,
+        "interactiveCount": 35,
+        "inaccessibleInteractiveCount": 0,
+        "inaccessibleInteractive": [],
+        "imagesMissingAlt": 0,
+        "lang": "en"
+      }
+    },
+    {
+      "route": "/treatments/emergency-dentistry",
+      "url": "http://localhost:3000/treatments/emergency-dentistry",
+      "status": "pass",
+      "httpStatus": 200,
+      "loadMs": 968,
+      "gotoError": null,
+      "fatalConsoleErrors": [],
+      "consoleWarningsAndErrors": [],
+      "checks": {
+        "routeLoads": true,
+        "noFatalConsoleErrors": true,
+        "primaryContentVisible": true,
+        "answerSurfacesVisible": false,
+        "navigationUsableEnoughForEvidence": true,
+        "noHorizontalOverflow": true,
+        "noSsrHydrationCrash": true
+      },
+      "pageEvidence": {
+        "title": "Emergency dentistry",
+        "h1": null,
+        "headingCount": 10,
+        "headings": [
+          {
+            "tag": "H2",
+            "text": "Emergency dentistry"
+          },
+          {
+            "tag": "H2",
+            "text": "What should I do if I need an emergency dentist in Shoreham-by-Sea?"
+          },
+          {
+            "tag": "H2",
+            "text": "How we handle dental emergencies"
+          },
+          {
+            "tag": "H3",
+            "text": "Common reasons people contact us urgently"
+          },
+          {
+            "tag": "H3",
+            "text": "What to do right now"
+          },
+          {
+            "tag": "H3",
+            "text": "Urgent care and follow-up"
+          },
+          {
+            "tag": "H3",
+            "text": "What you can expect at an emergency visit"
+          },
+          {
+            "tag": "H3",
+            "text": "When urgent care may not be necessary"
+          },
+          {
+            "tag": "H3",
+            "text": "Call for emergency dental care"
+          },
+          {
+            "tag": "H3",
+            "text": "Emergency Dentistry — full treatment list"
+          }
+        ],
+        "landmarks": {
+          "main": 1,
+          "nav": 2,
+          "header": 1,
+          "footer": 1,
+          "aside": 0
+        },
+        "roleLandmarks": [
+          "presentation",
+          "presentation",
+          "presentation",
+          "presentation",
+          "presentation",
+          "presentation",
+          "presentation",
+          "presentation"
+        ],
+        "mainPresent": true,
+        "mainVisible": true,
+        "primaryContentVisible": true,
+        "navPresent": true,
+        "navUsableEvidence": true,
+        "answerSurfaceCount": 0,
+        "answerSurfaceVisible": false,
+        "answerSurfaceTextSample": null,
+        "horizontalOverflow": false,
+        "viewportWidth": 836,
+        "scrollWidth": 836,
+        "bodyScrollWidth": 836,
+        "visibleTextLength": 6020,
+        "interactiveCount": 47,
+        "inaccessibleInteractiveCount": 0,
+        "inaccessibleInteractive": [],
+        "imagesMissingAlt": 0,
+        "lang": "en"
+      }
+    },
+    {
+      "route": "/treatments/implants",
+      "url": "http://localhost:3000/treatments/implants",
+      "status": "pass",
+      "httpStatus": 200,
+      "loadMs": 867,
+      "gotoError": null,
+      "fatalConsoleErrors": [],
+      "consoleWarningsAndErrors": [],
+      "checks": {
+        "routeLoads": true,
+        "noFatalConsoleErrors": true,
+        "primaryContentVisible": true,
+        "answerSurfacesVisible": false,
+        "navigationUsableEnoughForEvidence": true,
+        "noHorizontalOverflow": true,
+        "noSsrHydrationCrash": true
+      },
+      "pageEvidence": {
+        "title": "Dental Implants in Shoreham-by-Sea",
+        "h1": null,
+        "headingCount": 15,
+        "headings": [
+          {
+            "tag": "H2",
+            "text": "Planning first, surgery second"
+          },
+          {
+            "tag": "H3",
+            "text": "Implants Mid Cta"
+          },
+          {
+            "tag": "H2",
+            "text": "What are dental implants and who may they help?"
+          },
+          {
+            "tag": "H3",
+            "text": "Why patients trust us"
+          },
+          {
+            "tag": "H2",
+            "text": "A step-by-step approach"
+          },
+          {
+            "tag": "H3",
+            "text": "What is a dental implant?"
+          },
+          {
+            "tag": "H3",
+            "text": "Suitability and case selection"
+          },
+          {
+            "tag": "H3",
+            "text": "Implant treatment, step by step"
+          },
+          {
+            "tag": "H3",
+            "text": "CBCT + digital scanning"
+          },
+          {
+            "tag": "H3",
+            "text": "Important risks we discuss"
+          },
+          {
+            "tag": "H3",
+            "text": "Long-term success depends on care"
+          },
+          {
+            "tag": "H3",
+            "text": "Common questions about implants"
+          }
+        ],
+        "landmarks": {
+          "main": 1,
+          "nav": 2,
+          "header": 1,
+          "footer": 1,
+          "aside": 0
+        },
+        "roleLandmarks": [],
+        "mainPresent": true,
+        "mainVisible": true,
+        "primaryContentVisible": true,
+        "navPresent": true,
+        "navUsableEvidence": true,
+        "answerSurfaceCount": 0,
+        "answerSurfaceVisible": false,
+        "answerSurfaceTextSample": null,
+        "horizontalOverflow": false,
+        "viewportWidth": 836,
+        "scrollWidth": 836,
+        "bodyScrollWidth": 836,
+        "visibleTextLength": 9091,
+        "interactiveCount": 39,
+        "inaccessibleInteractiveCount": 0,
+        "inaccessibleInteractive": [],
+        "imagesMissingAlt": 0,
+        "lang": "en"
+      }
+    },
+    {
+      "route": "/treatments/clear-aligners-spark",
+      "url": "http://localhost:3000/treatments/clear-aligners-spark",
+      "status": "pass",
+      "httpStatus": 200,
+      "loadMs": 880,
+      "gotoError": null,
+      "fatalConsoleErrors": [],
+      "consoleWarningsAndErrors": [],
+      "checks": {
+        "routeLoads": true,
+        "noFatalConsoleErrors": true,
+        "primaryContentVisible": true,
+        "answerSurfacesVisible": false,
+        "navigationUsableEnoughForEvidence": true,
+        "noHorizontalOverflow": true,
+        "noSsrHydrationCrash": true
+      },
+      "pageEvidence": {
+        "title": "Spark clear aligners in Shoreham-by-Sea",
+        "h1": null,
+        "headingCount": 17,
+        "headings": [
+          {
+            "tag": "H2",
+            "text": "Spark clear aligners in Shoreham-by-Sea"
+          },
+          {
+            "tag": "H2",
+            "text": "Can I get Spark Aligners in Shoreham-by-Sea?"
+          },
+          {
+            "tag": "H3",
+            "text": "Transparent, clinician-led aligner care"
+          },
+          {
+            "tag": "H2",
+            "text": "Discreet trays planned for comfort and predictability"
+          },
+          {
+            "tag": "H3",
+            "text": "Clear Aligners Spark Mid Cta"
+          },
+          {
+            "tag": "H3",
+            "text": "Digital Spark planning with bite checks and stability in mind"
+          },
+          {
+            "tag": "H3",
+            "text": "Clear guidance on suitability"
+          },
+          {
+            "tag": "H3",
+            "text": "Steady steps with ongoing support"
+          },
+          {
+            "tag": "H3",
+            "text": "Set review intervals with options if teeth don’t track"
+          },
+          {
+            "tag": "H3",
+            "text": "Digital scans meet Spark clarity"
+          },
+          {
+            "tag": "H3",
+            "text": "Comfort-focused guidance with clear expectations"
+          },
+          {
+            "tag": "H3",
+            "text": "Fixed and removable retainers with long-term guidance"
+          }
+        ],
+        "landmarks": {
+          "main": 1,
+          "nav": 2,
+          "header": 1,
+          "footer": 1,
+          "aside": 0
+        },
+        "roleLandmarks": [],
+        "mainPresent": true,
+        "mainVisible": true,
+        "primaryContentVisible": true,
+        "navPresent": true,
+        "navUsableEvidence": true,
+        "answerSurfaceCount": 0,
+        "answerSurfaceVisible": false,
+        "answerSurfaceTextSample": null,
+        "horizontalOverflow": false,
+        "viewportWidth": 836,
+        "scrollWidth": 836,
+        "bodyScrollWidth": 836,
+        "visibleTextLength": 9302,
+        "interactiveCount": 40,
+        "inaccessibleInteractiveCount": 0,
+        "inaccessibleInteractive": [],
+        "imagesMissingAlt": 0,
+        "lang": "en"
+      }
+    },
+    {
+      "route": "/treatments/3d-dentistry-and-technology",
+      "url": "http://localhost:3000/treatments/3d-dentistry-and-technology",
+      "status": "pass",
+      "httpStatus": 200,
+      "loadMs": 982,
+      "gotoError": null,
+      "fatalConsoleErrors": [],
+      "consoleWarningsAndErrors": [],
+      "checks": {
+        "routeLoads": true,
+        "noFatalConsoleErrors": true,
+        "primaryContentVisible": true,
+        "answerSurfacesVisible": false,
+        "navigationUsableEnoughForEvidence": true,
+        "noHorizontalOverflow": true,
+        "noSsrHydrationCrash": true
+      },
+      "pageEvidence": {
+        "title": "3D dentistry & technology",
+        "h1": null,
+        "headingCount": 12,
+        "headings": [
+          {
+            "tag": "H2",
+            "text": "3D dentistry & technology in Shoreham-by-Sea"
+          },
+          {
+            "tag": "H2",
+            "text": "What is 3D dentistry at St Mary’s House Dental Care?"
+          },
+          {
+            "tag": "H3",
+            "text": "Calm, clinician-led control"
+          },
+          {
+            "tag": "H2",
+            "text": "Scan → Design → Print/Mill → Fit"
+          },
+          {
+            "tag": "H3",
+            "text": "Patients who want predictable, visual planning"
+          },
+          {
+            "tag": "H3",
+            "text": "3d Dentistry And Technology Mid Cta"
+          },
+          {
+            "tag": "H3",
+            "text": "Clear checkpoints from scan to maintenance"
+          },
+          {
+            "tag": "H3",
+            "text": "Precision outputs, clinician-reviewed"
+          },
+          {
+            "tag": "H3",
+            "text": "Long-term fit backed by maintenance"
+          },
+          {
+            "tag": "H3",
+            "text": "Answers before you choose"
+          },
+          {
+            "tag": "H2",
+            "text": "When this fits and what else to consider"
+          },
+          {
+            "tag": "H3",
+            "text": "See your options digitally before you commit"
+          }
+        ],
+        "landmarks": {
+          "main": 1,
+          "nav": 2,
+          "header": 1,
+          "footer": 1,
+          "aside": 0
+        },
+        "roleLandmarks": [],
+        "mainPresent": true,
+        "mainVisible": true,
+        "primaryContentVisible": true,
+        "navPresent": true,
+        "navUsableEvidence": true,
+        "answerSurfaceCount": 0,
+        "answerSurfaceVisible": false,
+        "answerSurfaceTextSample": null,
+        "horizontalOverflow": false,
+        "viewportWidth": 836,
+        "scrollWidth": 836,
+        "bodyScrollWidth": 836,
+        "visibleTextLength": 6801,
+        "interactiveCount": 38,
+        "inaccessibleInteractiveCount": 0,
+        "inaccessibleInteractive": [],
+        "imagesMissingAlt": 0,
+        "lang": "en"
+      }
+    },
+    {
+      "route": "/treatments/sedation-dentistry",
+      "url": "http://localhost:3000/treatments/sedation-dentistry",
+      "status": "pass",
+      "httpStatus": 200,
+      "loadMs": 933,
+      "gotoError": null,
+      "fatalConsoleErrors": [],
+      "consoleWarningsAndErrors": [],
+      "checks": {
+        "routeLoads": true,
+        "noFatalConsoleErrors": true,
+        "primaryContentVisible": true,
+        "answerSurfacesVisible": false,
+        "navigationUsableEnoughForEvidence": true,
+        "noHorizontalOverflow": true,
+        "noSsrHydrationCrash": true
+      },
+      "pageEvidence": {
+        "title": "Sedation dentistry",
+        "h1": null,
+        "headingCount": 11,
+        "headings": [
+          {
+            "tag": "H2",
+            "text": "Sedation support for calmer dental visits"
+          },
+          {
+            "tag": "H2",
+            "text": "Can sedation help if I feel anxious about dental treatment?"
+          },
+          {
+            "tag": "H3",
+            "text": "Clinician-led, safety-first sedation"
+          },
+          {
+            "tag": "H2",
+            "text": "Consultation, suitability, then a tailored plan"
+          },
+          {
+            "tag": "H3",
+            "text": "Sedation Dentistry Mid Cta"
+          },
+          {
+            "tag": "H3",
+            "text": "Suitable for specific needs"
+          },
+          {
+            "tag": "H3",
+            "text": "Clear steps from consult to recovery"
+          },
+          {
+            "tag": "H3",
+            "text": "Recover with clear guidance"
+          },
+          {
+            "tag": "H3",
+            "text": "Common questions answered"
+          },
+          {
+            "tag": "H2",
+            "text": "When this fits and what else to consider"
+          },
+          {
+            "tag": "H3",
+            "text": "Talk through sedation calmly first"
+          }
+        ],
+        "landmarks": {
+          "main": 1,
+          "nav": 2,
+          "header": 1,
+          "footer": 1,
+          "aside": 0
+        },
+        "roleLandmarks": [],
+        "mainPresent": true,
+        "mainVisible": true,
+        "primaryContentVisible": true,
+        "navPresent": true,
+        "navUsableEvidence": true,
+        "answerSurfaceCount": 0,
+        "answerSurfaceVisible": false,
+        "answerSurfaceTextSample": null,
+        "horizontalOverflow": false,
+        "viewportWidth": 836,
+        "scrollWidth": 836,
+        "bodyScrollWidth": 836,
+        "visibleTextLength": 7129,
+        "interactiveCount": 38,
+        "inaccessibleInteractiveCount": 0,
+        "inaccessibleInteractive": [],
+        "imagesMissingAlt": 0,
+        "lang": "en"
+      }
+    },
+    {
+      "route": "/treatments/preventative-and-general-dentistry",
+      "url": "http://localhost:3000/treatments/preventative-and-general-dentistry",
+      "status": "pass",
+      "httpStatus": 200,
+      "loadMs": 985,
+      "gotoError": null,
+      "fatalConsoleErrors": [],
+      "consoleWarningsAndErrors": [],
+      "checks": {
+        "routeLoads": true,
+        "noFatalConsoleErrors": true,
+        "primaryContentVisible": true,
+        "answerSurfacesVisible": false,
+        "navigationUsableEnoughForEvidence": true,
+        "noHorizontalOverflow": true,
+        "noSsrHydrationCrash": true
+      },
+      "pageEvidence": {
+        "title": "Preventative & general dentistry",
+        "h1": null,
+        "headingCount": 13,
+        "headings": [
+          {
+            "tag": "H2",
+            "text": "Prevention-first dentistry that keeps teeth for life"
+          },
+          {
+            "tag": "H2",
+            "text": "Do you offer dental hygiene and recall appointments in Shoreham-by-Sea?"
+          },
+          {
+            "tag": "H3",
+            "text": "Protect teeth before problems arise"
+          },
+          {
+            "tag": "H2",
+            "text": "Every check-up is detailed and documented"
+          },
+          {
+            "tag": "H3",
+            "text": "Professional hygiene that supports home care"
+          },
+          {
+            "tag": "H2",
+            "text": "Simple, science-led guidance you can follow"
+          },
+          {
+            "tag": "H3",
+            "text": "Preventative And General Dentistry Mid Cta"
+          },
+          {
+            "tag": "H3",
+            "text": "Early detection keeps treatment simpler"
+          },
+          {
+            "tag": "H3",
+            "text": "Care tailored to every stage"
+          },
+          {
+            "tag": "H3",
+            "text": "What patients ask most"
+          },
+          {
+            "tag": "H3",
+            "text": "Keep your routine care on track"
+          },
+          {
+            "tag": "H2",
+            "text": "When this fits and what else to consider"
+          }
+        ],
+        "landmarks": {
+          "main": 1,
+          "nav": 2,
+          "header": 1,
+          "footer": 1,
+          "aside": 0
+        },
+        "roleLandmarks": [],
+        "mainPresent": true,
+        "mainVisible": true,
+        "primaryContentVisible": true,
+        "navPresent": true,
+        "navUsableEvidence": true,
+        "answerSurfaceCount": 0,
+        "answerSurfaceVisible": false,
+        "answerSurfaceTextSample": null,
+        "horizontalOverflow": false,
+        "viewportWidth": 836,
+        "scrollWidth": 836,
+        "bodyScrollWidth": 836,
+        "visibleTextLength": 7878,
+        "interactiveCount": 39,
+        "inaccessibleInteractiveCount": 0,
+        "inaccessibleInteractive": [],
+        "imagesMissingAlt": 0,
+        "lang": "en"
+      }
+    }
+  ]
+}

--- a/tools/audits/lighthouse-cwv-mobile-accessibility-evidence-rerun/PERFORMANCE_RISK_REGISTER_RERUN_V1.json
+++ b/tools/audits/lighthouse-cwv-mobile-accessibility-evidence-rerun/PERFORMANCE_RISK_REGISTER_RERUN_V1.json
@@ -1,0 +1,118 @@
+{
+  "generatedAt": "2026-06-02T17:19:58.990Z",
+  "classification": "READY_FOR_FINAL_CERTIFICATION_RECHECK",
+  "risks": [
+    {
+      "route": "/",
+      "risk": "high_total_blocking_time_inp_proxy",
+      "severity": "medium",
+      "evidence": "1,120 ms",
+      "recommendedMission": "Main-thread/JavaScript cost reduction mission."
+    },
+    {
+      "route": "/",
+      "risk": "lighthouse_accessibility_below_100",
+      "severity": "low",
+      "evidence": "96",
+      "recommendedMission": "Accessibility audit remediation mission."
+    },
+    {
+      "route": "/contact",
+      "risk": "high_total_blocking_time_inp_proxy",
+      "severity": "medium",
+      "evidence": "1,070 ms",
+      "recommendedMission": "Main-thread/JavaScript cost reduction mission."
+    },
+    {
+      "route": "/contact",
+      "risk": "lighthouse_accessibility_below_100",
+      "severity": "low",
+      "evidence": "96",
+      "recommendedMission": "Accessibility audit remediation mission."
+    },
+    {
+      "route": "/treatments/emergency-dentistry",
+      "risk": "high_total_blocking_time_inp_proxy",
+      "severity": "medium",
+      "evidence": "1,030 ms",
+      "recommendedMission": "Main-thread/JavaScript cost reduction mission."
+    },
+    {
+      "route": "/treatments/emergency-dentistry",
+      "risk": "lcp_above_good_lab_threshold",
+      "severity": "medium",
+      "evidence": "2.5 s",
+      "recommendedMission": "Hero/media and above-the-fold delivery review mission."
+    },
+    {
+      "route": "/treatments/emergency-dentistry",
+      "risk": "lighthouse_accessibility_below_100",
+      "severity": "low",
+      "evidence": "96",
+      "recommendedMission": "Accessibility audit remediation mission."
+    },
+    {
+      "route": "/treatments/implants",
+      "risk": "high_total_blocking_time_inp_proxy",
+      "severity": "medium",
+      "evidence": "1,100 ms",
+      "recommendedMission": "Main-thread/JavaScript cost reduction mission."
+    },
+    {
+      "route": "/treatments/implants",
+      "risk": "lcp_above_good_lab_threshold",
+      "severity": "medium",
+      "evidence": "2.5 s",
+      "recommendedMission": "Hero/media and above-the-fold delivery review mission."
+    },
+    {
+      "route": "/treatments/clear-aligners-spark",
+      "risk": "high_total_blocking_time_inp_proxy",
+      "severity": "medium",
+      "evidence": "1,530 ms",
+      "recommendedMission": "Main-thread/JavaScript cost reduction mission."
+    },
+    {
+      "route": "/treatments/clear-aligners-spark",
+      "risk": "lcp_above_good_lab_threshold",
+      "severity": "medium",
+      "evidence": "2.7 s",
+      "recommendedMission": "Hero/media and above-the-fold delivery review mission."
+    },
+    {
+      "route": "/treatments/3d-dentistry-and-technology",
+      "risk": "high_total_blocking_time_inp_proxy",
+      "severity": "medium",
+      "evidence": "930 ms",
+      "recommendedMission": "Main-thread/JavaScript cost reduction mission."
+    },
+    {
+      "route": "/treatments/3d-dentistry-and-technology",
+      "risk": "lcp_above_good_lab_threshold",
+      "severity": "medium",
+      "evidence": "2.6 s",
+      "recommendedMission": "Hero/media and above-the-fold delivery review mission."
+    },
+    {
+      "route": "/treatments/sedation-dentistry",
+      "risk": "high_total_blocking_time_inp_proxy",
+      "severity": "medium",
+      "evidence": "880 ms",
+      "recommendedMission": "Main-thread/JavaScript cost reduction mission."
+    },
+    {
+      "route": "/treatments/preventative-and-general-dentistry",
+      "risk": "high_total_blocking_time_inp_proxy",
+      "severity": "medium",
+      "evidence": "1,020 ms",
+      "recommendedMission": "Main-thread/JavaScript cost reduction mission."
+    },
+    {
+      "route": "/treatments/preventative-and-general-dentistry",
+      "risk": "lcp_above_good_lab_threshold",
+      "severity": "medium",
+      "evidence": "2.6 s",
+      "recommendedMission": "Hero/media and above-the-fold delivery review mission."
+    }
+  ]
+}


### PR DESCRIPTION
### Motivation

- Re-run the Lighthouse/CWV/mobile/accessibility evidence after the `/treatments/3d-dentistry-and-technology` availability fix so the full 8-route evidence set can be certified. 
- This is an evidence-only change: no page redesigns, SEO/schema/manifest changes, or deployments were performed.

### Description

- Add a complete evidence packet under `tools/audits/lighthouse-cwv-mobile-accessibility-evidence-rerun/` including `LIGHTHOUSE_CWV_MOBILE_ACCESSIBILITY_RERUN_REPORT_V1.{md,json}`, `LIGHTHOUSE_ROUTE_RESULTS_RERUN_V1.json`, `MOBILE_READINESS_RESULTS_RERUN_V1.json`, `ACCESSIBILITY_RESULTS_RERUN_V1.json`, `PERFORMANCE_RISK_REGISTER_RERUN_V1.json`, and `FINAL_CERTIFICATION_RECHECK_RECOMMENDATION_RERUN_V1.md`.
- The report records Lighthouse/CWV-style mobile lab scores for all 8 required routes, Playwright mobile viewport readiness checks, DOM/accessibility heuristics (axe-core was not installed), and a performance risk register.
- The final recommendation in the rerun artifacts is `READY_FOR_FINAL_CERTIFICATION_RECHECK` with remaining risks called out (TBT/INP-proxy and LCP threshold observations).
- No application code, manifests, schema, or SEO registries were modified as part of this work.

### Testing

- Built and validated the production app with `pnpm run build:web` and served via `cd apps/web && pnpm exec next start -p 3000`, and confirmed all 8 required routes returned HTTP 200 via `curl` (8/8 success).
- Ran Lighthouse for all 8 routes (via `pnpm dlx lighthouse` with Playwright Chromium) and produced JSON outputs for each route; all 8 routes were measured successfully (Lighthouse JSONs present).
- Ran Playwright mobile viewport heuristics to produce `MOBILE_READINESS_RESULTS_RERUN_V1.json` and accessibility DOM checks to produce `ACCESSIBILITY_RESULTS_RERUN_V1.json`, and executed repository guards and SEO QA (`pnpm run guard:canon`, `pnpm run guard:hero`, `pnpm run seo:*`), all of which passed.
- Ran the repo `verify` flow and validated generated JSON files (`node -e 'JSON.parse(...)'`) and confirmed no binary screenshots/PDFs were committed; all automated checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f0ea49b5c833292e903fd208cddf5)