### PR TITLE
Add final launch certification recheck audit artifacts

### DIFF
--- a/tools/audits/final-launch-certification-recheck/CHAMPAGNE_FINAL_LAUNCH_CERTIFICATION_RECHECK_V1.json
+++ b/tools/audits/final-launch-certification-recheck/CHAMPAGNE_FINAL_LAUNCH_CERTIFICATION_RECHECK_V1.json
@@ -1,0 +1,578 @@
+{
+  "version": "CHAMPAGNE_FINAL_LAUNCH_CERTIFICATION_RECHECK_V1",
+  "generatedAt": "2026-06-02T17:56:51.164Z",
+  "role": "CHAMPAGNE_FINAL_LAUNCH_CERTIFICATION_RECHECK_V1",
+  "missionBoundary": [
+    "Audit only",
+    "No fixes implemented",
+    "No deployment",
+    "No PHI/PMS/Dentally/booking workflow/chatbot runtime mutation",
+    "No SEO registry/schema/manifest/approval flag mutation"
+  ],
+  "certificationDecision": "CERTIFIED_READY_FOR_LAUNCH_PREPARATION",
+  "decisionRationale": [
+    "The only previous certification-withholding evidence gap was current Lighthouse/CWV/mobile/accessibility evidence.",
+    "The rerun resolves that gap: 8/8 routes returned HTTP 200, 8/8 routes were measured, 8/8 passed mobile readiness, and 8/8 passed accessibility heuristics.",
+    "No remaining item is classified as BLOCKER or HIGH. Medium items are prelaunch review/optimization tasks and do not invalidate readiness for launch preparation."
+  ],
+  "evidenceReviewed": {
+    "previousFinalCertification": {
+      "certification": "NOT_CERTIFIED_READY_FOR_LAUNCH_PREPARATION",
+      "blockerCount": 8
+    },
+    "lighthouseCwvMobileAccessibilityRerun": {
+      "classification": "READY_FOR_FINAL_CERTIFICATION_RECHECK",
+      "summary": {
+        "lighthouseMeasuredRoutes": 8,
+        "lighthouseRequestedRoutes": 8,
+        "routeHttp200": 8,
+        "mobilePassRoutes": 8,
+        "accessibilityBasicPassRoutes": 8,
+        "performanceScores": {
+          "/": 75,
+          "/contact": 75,
+          "/treatments/emergency-dentistry": 75,
+          "/treatments/implants": 74,
+          "/treatments/clear-aligners-spark": 70,
+          "/treatments/3d-dentistry-and-technology": 76,
+          "/treatments/sedation-dentistry": 77,
+          "/treatments/preventative-and-general-dentistry": 75
+        },
+        "accessibilityScores": {
+          "/": 96,
+          "/contact": 96,
+          "/treatments/emergency-dentistry": 96,
+          "/treatments/implants": 100,
+          "/treatments/clear-aligners-spark": 100,
+          "/treatments/3d-dentistry-and-technology": 100,
+          "/treatments/sedation-dentistry": 100,
+          "/treatments/preventative-and-general-dentistry": 100
+        },
+        "remainingRiskCount": 16
+      },
+      "measuredRoutes": [
+        {
+          "route": "/",
+          "httpStatus": 200,
+          "lighthouseStatus": "measured",
+          "performance": 75,
+          "accessibility": 96,
+          "bestPractices": 100,
+          "seo": 54,
+          "fcp": "1.3\u00a0s",
+          "lcp": "2.3\u00a0s",
+          "cls": "0",
+          "tbt": "1,120\u00a0ms"
+        },
+        {
+          "route": "/contact",
+          "httpStatus": 200,
+          "lighthouseStatus": "measured",
+          "performance": 75,
+          "accessibility": 96,
+          "bestPractices": 100,
+          "seo": 54,
+          "fcp": "1.3\u00a0s",
+          "lcp": "2.5\u00a0s",
+          "cls": "0",
+          "tbt": "1,070\u00a0ms"
+        },
+        {
+          "route": "/treatments/emergency-dentistry",
+          "httpStatus": 200,
+          "lighthouseStatus": "measured",
+          "performance": 75,
+          "accessibility": 96,
+          "bestPractices": 100,
+          "seo": 54,
+          "fcp": "1.2\u00a0s",
+          "lcp": "2.5\u00a0s",
+          "cls": "0",
+          "tbt": "1,030\u00a0ms"
+        },
+        {
+          "route": "/treatments/implants",
+          "httpStatus": 200,
+          "lighthouseStatus": "measured",
+          "performance": 74,
+          "accessibility": 100,
+          "bestPractices": 100,
+          "seo": 54,
+          "fcp": "1.2\u00a0s",
+          "lcp": "2.5\u00a0s",
+          "cls": "0",
+          "tbt": "1,100\u00a0ms"
+        },
+        {
+          "route": "/treatments/clear-aligners-spark",
+          "httpStatus": 200,
+          "lighthouseStatus": "measured",
+          "performance": 70,
+          "accessibility": 100,
+          "bestPractices": 100,
+          "seo": 54,
+          "fcp": "1.2\u00a0s",
+          "lcp": "2.7\u00a0s",
+          "cls": "0",
+          "tbt": "1,530\u00a0ms"
+        },
+        {
+          "route": "/treatments/3d-dentistry-and-technology",
+          "httpStatus": 200,
+          "lighthouseStatus": "measured",
+          "performance": 76,
+          "accessibility": 100,
+          "bestPractices": 100,
+          "seo": 54,
+          "fcp": "1.3\u00a0s",
+          "lcp": "2.6\u00a0s",
+          "cls": "0",
+          "tbt": "930\u00a0ms"
+        },
+        {
+          "route": "/treatments/sedation-dentistry",
+          "httpStatus": 200,
+          "lighthouseStatus": "measured",
+          "performance": 77,
+          "accessibility": 100,
+          "bestPractices": 100,
+          "seo": 54,
+          "fcp": "1.3\u00a0s",
+          "lcp": "2.5\u00a0s",
+          "cls": "0",
+          "tbt": "880\u00a0ms"
+        },
+        {
+          "route": "/treatments/preventative-and-general-dentistry",
+          "httpStatus": 200,
+          "lighthouseStatus": "measured",
+          "performance": 75,
+          "accessibility": 100,
+          "bestPractices": 100,
+          "seo": 54,
+          "fcp": "1.3\u00a0s",
+          "lcp": "2.6\u00a0s",
+          "cls": "0",
+          "tbt": "1,020\u00a0ms"
+        }
+      ],
+      "performanceRiskCounts": {
+        "medium": 13,
+        "low": 3
+      }
+    },
+    "routeReconciliation": {
+      "status": "pass",
+      "recommendation": "LIGHTHOUSE_EVIDENCE_CAN_BE_RERUN"
+    },
+    "schemaQa": {
+      "status": "pass",
+      "approvedSchemaAnswerCount": 16,
+      "verifiedTeamMemberCount": 5,
+      "priorityServiceCount": 11,
+      "errors": [],
+      "warnings": []
+    },
+    "answerQa": {
+      "answerFoundationRegistryStatus": {
+        "answerRegistryEntries": 18,
+        "treatmentFactEntries": 12,
+        "questionInventoryEntries": 55,
+        "voicePatterns": 7,
+        "chatbotAlignmentMappings": 17
+      },
+      "priorityPacketStatus": "pass_activation_supported",
+      "visibleRenderingStatus": "pass",
+      "finalHardeningStatus": "pass_with_known_warnings"
+    },
+    "localIdentity": {
+      "status": "bounded_foundation_implemented_not_launch_certified",
+      "schemaNodesImplemented": [
+        "Dentist/LocalBusiness",
+        "Organization",
+        "WebSite",
+        "WebPage",
+        "ProfilePage",
+        "Person/Dentist for Dr Nick Maxwell",
+        "Person/Dentist for verified associates",
+        "Person for verified hygienists",
+        "BreadcrumbList for treatments",
+        "Service for priority services with route data"
+      ],
+      "phiTouched": false,
+      "pmsOrBookingBackendTouched": false,
+      "deploymentSettingsTouched": false
+    },
+    "teamRegistry": {
+      "status": "verified_bounded_foundation",
+      "verifiedForProductionSchema": [
+        {
+          "name": "Dr Nick Maxwell",
+          "role": "Principal Dentist",
+          "gdcNumber": "74877",
+          "sources": [
+            "mission_prompt",
+            "https://www.smhdental.co.uk/team/",
+            "page-truth/team-nick-maxwell.txt"
+          ]
+        },
+        {
+          "name": "Dr Sylvia Krafft",
+          "role": "Associate Dentist",
+          "gdcNumber": "174528",
+          "sources": [
+            "mission_prompt",
+            "https://www.smhdental.co.uk/team/",
+            "page-truth/team-sylvia-krafft.txt"
+          ],
+          "note": "Live site heading appears as Dr Sylvia Kraftt; canonical registry follows user prompt and repo spelling Krafft while recording alternate live spelling."
+        },
+        {
+          "name": "Kitty Ingarfield",
+          "role": "Associate Dentist",
+          "gdcNumber": "302160",
+          "sources": [
+            "https://www.smhdental.co.uk/team/"
+          ]
+        },
+        {
+          "name": "Sara Burden",
+          "role": "Dental Hygienist",
+          "gdcNumber": "3966",
+          "sources": [
+            "https://www.smhdental.co.uk/team/",
+            "page-truth/team-sara-burden.txt"
+          ]
+        },
+        {
+          "name": "Evgenia Georgieva (Jenny)",
+          "role": "Dental Hygienist",
+          "gdcNumber": "275874",
+          "sources": [
+            "https://www.smhdental.co.uk/team/"
+          ]
+        }
+      ],
+      "conflictsOrDrift": [
+        "Current repo page-truth/team.txt labels Sara Burden as Associate dentist in one routing-card block, while live site and profile page-truth/team-sara-burden.txt verify Sara Burden as Dental Hygienist. Registry uses Dental Hygienist and records the drift for future content cleanup.",
+        "Live site search cache showed older team names not present in the current opened team page. Registry uses current opened live page facts plus repo/user prompt facts only."
+      ]
+    },
+    "clinicalApprovalRegistry": {
+      "recommendation": "READY_FOR_FINAL_LAUNCH_HARDENING",
+      "remainingLaunchBlockers": [],
+      "summary": {
+        "packets_reviewed": 11,
+        "packets_approved": 11,
+        "packets_approved_with_edits": 0,
+        "packets_rejected": 0,
+        "approval_flags_recommended_for_enablement": 44,
+        "runtime_approval_flags_changed": 0,
+        "excluded_packet_note": "cosmetic-dentistry packet exists in the answer registry but was outside the 11-packet clinical approval audit scope for this mission."
+      },
+      "priorRemainingLaunchBlockers": [
+        "Apply approved_for_* runtime flag mutations in a bounded implementation packet or update QA contract to consume this approval ledger.",
+        "Run final launch hardening after approval flags and schema consumption are aligned with CI evidence.",
+        "Do not claim launch certification until final hardening evidence passes."
+      ],
+      "currentResolutionEvidence": "Final hardening QA and approval flag activation evidence are now present and passing."
+    },
+    "approvalFlagActivation": {
+      "status": "pass",
+      "approvedPacketCount": 11,
+      "activatedFlagCount": 44,
+      "notActivated": [
+        {
+          "packet": "smh-answer-priority-cosmetic-dentistry-packet-v1",
+          "reason": "Outside 11-packet clinical approval ledger scope; flags remain false."
+        }
+      ]
+    },
+    "chatbotAlignment": {
+      "status": "alignment_foundation_only",
+      "runtimeMutation": false,
+      "mappingCount": 17,
+      "driftRisks": []
+    }
+  },
+  "blockerMatrix": {
+    "version": "CHAMPAGNE_FINAL_RECHECK_BLOCKER_MATRIX_V1",
+    "generatedAt": "2026-06-02T17:56:51.164Z",
+    "certification": "CERTIFIED_READY_FOR_LAUNCH_PREPARATION",
+    "blockers": [],
+    "resolvedFromPreviousAudit": [
+      {
+        "id": "current_lighthouse_cwv_mobile_accessibility_evidence",
+        "previousClassification": "HIGH",
+        "currentClassification": "RESOLVED",
+        "evidence": "8/8 required routes returned HTTP 200; 8/8 produced Lighthouse mobile lab evidence; 8/8 passed mobile readiness; 8/8 passed accessibility heuristics."
+      }
+    ],
+    "remainingItems": [
+      {
+        "id": "high_total_blocking_time_inp_proxy",
+        "classification": "MEDIUM",
+        "preLaunchRequired": true,
+        "itemCount": 8,
+        "justification": "Rerun records TBT as a lab INP proxy and classifies these entries as medium; no field INP evidence is available in local Lighthouse."
+      },
+      {
+        "id": "lcp_above_good_lab_threshold",
+        "classification": "MEDIUM",
+        "preLaunchRequired": true,
+        "itemCount": 5,
+        "justification": "Treatment LCP observations range from 2.5 s to 2.7 s in the rerun and are medium-risk optimization items."
+      },
+      {
+        "id": "lighthouse_accessibility_below_100",
+        "classification": "LOW",
+        "preLaunchRequired": false,
+        "itemCount": 3,
+        "justification": "Affected routes still scored 96 and all required routes passed basic accessibility heuristics."
+      },
+      {
+        "id": "seo_launch_safety_treatment_layout_warnings",
+        "classification": "MEDIUM",
+        "preLaunchRequired": true,
+        "justification": "Carried from the previous audit as review-only: SMH layout guard passes, while launch-safety warnings should be reviewed before deployment."
+      },
+      {
+        "id": "lighthouse_seo_lab_score_meta_description_observation",
+        "classification": "MEDIUM",
+        "preLaunchRequired": true,
+        "justification": "Rerun Lighthouse SEO scores are 54 with meta-description audit observations, while repo schema/metadata QA pass. This is a validation discrepancy to review before deployment, not a certification blocker for launch preparation."
+      },
+      {
+        "id": "answer_length_warnings",
+        "classification": "LOW",
+        "preLaunchRequired": false,
+        "justification": "Answer foundation warnings remain non-blocking; packet QA and rendering QA pass."
+      },
+      {
+        "id": "cosmetic_dentistry_packet_unapproved",
+        "classification": "LOW",
+        "preLaunchRequired": false,
+        "justification": "Contained because the packet remains unactivated/out of scope without fresh approval."
+      },
+      {
+        "id": "intent_cannibalisation_clusters",
+        "classification": "POST_LAUNCH",
+        "preLaunchRequired": false,
+        "justification": "Best handled with Search Console/Semrush evidence after launch."
+      },
+      {
+        "id": "indexnow_absent",
+        "classification": "POST_LAUNCH",
+        "preLaunchRequired": false,
+        "justification": "Affects Bing discovery speed, not Google/local launch preparation readiness."
+      },
+      {
+        "id": "chatbot_runtime_sync_absent",
+        "classification": "POST_LAUNCH",
+        "preLaunchRequired": false,
+        "justification": "Runtime mutation intentionally remains false; alignment evidence is sufficient for launch preparation."
+      }
+    ],
+    "severityCounts": {
+      "BLOCKER": 0,
+      "HIGH": 0,
+      "MEDIUM": 4,
+      "LOW": 3,
+      "POST_LAUNCH": 3
+    }
+  },
+  "scorecard": {
+    "version": "CHAMPAGNE_FINAL_RECHECK_SCORECARD_V1",
+    "generatedAt": "2026-06-02T17:56:51.164Z",
+    "certificationStatus": "CERTIFIED_READY_FOR_LAUNCH_PREPARATION",
+    "overallScore": 86,
+    "scores": [
+      {
+        "area": "Route Availability",
+        "score": 100,
+        "status": "PASS",
+        "evidence": [
+          "8/8 required routes HTTP 200 in rerun",
+          "Route reconciliation status: pass"
+        ],
+        "risk": "None blocking."
+      },
+      {
+        "area": "Lighthouse/CWV Lab Evidence",
+        "score": 76,
+        "status": "PARTIAL_PASS",
+        "evidence": [
+          "8/8 routes measured under mobile Lighthouse lab settings",
+          "Performance scores 70-77",
+          "CLS is 0 on all measured routes"
+        ],
+        "risk": "TBT/INP-proxy and LCP observations remain medium-risk prelaunch optimization tasks."
+      },
+      {
+        "area": "Mobile Readiness",
+        "score": 100,
+        "status": "PASS",
+        "evidence": [
+          "8/8 routes passed mobile readiness evidence"
+        ],
+        "risk": "None blocking."
+      },
+      {
+        "area": "Accessibility Readiness",
+        "score": 96,
+        "status": "PASS",
+        "evidence": [
+          "8/8 routes passed accessibility heuristics",
+          "Lighthouse accessibility scores are 96-100"
+        ],
+        "risk": "Low-risk refinements remain on routes scoring below 100."
+      },
+      {
+        "area": "Schema QA",
+        "score": 89,
+        "status": "PASS",
+        "evidence": [
+          "16 approved schema answers checked",
+          "5 verified team members",
+          "11 priority services"
+        ],
+        "risk": "Future FAQPage/media/offer expansion remains post-launch hardening."
+      },
+      {
+        "area": "Answer QA",
+        "score": 88,
+        "status": "PASS_WITH_WARNINGS",
+        "evidence": [
+          "Answer foundation registry entries: 18; treatment facts: 12; question inventory entries: 55",
+          "Priority packet status: pass_activation_supported",
+          "Visible answer rendering status: pass"
+        ],
+        "risk": "Answer-length refinements are non-blocking."
+      },
+      {
+        "area": "Local Identity",
+        "score": 88,
+        "status": "REVIEW",
+        "evidence": [
+          "Local identity/team schema foundation report is pass",
+          "Production schema did not touch deployment settings, PHI, PMS, or booking backend"
+        ],
+        "risk": "GBP identifiers, geo/hasMap/sameAs remain post-launch/future hardening."
+      },
+      {
+        "area": "Team Registry",
+        "score": 90,
+        "status": "REVIEW",
+        "evidence": [
+          "5 team members verified for schema"
+        ],
+        "risk": "No blocking drift recorded."
+      },
+      {
+        "area": "Clinical Approval Registry",
+        "score": 90,
+        "status": "PASS_AFTER_FINAL_HARDENING",
+        "evidence": [
+          "11 clinical approval decisions recorded",
+          "Prior runtime-flag/final-hardening prerequisites are now covered by final hardening and approval-flag activation evidence"
+        ],
+        "risk": "Continue clinical review intervals after launch."
+      },
+      {
+        "area": "Approval Flag Activation",
+        "score": 88,
+        "status": "PASS",
+        "evidence": [
+          "44 flags activated",
+          "11 approved packets"
+        ],
+        "risk": "Unapproved cosmetic-dentistry packet remains contained."
+      },
+      {
+        "area": "Chatbot Alignment",
+        "score": 84,
+        "status": "REVIEW",
+        "evidence": [
+          "17 mappings",
+          "runtimeMutation: false"
+        ],
+        "risk": "Runtime chatbot mutation remains intentionally absent and post-launch."
+      },
+      {
+        "area": "Launch Preparation Readiness",
+        "score": 86,
+        "status": "CERTIFIED",
+        "evidence": [
+          "Previous evidence blocker is resolved",
+          "Required repository guards and SEO QA are requested for this recheck"
+        ],
+        "risk": "Deployment still requires resolving/reviewing prelaunch optimization tasks and live release authorization."
+      }
+    ]
+  },
+  "prelaunchVsPostlaunch": {
+    "version": "CHAMPAGNE_FINAL_RECHECK_PRELAUNCH_VS_POSTLAUNCH_V1",
+    "generatedAt": "2026-06-02T17:56:51.164Z",
+    "certification": "CERTIFIED_READY_FOR_LAUNCH_PREPARATION",
+    "preLaunchRequired": [
+      {
+        "id": "main_thread_tbt_inp_proxy_review",
+        "classification": "MEDIUM",
+        "owner": "performance mission",
+        "evidence": "8 medium TBT/INP-proxy risk entries in rerun."
+      },
+      {
+        "id": "lcp_threshold_review",
+        "classification": "MEDIUM",
+        "owner": "performance mission",
+        "evidence": "5 medium LCP threshold risk entries in rerun."
+      },
+      {
+        "id": "seo_launch_safety_layout_warning_review",
+        "classification": "MEDIUM",
+        "owner": "SEO launch-safety mission",
+        "evidence": "Carried from previous final audit as review-only because SMH layout guard passed."
+      },
+      {
+        "id": "lighthouse_seo_meta_description_discrepancy_review",
+        "classification": "MEDIUM",
+        "owner": "SEO validation mission",
+        "evidence": "Lighthouse rerun SEO score 54/meta-description observation conflicts with repo metadata/schema QA pass evidence."
+      }
+    ],
+    "postLaunchOrOptional": [
+      {
+        "id": "accessibility_score_96_refinement",
+        "classification": "LOW",
+        "evidence": "3 routes scored 96 while all routes passed accessibility heuristics."
+      },
+      {
+        "id": "answer_length_refinement",
+        "classification": "LOW",
+        "evidence": "Answer foundation warnings remain non-blocking."
+      },
+      {
+        "id": "cosmetic_dentistry_packet_approval",
+        "classification": "LOW",
+        "evidence": "Contained unapproved packet; activate only after fresh clinical approval if needed."
+      },
+      {
+        "id": "indexnow",
+        "classification": "POST_LAUNCH",
+        "evidence": "Bing discovery hardening only."
+      },
+      {
+        "id": "intent_cannibalisation_learning",
+        "classification": "POST_LAUNCH",
+        "evidence": "Requires post-launch Search Console/Semrush evidence."
+      },
+      {
+        "id": "chatbot_runtime_sync",
+        "classification": "POST_LAUNCH",
+        "evidence": "Alignment pass without runtime mutation."
+      }
+    ],
+    "singleNextRecommendation": "Proceed to launch-preparation checklist with a focused prelaunch performance/SEO-validation review; do not deploy until launch owner accepts the remaining medium-risk items."
+  },
+  "finalRecommendation": "Proceed to launch-preparation checklist with a focused prelaunch performance/SEO-validation review; do not deploy until launch owner accepts the remaining medium-risk items."
+}

--- a/tools/audits/final-launch-certification-recheck/CHAMPAGNE_FINAL_LAUNCH_CERTIFICATION_RECHECK_V1.md
+++ b/tools/audits/final-launch-certification-recheck/CHAMPAGNE_FINAL_LAUNCH_CERTIFICATION_RECHECK_V1.md
@@ -1,0 +1,81 @@
+# CHAMPAGNE_FINAL_LAUNCH_CERTIFICATION_RECHECK_V1
+
+Generated: 2026-06-02T17:56:51.164Z
+
+## Certification decision
+
+CERTIFIED_READY_FOR_LAUNCH_PREPARATION
+
+## Boundary
+
+This recheck is audit-only. No fixes, redesigns, deployments, PHI/PMS/Dentally work, booking workflow edits, chatbot runtime changes, SEO registry mutations, schema mutations, manifest mutations, or approval flag mutations were performed.
+
+## Evidence reviewed
+
+- Previous final launch certification audit: NOT_CERTIFIED_READY_FOR_LAUNCH_PREPARATION; withholding reason was missing current Lighthouse/CWV/mobile/accessibility evidence.
+- Lighthouse/CWV/mobile/accessibility rerun: READY_FOR_FINAL_CERTIFICATION_RECHECK.
+- Required route availability: 8/8 HTTP 200.
+- Lighthouse mobile lab evidence: 8/8 routes measured.
+- Mobile readiness: 8/8 routes passed.
+- Accessibility heuristics: 8/8 routes passed; Lighthouse accessibility scores were 96-100.
+- Route reconciliation: pass.
+- Schema QA: pass; 16 approved schema answers, 5 verified team members, 11 priority services.
+- Answer QA/rendering: priority packet status pass_activation_supported; visible rendering status pass.
+- Local identity/team registry: local identity report bounded_foundation_implemented_not_launch_certified; team registry verified_bounded_foundation.
+- Clinical approval registry: READY_FOR_FINAL_LAUNCH_HARDENING with prior runtime-flag/final-hardening prerequisites now covered by final hardening and approval-flag activation evidence.
+- Approval flag activation: pass; 44 activated flags across 11 approved packets.
+- Chatbot alignment: alignment_foundation_only; runtimeMutation remains false; mappings 17.
+
+## Scorecard
+
+| Area | Score | Status | Remaining risk |
+| --- | ---: | --- | --- |
+| Route Availability | 100 | PASS | None blocking. |
+| Lighthouse/CWV Lab Evidence | 76 | PARTIAL_PASS | TBT/INP-proxy and LCP observations remain medium-risk prelaunch optimization tasks. |
+| Mobile Readiness | 100 | PASS | None blocking. |
+| Accessibility Readiness | 96 | PASS | Low-risk refinements remain on routes scoring below 100. |
+| Schema QA | 89 | PASS | Future FAQPage/media/offer expansion remains post-launch hardening. |
+| Answer QA | 88 | PASS_WITH_WARNINGS | Answer-length refinements are non-blocking. |
+| Local Identity | 88 | REVIEW | GBP identifiers, geo/hasMap/sameAs remain post-launch/future hardening. |
+| Team Registry | 90 | REVIEW | No blocking drift recorded. |
+| Clinical Approval Registry | 90 | PASS_AFTER_FINAL_HARDENING | Continue clinical review intervals after launch. |
+| Approval Flag Activation | 88 | PASS | Unapproved cosmetic-dentistry packet remains contained. |
+| Chatbot Alignment | 84 | REVIEW | Runtime chatbot mutation remains intentionally absent and post-launch. |
+| Launch Preparation Readiness | 86 | CERTIFIED | Deployment still requires resolving/reviewing prelaunch optimization tasks and live release authorization. |
+
+## Remaining blocker classification
+
+No BLOCKER or HIGH items remain for launch-preparation certification.
+
+| Item | Classification | Prelaunch required | Basis |
+| --- | --- | --- | --- |
+| high_total_blocking_time_inp_proxy | MEDIUM | yes | Rerun records TBT as a lab INP proxy and classifies these entries as medium; no field INP evidence is available in local Lighthouse. |
+| lcp_above_good_lab_threshold | MEDIUM | yes | Treatment LCP observations range from 2.5 s to 2.7 s in the rerun and are medium-risk optimization items. |
+| lighthouse_accessibility_below_100 | LOW | no | Affected routes still scored 96 and all required routes passed basic accessibility heuristics. |
+| seo_launch_safety_treatment_layout_warnings | MEDIUM | yes | Carried from the previous audit as review-only: SMH layout guard passes, while launch-safety warnings should be reviewed before deployment. |
+| lighthouse_seo_lab_score_meta_description_observation | MEDIUM | yes | Rerun Lighthouse SEO scores are 54 with meta-description audit observations, while repo schema/metadata QA pass. This is a validation discrepancy to review before deployment, not a certification blocker for launch preparation. |
+| answer_length_warnings | LOW | no | Answer foundation warnings remain non-blocking; packet QA and rendering QA pass. |
+| cosmetic_dentistry_packet_unapproved | LOW | no | Contained because the packet remains unactivated/out of scope without fresh approval. |
+| intent_cannibalisation_clusters | POST_LAUNCH | no | Best handled with Search Console/Semrush evidence after launch. |
+| indexnow_absent | POST_LAUNCH | no | Affects Bing discovery speed, not Google/local launch preparation readiness. |
+| chatbot_runtime_sync_absent | POST_LAUNCH | no | Runtime mutation intentionally remains false; alignment evidence is sufficient for launch preparation. |
+
+## Prelaunch tasks
+
+- MEDIUM: main_thread_tbt_inp_proxy_review — 8 medium TBT/INP-proxy risk entries in rerun.
+- MEDIUM: lcp_threshold_review — 5 medium LCP threshold risk entries in rerun.
+- MEDIUM: seo_launch_safety_layout_warning_review — Carried from previous final audit as review-only because SMH layout guard passed.
+- MEDIUM: lighthouse_seo_meta_description_discrepancy_review — Lighthouse rerun SEO score 54/meta-description observation conflicts with repo metadata/schema QA pass evidence.
+
+## Post-launch / optional tasks
+
+- LOW: accessibility_score_96_refinement — 3 routes scored 96 while all routes passed accessibility heuristics.
+- LOW: answer_length_refinement — Answer foundation warnings remain non-blocking.
+- LOW: cosmetic_dentistry_packet_approval — Contained unapproved packet; activate only after fresh clinical approval if needed.
+- POST_LAUNCH: indexnow — Bing discovery hardening only.
+- POST_LAUNCH: intent_cannibalisation_learning — Requires post-launch Search Console/Semrush evidence.
+- POST_LAUNCH: chatbot_runtime_sync — Alignment pass without runtime mutation.
+
+## Decision rationale
+
+The previous final certification blocker is resolved by the rerun evidence. The remaining issues are medium-risk performance/validation review items, low-risk refinements, or post-launch hardening. Therefore the repository is certified ready for launch preparation, but this does not certify deployment and does not authorize launch.

--- a/tools/audits/final-launch-certification-recheck/CHAMPAGNE_FINAL_RECHECK_BLOCKER_MATRIX_V1.json
+++ b/tools/audits/final-launch-certification-recheck/CHAMPAGNE_FINAL_RECHECK_BLOCKER_MATRIX_V1.json
@@ -1,0 +1,86 @@
+{
+  "version": "CHAMPAGNE_FINAL_RECHECK_BLOCKER_MATRIX_V1",
+  "generatedAt": "2026-06-02T17:56:51.164Z",
+  "certification": "CERTIFIED_READY_FOR_LAUNCH_PREPARATION",
+  "blockers": [],
+  "resolvedFromPreviousAudit": [
+    {
+      "id": "current_lighthouse_cwv_mobile_accessibility_evidence",
+      "previousClassification": "HIGH",
+      "currentClassification": "RESOLVED",
+      "evidence": "8/8 required routes returned HTTP 200; 8/8 produced Lighthouse mobile lab evidence; 8/8 passed mobile readiness; 8/8 passed accessibility heuristics."
+    }
+  ],
+  "remainingItems": [
+    {
+      "id": "high_total_blocking_time_inp_proxy",
+      "classification": "MEDIUM",
+      "preLaunchRequired": true,
+      "itemCount": 8,
+      "justification": "Rerun records TBT as a lab INP proxy and classifies these entries as medium; no field INP evidence is available in local Lighthouse."
+    },
+    {
+      "id": "lcp_above_good_lab_threshold",
+      "classification": "MEDIUM",
+      "preLaunchRequired": true,
+      "itemCount": 5,
+      "justification": "Treatment LCP observations range from 2.5 s to 2.7 s in the rerun and are medium-risk optimization items."
+    },
+    {
+      "id": "lighthouse_accessibility_below_100",
+      "classification": "LOW",
+      "preLaunchRequired": false,
+      "itemCount": 3,
+      "justification": "Affected routes still scored 96 and all required routes passed basic accessibility heuristics."
+    },
+    {
+      "id": "seo_launch_safety_treatment_layout_warnings",
+      "classification": "MEDIUM",
+      "preLaunchRequired": true,
+      "justification": "Carried from the previous audit as review-only: SMH layout guard passes, while launch-safety warnings should be reviewed before deployment."
+    },
+    {
+      "id": "lighthouse_seo_lab_score_meta_description_observation",
+      "classification": "MEDIUM",
+      "preLaunchRequired": true,
+      "justification": "Rerun Lighthouse SEO scores are 54 with meta-description audit observations, while repo schema/metadata QA pass. This is a validation discrepancy to review before deployment, not a certification blocker for launch preparation."
+    },
+    {
+      "id": "answer_length_warnings",
+      "classification": "LOW",
+      "preLaunchRequired": false,
+      "justification": "Answer foundation warnings remain non-blocking; packet QA and rendering QA pass."
+    },
+    {
+      "id": "cosmetic_dentistry_packet_unapproved",
+      "classification": "LOW",
+      "preLaunchRequired": false,
+      "justification": "Contained because the packet remains unactivated/out of scope without fresh approval."
+    },
+    {
+      "id": "intent_cannibalisation_clusters",
+      "classification": "POST_LAUNCH",
+      "preLaunchRequired": false,
+      "justification": "Best handled with Search Console/Semrush evidence after launch."
+    },
+    {
+      "id": "indexnow_absent",
+      "classification": "POST_LAUNCH",
+      "preLaunchRequired": false,
+      "justification": "Affects Bing discovery speed, not Google/local launch preparation readiness."
+    },
+    {
+      "id": "chatbot_runtime_sync_absent",
+      "classification": "POST_LAUNCH",
+      "preLaunchRequired": false,
+      "justification": "Runtime mutation intentionally remains false; alignment evidence is sufficient for launch preparation."
+    }
+  ],
+  "severityCounts": {
+    "BLOCKER": 0,
+    "HIGH": 0,
+    "MEDIUM": 4,
+    "LOW": 3,
+    "POST_LAUNCH": 3
+  }
+}

--- a/tools/audits/final-launch-certification-recheck/CHAMPAGNE_FINAL_RECHECK_PRELAUNCH_VS_POSTLAUNCH_V1.json
+++ b/tools/audits/final-launch-certification-recheck/CHAMPAGNE_FINAL_RECHECK_PRELAUNCH_VS_POSTLAUNCH_V1.json
@@ -1,0 +1,64 @@
+{
+  "version": "CHAMPAGNE_FINAL_RECHECK_PRELAUNCH_VS_POSTLAUNCH_V1",
+  "generatedAt": "2026-06-02T17:56:51.164Z",
+  "certification": "CERTIFIED_READY_FOR_LAUNCH_PREPARATION",
+  "preLaunchRequired": [
+    {
+      "id": "main_thread_tbt_inp_proxy_review",
+      "classification": "MEDIUM",
+      "owner": "performance mission",
+      "evidence": "8 medium TBT/INP-proxy risk entries in rerun."
+    },
+    {
+      "id": "lcp_threshold_review",
+      "classification": "MEDIUM",
+      "owner": "performance mission",
+      "evidence": "5 medium LCP threshold risk entries in rerun."
+    },
+    {
+      "id": "seo_launch_safety_layout_warning_review",
+      "classification": "MEDIUM",
+      "owner": "SEO launch-safety mission",
+      "evidence": "Carried from previous final audit as review-only because SMH layout guard passed."
+    },
+    {
+      "id": "lighthouse_seo_meta_description_discrepancy_review",
+      "classification": "MEDIUM",
+      "owner": "SEO validation mission",
+      "evidence": "Lighthouse rerun SEO score 54/meta-description observation conflicts with repo metadata/schema QA pass evidence."
+    }
+  ],
+  "postLaunchOrOptional": [
+    {
+      "id": "accessibility_score_96_refinement",
+      "classification": "LOW",
+      "evidence": "3 routes scored 96 while all routes passed accessibility heuristics."
+    },
+    {
+      "id": "answer_length_refinement",
+      "classification": "LOW",
+      "evidence": "Answer foundation warnings remain non-blocking."
+    },
+    {
+      "id": "cosmetic_dentistry_packet_approval",
+      "classification": "LOW",
+      "evidence": "Contained unapproved packet; activate only after fresh clinical approval if needed."
+    },
+    {
+      "id": "indexnow",
+      "classification": "POST_LAUNCH",
+      "evidence": "Bing discovery hardening only."
+    },
+    {
+      "id": "intent_cannibalisation_learning",
+      "classification": "POST_LAUNCH",
+      "evidence": "Requires post-launch Search Console/Semrush evidence."
+    },
+    {
+      "id": "chatbot_runtime_sync",
+      "classification": "POST_LAUNCH",
+      "evidence": "Alignment pass without runtime mutation."
+    }
+  ],
+  "singleNextRecommendation": "Proceed to launch-preparation checklist with a focused prelaunch performance/SEO-validation review; do not deploy until launch owner accepts the remaining medium-risk items."
+}

--- a/tools/audits/final-launch-certification-recheck/CHAMPAGNE_FINAL_RECHECK_RECOMMENDATION_V1.md
+++ b/tools/audits/final-launch-certification-recheck/CHAMPAGNE_FINAL_RECHECK_RECOMMENDATION_V1.md
@@ -1,0 +1,26 @@
+# CHAMPAGNE_FINAL_RECHECK_RECOMMENDATION_V1
+
+Generated: 2026-06-02T17:56:51.164Z
+
+## Recommendation
+
+CERTIFIED_READY_FOR_LAUNCH_PREPARATION
+
+## Single next recommendation
+
+Proceed to launch-preparation checklist with a focused prelaunch performance/SEO-validation review; do not deploy until launch owner accepts the remaining medium-risk items.
+
+## Why
+
+- The previous missing Lighthouse/CWV/mobile/accessibility evidence blocker is resolved.
+- No remaining item is classified as BLOCKER or HIGH.
+- Medium items are prelaunch review/optimization tasks: main-thread TBT/INP-proxy review, LCP threshold review, SEO launch-safety layout warning review, and Lighthouse SEO/meta-description validation discrepancy review.
+- Low and post-launch items are contained and should not block launch-preparation certification.
+
+## Not authorized by this recommendation
+
+- Deployment.
+- PHI/PMS/Dentally changes.
+- Booking workflow changes.
+- Chatbot runtime mutation.
+- SEO registry/schema/manifest/approval flag mutation.

--- a/tools/audits/final-launch-certification-recheck/CHAMPAGNE_FINAL_RECHECK_SCORECARD_V1.json
+++ b/tools/audits/final-launch-certification-recheck/CHAMPAGNE_FINAL_RECHECK_SCORECARD_V1.json
@@ -1,0 +1,129 @@
+{
+  "version": "CHAMPAGNE_FINAL_RECHECK_SCORECARD_V1",
+  "generatedAt": "2026-06-02T17:56:51.164Z",
+  "certificationStatus": "CERTIFIED_READY_FOR_LAUNCH_PREPARATION",
+  "overallScore": 86,
+  "scores": [
+    {
+      "area": "Route Availability",
+      "score": 100,
+      "status": "PASS",
+      "evidence": [
+        "8/8 required routes HTTP 200 in rerun",
+        "Route reconciliation status: pass"
+      ],
+      "risk": "None blocking."
+    },
+    {
+      "area": "Lighthouse/CWV Lab Evidence",
+      "score": 76,
+      "status": "PARTIAL_PASS",
+      "evidence": [
+        "8/8 routes measured under mobile Lighthouse lab settings",
+        "Performance scores 70-77",
+        "CLS is 0 on all measured routes"
+      ],
+      "risk": "TBT/INP-proxy and LCP observations remain medium-risk prelaunch optimization tasks."
+    },
+    {
+      "area": "Mobile Readiness",
+      "score": 100,
+      "status": "PASS",
+      "evidence": [
+        "8/8 routes passed mobile readiness evidence"
+      ],
+      "risk": "None blocking."
+    },
+    {
+      "area": "Accessibility Readiness",
+      "score": 96,
+      "status": "PASS",
+      "evidence": [
+        "8/8 routes passed accessibility heuristics",
+        "Lighthouse accessibility scores are 96-100"
+      ],
+      "risk": "Low-risk refinements remain on routes scoring below 100."
+    },
+    {
+      "area": "Schema QA",
+      "score": 89,
+      "status": "PASS",
+      "evidence": [
+        "16 approved schema answers checked",
+        "5 verified team members",
+        "11 priority services"
+      ],
+      "risk": "Future FAQPage/media/offer expansion remains post-launch hardening."
+    },
+    {
+      "area": "Answer QA",
+      "score": 88,
+      "status": "PASS_WITH_WARNINGS",
+      "evidence": [
+        "Answer foundation registry entries: 18; treatment facts: 12; question inventory entries: 55",
+        "Priority packet status: pass_activation_supported",
+        "Visible answer rendering status: pass"
+      ],
+      "risk": "Answer-length refinements are non-blocking."
+    },
+    {
+      "area": "Local Identity",
+      "score": 88,
+      "status": "REVIEW",
+      "evidence": [
+        "Local identity/team schema foundation report is pass",
+        "Production schema did not touch deployment settings, PHI, PMS, or booking backend"
+      ],
+      "risk": "GBP identifiers, geo/hasMap/sameAs remain post-launch/future hardening."
+    },
+    {
+      "area": "Team Registry",
+      "score": 90,
+      "status": "REVIEW",
+      "evidence": [
+        "5 team members verified for schema"
+      ],
+      "risk": "No blocking drift recorded."
+    },
+    {
+      "area": "Clinical Approval Registry",
+      "score": 90,
+      "status": "PASS_AFTER_FINAL_HARDENING",
+      "evidence": [
+        "11 clinical approval decisions recorded",
+        "Prior runtime-flag/final-hardening prerequisites are now covered by final hardening and approval-flag activation evidence"
+      ],
+      "risk": "Continue clinical review intervals after launch."
+    },
+    {
+      "area": "Approval Flag Activation",
+      "score": 88,
+      "status": "PASS",
+      "evidence": [
+        "44 flags activated",
+        "11 approved packets"
+      ],
+      "risk": "Unapproved cosmetic-dentistry packet remains contained."
+    },
+    {
+      "area": "Chatbot Alignment",
+      "score": 84,
+      "status": "REVIEW",
+      "evidence": [
+        "17 mappings",
+        "runtimeMutation: false"
+      ],
+      "risk": "Runtime chatbot mutation remains intentionally absent and post-launch."
+    },
+    {
+      "area": "Launch Preparation Readiness",
+      "score": 86,
+      "status": "CERTIFIED",
+      "evidence": [
+        "Previous evidence blocker is resolved",
+        "Required repository guards and SEO QA are requested for this recheck"
+      ],
+      "risk": "Deployment still requires resolving/reviewing prelaunch optimization tasks and live release authorization."
+    }
+  ]
+}

--- a/tools/audits/launch-preparation-acceptance/CHAMPAGNE_DEPLOYMENT_PLAN_V1.md
+++ b/tools/audits/launch-preparation-acceptance/CHAMPAGNE_DEPLOYMENT_PLAN_V1.md
@@ -1,0 +1,22 @@
+# CHAMPAGNE_DEPLOYMENT_PLAN_V1
+
+Generated: 2026-06-03T01:53:18.708Z
+
+## Boundary
+
+Planning only. No deployment, merge, production infrastructure mutation, PHI/PMS/Dentally work, booking workflow change, or chatbot runtime mutation is authorized by this plan.
+
+## Recommended sequence
+
+1. Final owner review of the launch-preparation acceptance package.
+2. Medium-risk acceptance: explicitly accept or remediate TBT/INP-proxy, LCP, SEO launch-safety layout warning, and Lighthouse SEO/meta-description discrepancy review items.
+3. Production build verification on the exact deploy candidate commit.
+4. Merge approval by authorized owner only.
+5. Schedule deploy window.
+6. Deploy-window smoke test plan: required routes, schema output, mobile rendering, accessibility heuristics, SEO metadata/schema, contact route, patient portal safety, and no retired booking target regressions.
+7. Search Console/sitemap submission after deployment.
+8. Monitoring: route availability, Core Web Vitals/INP field data, Search Console query learning, Semrush/cannibalisation monitoring, and post-launch backlog triage.
+
+## Deployment planning status
+
+READY_FOR_DEPLOYMENT_PLANNING

--- a/tools/audits/launch-preparation-acceptance/CHAMPAGNE_DEPLOYMENT_READINESS_V1.json
+++ b/tools/audits/launch-preparation-acceptance/CHAMPAGNE_DEPLOYMENT_READINESS_V1.json
@@ -1,0 +1,43 @@
+{
+  "version": "CHAMPAGNE_DEPLOYMENT_READINESS_V1",
+  "generatedAt": "2026-06-03T01:53:18.708Z",
+  "deploymentReadiness": "CONDITIONAL_READY",
+  "planningStatus": "READY_FOR_DEPLOYMENT_PLANNING",
+  "conditions": [
+    "Launch owner must accept or remediate the remaining medium-risk items before deploy approval.",
+    "Run final production build/guard verification on the exact deploy candidate commit.",
+    "Deployment, merge, and production mutation remain outside this packet."
+  ],
+  "assessments": [
+    {
+      "area": "Build status",
+      "status": "READY",
+      "evidence": "pnpm run verify passed during this acceptance packet run."
+    },
+    {
+      "area": "Route status",
+      "status": "READY",
+      "evidence": "8/8 required routes returned HTTP 200; route reconciliation status pass."
+    },
+    {
+      "area": "Schema status",
+      "status": "READY",
+      "evidence": "Schema QA status pass; 16 approved schema answers, 5 verified team members, 11 priority services."
+    },
+    {
+      "area": "SEO status",
+      "status": "CONDITIONAL_READY",
+      "evidence": "Final hardening QA pass_with_known_warnings; final recheck certified readiness; medium SEO review items remain for owner acceptance."
+    },
+    {
+      "area": "Mobile status",
+      "status": "READY",
+      "evidence": "8/8 routes passed mobile readiness."
+    },
+    {
+      "area": "Accessibility status",
+      "status": "READY",
+      "evidence": "8/8 routes passed accessibility heuristics; scores 96-100."
+    }
+  ]
+}

--- a/tools/audits/launch-preparation-acceptance/CHAMPAGNE_FINAL_RECOMMENDATION_V1.md
+++ b/tools/audits/launch-preparation-acceptance/CHAMPAGNE_FINAL_RECOMMENDATION_V1.md
@@ -1,0 +1,24 @@
+# CHAMPAGNE_FINAL_RECOMMENDATION_V1
+
+Generated: 2026-06-03T01:53:18.708Z
+
+## Required final status
+
+READY_FOR_DEPLOYMENT_PLANNING
+
+## Deployment readiness
+
+CONDITIONAL_READY
+
+## Recommendation
+
+Proceed to deployment planning, not deployment. The site is certified ready for launch preparation, has 0 blockers and 0 high-risk items, and has only medium-risk owner-acceptance items remaining before deploy approval.
+
+## Non-negotiable boundaries
+
+- Do not deploy from this packet.
+- Do not merge from this packet.
+- Do not mutate production infrastructure.
+- Do not touch PHI/PMS/Dentally systems.
+- Do not modify booking workflows.
+- Do not modify chatbot runtime.

--- a/tools/audits/launch-preparation-acceptance/CHAMPAGNE_LAUNCH_PREPARATION_ACCEPTANCE_V1.json
+++ b/tools/audits/launch-preparation-acceptance/CHAMPAGNE_LAUNCH_PREPARATION_ACCEPTANCE_V1.json
@@ -1,0 +1,391 @@
+{
+  "version": "CHAMPAGNE_LAUNCH_PREPARATION_ACCEPTANCE_V1",
+  "generatedAt": "2026-06-03T01:53:18.708Z",
+  "role": "CHAMPAGNE_LAUNCH_PREPARATION_ACCEPTANCE_CHECKLIST_V1",
+  "boundary": [
+    "Governance and launch-planning only.",
+    "No deployment.",
+    "No merge.",
+    "No production infrastructure mutation.",
+    "No redesign or content rewrite.",
+    "No PHI/PMS/Dentally work.",
+    "No chatbot runtime mutation."
+  ],
+  "finalStatus": "READY_FOR_DEPLOYMENT_PLANNING",
+  "deploymentReadiness": "CONDITIONAL_READY",
+  "consolidatedTruthView": {
+    "certification": {
+      "currentStatus": "CERTIFIED_READY_FOR_LAUNCH_PREPARATION",
+      "readinessScore": 86,
+      "blockerCount": 0,
+      "highRiskCount": 0,
+      "mediumRiskCount": 4
+    },
+    "routeEvidence": {
+      "routeReconciliationStatus": "pass",
+      "routeQaMode": "runtime_and_static",
+      "requiredRoutesHttp200": "8/8"
+    },
+    "lighthouseEvidence": {
+      "classification": "READY_FOR_FINAL_CERTIFICATION_RECHECK",
+      "measuredRoutes": "8/8",
+      "performanceScores": {
+        "/": 75,
+        "/contact": 75,
+        "/treatments/emergency-dentistry": 75,
+        "/treatments/implants": 74,
+        "/treatments/clear-aligners-spark": 70,
+        "/treatments/3d-dentistry-and-technology": 76,
+        "/treatments/sedation-dentistry": 77,
+        "/treatments/preventative-and-general-dentistry": 75
+      },
+      "remainingRiskCount": 16
+    },
+    "mobileEvidence": {
+      "passedRoutes": "8/8"
+    },
+    "accessibilityEvidence": {
+      "passedRoutes": "8/8",
+      "scores": {
+        "/": 96,
+        "/contact": 96,
+        "/treatments/emergency-dentistry": 96,
+        "/treatments/implants": 100,
+        "/treatments/clear-aligners-spark": 100,
+        "/treatments/3d-dentistry-and-technology": 100,
+        "/treatments/sedation-dentistry": 100,
+        "/treatments/preventative-and-general-dentistry": 100
+      }
+    },
+    "seoEvidence": {
+      "finalHardeningQaStatus": "pass_with_known_warnings",
+      "localIdentityStatus": "bounded_foundation_implemented_not_launch_certified",
+      "teamRegistryStatus": "verified_bounded_foundation"
+    },
+    "schemaEvidence": {
+      "status": "pass",
+      "approvedSchemaAnswerCount": 16,
+      "verifiedTeamMemberCount": 5,
+      "priorityServiceCount": 11,
+      "errors": [],
+      "warnings": []
+    },
+    "answerEvidence": {
+      "foundationScores": {
+        "aiReadinessScore": 83,
+        "zeroClickReadinessScore": 71
+      },
+      "packetStatus": "pass_activation_supported",
+      "visibleRenderingStatus": "pass"
+    },
+    "clinicalAndApprovalEvidence": {
+      "clinicalRecommendation": "READY_FOR_FINAL_LAUNCH_HARDENING",
+      "approvedPackets": 11,
+      "approvalFlagStatus": "pass",
+      "activatedFlagCount": 44
+    },
+    "chatbotEvidence": {
+      "status": "alignment_foundation_only",
+      "mappingCount": 17,
+      "runtimeMutation": false
+    }
+  },
+  "prelaunchChecklist": {
+    "version": "CHAMPAGNE_PRELAUNCH_CHECKLIST_V1",
+    "generatedAt": "2026-06-03T01:53:18.708Z",
+    "status": "READY_FOR_DEPLOYMENT_PLANNING_WITH_OWNER_ACCEPTANCE_REQUIRED",
+    "requiredBeforeDeploy": [
+      {
+        "id": "launch_owner_acceptance_of_certification_recheck",
+        "classification": "REQUIRED BEFORE DEPLOY",
+        "evidence": "Final recheck is CERTIFIED_READY_FOR_LAUNCH_PREPARATION with 0 blockers and 0 high-risk items.",
+        "acceptanceCriterion": "Launch owner records acceptance of the certification decision and remaining medium-risk items."
+      },
+      {
+        "id": "main_thread_tbt_inp_proxy_review",
+        "classification": "REQUIRED BEFORE DEPLOY",
+        "riskLevel": "MEDIUM",
+        "owner": "performance mission",
+        "evidence": "8 medium TBT/INP-proxy risk entries in rerun.",
+        "acceptanceCriterion": "Review and either remediate or explicitly accept before deployment approval."
+      },
+      {
+        "id": "lcp_threshold_review",
+        "classification": "REQUIRED BEFORE DEPLOY",
+        "riskLevel": "MEDIUM",
+        "owner": "performance mission",
+        "evidence": "5 medium LCP threshold risk entries in rerun.",
+        "acceptanceCriterion": "Review and either remediate or explicitly accept before deployment approval."
+      },
+      {
+        "id": "seo_launch_safety_layout_warning_review",
+        "classification": "REQUIRED BEFORE DEPLOY",
+        "riskLevel": "MEDIUM",
+        "owner": "SEO launch-safety mission",
+        "evidence": "Carried from previous final audit as review-only because SMH layout guard passed.",
+        "acceptanceCriterion": "Review and either remediate or explicitly accept before deployment approval."
+      },
+      {
+        "id": "lighthouse_seo_meta_description_discrepancy_review",
+        "classification": "REQUIRED BEFORE DEPLOY",
+        "riskLevel": "MEDIUM",
+        "owner": "SEO validation mission",
+        "evidence": "Lighthouse rerun SEO score 54/meta-description observation conflicts with repo metadata/schema QA pass evidence.",
+        "acceptanceCriterion": "Review and either remediate or explicitly accept before deployment approval."
+      },
+      {
+        "id": "fresh_production_build_verification_before_deploy_window",
+        "classification": "REQUIRED BEFORE DEPLOY",
+        "evidence": "pnpm run verify passed during the acceptance packet run; repeat immediately before deploy window if code changes land after this packet.",
+        "acceptanceCriterion": "Production build verification passes on the deploy candidate commit."
+      },
+      {
+        "id": "no_deployment_or_runtime_mutation_in_this_packet",
+        "classification": "REQUIRED BEFORE DEPLOY",
+        "evidence": "This packet is governance/planning only and does not deploy, merge, alter production infrastructure, touch PHI/PMS/Dentally, or mutate chatbot runtime.",
+        "acceptanceCriterion": "Launch owner confirms deployment remains a separately approved event."
+      }
+    ],
+    "optionalBeforeDeploy": [
+      {
+        "id": "accessibility_score_96_refinement",
+        "classification": "OPTIONAL BEFORE DEPLOY",
+        "riskLevel": "LOW",
+        "evidence": "Three Lighthouse accessibility scores are 96 while all eight required routes passed accessibility heuristics.",
+        "acceptanceCriterion": "Optional refinement may be deferred because readiness evidence passes."
+      },
+      {
+        "id": "answer_length_refinement",
+        "classification": "OPTIONAL BEFORE DEPLOY",
+        "riskLevel": "LOW",
+        "evidence": "Answer foundation QA passes with over-length warnings only.",
+        "acceptanceCriterion": "Optional copy-length refinement may be scheduled without blocking deploy planning."
+      },
+      {
+        "id": "cosmetic_dentistry_packet_approval",
+        "classification": "OPTIONAL BEFORE DEPLOY",
+        "riskLevel": "LOW",
+        "evidence": "Cosmetic dentistry packet remains contained/unactivated without fresh approval.",
+        "acceptanceCriterion": "Do not activate unless a fresh clinical approval packet is completed."
+      }
+    ]
+  },
+  "postlaunchBacklog": {
+    "version": "CHAMPAGNE_POSTLAUNCH_BACKLOG_V1",
+    "generatedAt": "2026-06-03T01:53:18.708Z",
+    "status": "POST_LAUNCH_BACKLOG_DEFINED_NOT_BLOCKING_DEPLOYMENT_PLANNING",
+    "items": [
+      {
+        "id": "indexnow",
+        "classification": "POST_LAUNCH",
+        "priority": "LOW",
+        "evidence": "IndexNow absence affects Bing rapid discovery only and is not a Google/local launch blocker.",
+        "recommendedTiming": "After launch stabilization."
+      },
+      {
+        "id": "chatbot_runtime_sync",
+        "classification": "POST_LAUNCH",
+        "priority": "LOW",
+        "evidence": "Chatbot alignment passes with 17 mappings; runtimeMutation remains false.",
+        "recommendedTiming": "After launch, under a dedicated chatbot runtime authorization."
+      },
+      {
+        "id": "answer_refinement",
+        "classification": "POST_LAUNCH",
+        "priority": "LOW",
+        "evidence": "Answer QA passes; length warnings are refinement-only.",
+        "recommendedTiming": "After Search Console/query evidence is available."
+      },
+      {
+        "id": "intent_cannibalisation_monitoring",
+        "classification": "POST_LAUNCH",
+        "priority": "MEDIUM",
+        "evidence": "Launch-safety reports high-risk topic clusters for audit; no hard route/schema failure is present.",
+        "recommendedTiming": "After Search Console and Semrush learning starts."
+      },
+      {
+        "id": "search_console_learning",
+        "classification": "POST_LAUNCH",
+        "priority": "MEDIUM",
+        "evidence": "AI Mode, zero-click, and local dominance tuning require live query data.",
+        "recommendedTiming": "Begin immediately after deployment and indexing submission."
+      },
+      {
+        "id": "semrush_learning",
+        "classification": "POST_LAUNCH",
+        "priority": "MEDIUM",
+        "evidence": "Competitor and cannibalisation monitoring require live market data.",
+        "recommendedTiming": "After first indexing and ranking signals."
+      },
+      {
+        "id": "competitor_analysis",
+        "classification": "POST_LAUNCH",
+        "priority": "LOW",
+        "evidence": "Competitive readiness is adequate for launch preparation; market response should guide refinements.",
+        "recommendedTiming": "Post-launch month 1."
+      },
+      {
+        "id": "cosmetic_dentistry_packet_approval",
+        "classification": "POST_LAUNCH",
+        "priority": "LOW",
+        "evidence": "Cosmetic dentistry answer packet is unapproved and contained.",
+        "recommendedTiming": "Only if activation becomes a product/SEO priority."
+      }
+    ]
+  },
+  "riskAcceptanceMatrix": {
+    "version": "CHAMPAGNE_RISK_ACCEPTANCE_MATRIX_V1",
+    "generatedAt": "2026-06-03T01:53:18.708Z",
+    "summary": {
+      "LOW": 5,
+      "MEDIUM": 5,
+      "HIGH": 0,
+      "BLOCKER": 0,
+      "POST_LAUNCH_TRACKED": 3
+    },
+    "risks": [
+      {
+        "level": "MEDIUM",
+        "id": "high_total_blocking_time_inp_proxy",
+        "risk": "Rerun records TBT as a lab INP proxy and classifies these entries as medium; no field INP evidence is available in local Lighthouse.",
+        "impact": "Potential interaction latency / INP-proxy concern in lab evidence.",
+        "mitigation": "Review during launch-owner acceptance; remediate if owner requires, otherwise explicitly accept and monitor after launch.",
+        "launchRecommendation": "Do not block deployment planning; require owner acceptance before actual deploy approval."
+      },
+      {
+        "level": "MEDIUM",
+        "id": "lcp_above_good_lab_threshold",
+        "risk": "Treatment LCP observations range from 2.5 s to 2.7 s in the rerun and are medium-risk optimization items.",
+        "impact": "Potential above-the-fold loading delay on measured treatment routes.",
+        "mitigation": "Review during launch-owner acceptance; remediate if owner requires, otherwise explicitly accept and monitor after launch.",
+        "launchRecommendation": "Do not block deployment planning; require owner acceptance before actual deploy approval."
+      },
+      {
+        "level": "MEDIUM",
+        "id": "seo_launch_safety_treatment_layout_warnings",
+        "risk": "Carried from the previous audit as review-only: SMH layout guard passes, while launch-safety warnings should be reviewed before deployment.",
+        "impact": "Pre-deploy SEO review item from launch-safety evidence.",
+        "mitigation": "Review during launch-owner acceptance; remediate if owner requires, otherwise explicitly accept and monitor after launch.",
+        "launchRecommendation": "Do not block deployment planning; require owner acceptance before actual deploy approval."
+      },
+      {
+        "level": "MEDIUM",
+        "id": "lighthouse_seo_lab_score_meta_description_observation",
+        "risk": "Rerun Lighthouse SEO scores are 54 with meta-description audit observations, while repo schema/metadata QA pass. This is a validation discrepancy to review before deployment, not a certification blocker for launch preparation.",
+        "impact": "Validation discrepancy between Lighthouse SEO lab observations and repo metadata/schema QA.",
+        "mitigation": "Review during launch-owner acceptance; remediate if owner requires, otherwise explicitly accept and monitor after launch.",
+        "launchRecommendation": "Do not block deployment planning; require owner acceptance before actual deploy approval."
+      },
+      {
+        "level": "LOW",
+        "id": "lighthouse_accessibility_below_100",
+        "risk": "Affected routes still scored 96 and all required routes passed basic accessibility heuristics.",
+        "impact": "Refinement opportunity only; current QA evidence remains passing or contained.",
+        "mitigation": "Schedule as optional pre-deploy or post-launch backlog work.",
+        "launchRecommendation": "Do not block deployment planning or deploy approval unless scope is expanded."
+      },
+      {
+        "level": "LOW",
+        "id": "answer_length_warnings",
+        "risk": "Answer foundation warnings remain non-blocking; packet QA and rendering QA pass.",
+        "impact": "Refinement opportunity only; current QA evidence remains passing or contained.",
+        "mitigation": "Schedule as optional pre-deploy or post-launch backlog work.",
+        "launchRecommendation": "Do not block deployment planning or deploy approval unless scope is expanded."
+      },
+      {
+        "level": "LOW",
+        "id": "cosmetic_dentistry_packet_unapproved",
+        "risk": "Contained because the packet remains unactivated/out of scope without fresh approval.",
+        "impact": "Refinement opportunity only; current QA evidence remains passing or contained.",
+        "mitigation": "Schedule as optional pre-deploy or post-launch backlog work.",
+        "launchRecommendation": "Do not block deployment planning or deploy approval unless scope is expanded."
+      },
+      {
+        "level": "LOW",
+        "id": "indexnow_absent",
+        "risk": "IndexNow absence affects Bing discovery speed but not Google/local launch preparation readiness.",
+        "impact": "Slower Bing discovery only.",
+        "mitigation": "Schedule IndexNow after launch stabilization if Bing rapid discovery becomes a priority.",
+        "launchRecommendation": "Do not block deployment planning or deploy approval."
+      },
+      {
+        "level": "MEDIUM",
+        "id": "intent_cannibalisation_clusters",
+        "risk": "High-risk intent clusters need live Search Console/Semrush learning after launch.",
+        "impact": "Possible ranking dilution if live query data shows competing page intent.",
+        "mitigation": "Monitor Search Console and Semrush after launch; adjust only with evidence.",
+        "launchRecommendation": "Do not block deployment planning; include in post-launch monitoring."
+      },
+      {
+        "level": "LOW",
+        "id": "chatbot_runtime_sync_absent",
+        "risk": "Chatbot runtime mutation remains intentionally absent while alignment evidence passes.",
+        "impact": "Runtime chatbot may not consume all newly aligned packet flags until a separately authorized sync mission.",
+        "mitigation": "Keep runtime unchanged for launch; schedule a bounded chatbot sync mission after launch if needed.",
+        "launchRecommendation": "Do not block deployment planning or deploy approval."
+      },
+      {
+        "level": "HIGH",
+        "id": "none_remaining",
+        "risk": "No high-risk items remain in the certification recheck blocker matrix.",
+        "impact": "No high-risk launch-preparation blocker identified from current evidence.",
+        "mitigation": "Keep guards and final deploy-candidate verification in place.",
+        "launchRecommendation": "Proceed to deployment planning."
+      }
+    ]
+  },
+  "deploymentReadinessAssessment": {
+    "version": "CHAMPAGNE_DEPLOYMENT_READINESS_V1",
+    "generatedAt": "2026-06-03T01:53:18.708Z",
+    "deploymentReadiness": "CONDITIONAL_READY",
+    "planningStatus": "READY_FOR_DEPLOYMENT_PLANNING",
+    "conditions": [
+      "Launch owner must accept or remediate the remaining medium-risk items before deploy approval.",
+      "Run final production build/guard verification on the exact deploy candidate commit.",
+      "Deployment, merge, and production mutation remain outside this packet."
+    ],
+    "assessments": [
+      {
+        "area": "Build status",
+        "status": "READY",
+        "evidence": "pnpm run verify passed during this acceptance packet run."
+      },
+      {
+        "area": "Route status",
+        "status": "READY",
+        "evidence": "8/8 required routes returned HTTP 200; route reconciliation status pass."
+      },
+      {
+        "area": "Schema status",
+        "status": "READY",
+        "evidence": "Schema QA status pass; 16 approved schema answers, 5 verified team members, 11 priority services."
+      },
+      {
+        "area": "SEO status",
+        "status": "CONDITIONAL_READY",
+        "evidence": "Final hardening QA pass_with_known_warnings; final recheck certified readiness; medium SEO review items remain for owner acceptance."
+      },
+      {
+        "area": "Mobile status",
+        "status": "READY",
+        "evidence": "8/8 routes passed mobile readiness."
+      },
+      {
+        "area": "Accessibility status",
+        "status": "READY",
+        "evidence": "8/8 routes passed accessibility heuristics; scores 96-100."
+      }
+    ]
+  },
+  "deploymentPlan": [
+    "Final owner review of this acceptance package.",
+    "Explicit acceptance or remediation of remaining medium-risk items.",
+    "Production build verification on the deploy candidate commit.",
+    "Merge approval by authorized owner only.",
+    "Schedule deploy window; no deployment is performed by this packet.",
+    "Deploy-window smoke test plan covering route, schema, mobile, accessibility, SEO, and contact/portal safety checks.",
+    "Search Console/sitemap submission after deployment.",
+    "Monitoring and post-launch learning backlog activation."
+  ],
+  "finalRecommendation": "Proceed to deployment planning, not deployment. Deployment approval remains conditional on launch-owner acceptance of medium-risk items and fresh deploy-candidate verification."
+}

--- a/tools/audits/launch-preparation-acceptance/CHAMPAGNE_LAUNCH_PREPARATION_ACCEPTANCE_V1.md
+++ b/tools/audits/launch-preparation-acceptance/CHAMPAGNE_LAUNCH_PREPARATION_ACCEPTANCE_V1.md
@@ -1,0 +1,95 @@
+# CHAMPAGNE_LAUNCH_PREPARATION_ACCEPTANCE_V1
+
+Generated: 2026-06-03T01:53:18.708Z
+
+## Final status
+
+READY_FOR_DEPLOYMENT_PLANNING
+
+## Deployment readiness
+
+CONDITIONAL_READY
+
+This is a governance and launch-planning package only. It does not deploy, merge, mutate production infrastructure, touch PHI/PMS/Dentally systems, modify booking workflows, or mutate chatbot runtime.
+
+## Consolidated truth view
+
+| Area | Evidence status | Launch-preparation interpretation |
+| --- | --- | --- |
+| Certification | CERTIFIED_READY_FOR_LAUNCH_PREPARATION; score 86; blockers 0; high-risk 0 | Certified ready for launch preparation. |
+| Routes | 8/8 required routes HTTP 200; route reconciliation pass | Ready. |
+| Lighthouse/CWV lab | 8/8 routes measured; performance scores 70-77; 16 risk observations | Conditional-ready; medium items require owner acceptance before deploy approval. |
+| Mobile | 8/8 routes passed | Ready. |
+| Accessibility | 8/8 routes passed; Lighthouse scores 96-100 | Ready with low refinements. |
+| Schema | pass; 16 approved schema answers; 5 verified team members; 11 priority services | Ready. |
+| Answers | packet QA pass_activation_supported; visible rendering pass | Ready with non-blocking answer-length refinements. |
+| Local identity/team | local identity bounded_foundation_implemented_not_launch_certified; team registry verified_bounded_foundation | Ready for launch preparation. |
+| Clinical approval / flags | 11 packets approved; approval flag status pass; 44 flags activated | Ready; unapproved cosmetic packet remains contained. |
+| Chatbot alignment | alignment_foundation_only; 17 mappings; runtimeMutation false | Aligned for launch preparation; runtime sync is post-launch/authorized mission only. |
+
+## Pre-launch checklist
+
+### Required before deploy
+
+- **launch_owner_acceptance_of_certification_recheck** — Final recheck is CERTIFIED_READY_FOR_LAUNCH_PREPARATION with 0 blockers and 0 high-risk items.
+- **main_thread_tbt_inp_proxy_review** — 8 medium TBT/INP-proxy risk entries in rerun.
+- **lcp_threshold_review** — 5 medium LCP threshold risk entries in rerun.
+- **seo_launch_safety_layout_warning_review** — Carried from previous final audit as review-only because SMH layout guard passed.
+- **lighthouse_seo_meta_description_discrepancy_review** — Lighthouse rerun SEO score 54/meta-description observation conflicts with repo metadata/schema QA pass evidence.
+- **fresh_production_build_verification_before_deploy_window** — pnpm run verify passed during the acceptance packet run; repeat immediately before deploy window if code changes land after this packet.
+- **no_deployment_or_runtime_mutation_in_this_packet** — This packet is governance/planning only and does not deploy, merge, alter production infrastructure, touch PHI/PMS/Dentally, or mutate chatbot runtime.
+
+### Optional before deploy
+
+- **accessibility_score_96_refinement** — Three Lighthouse accessibility scores are 96 while all eight required routes passed accessibility heuristics.
+- **answer_length_refinement** — Answer foundation QA passes with over-length warnings only.
+- **cosmetic_dentistry_packet_approval** — Cosmetic dentistry packet remains contained/unactivated without fresh approval.
+
+## Remaining medium-risk items
+
+- **high_total_blocking_time_inp_proxy** — Rerun records TBT as a lab INP proxy and classifies these entries as medium; no field INP evidence is available in local Lighthouse.
+- **lcp_above_good_lab_threshold** — Treatment LCP observations range from 2.5 s to 2.7 s in the rerun and are medium-risk optimization items.
+- **seo_launch_safety_treatment_layout_warnings** — Carried from the previous audit as review-only: SMH layout guard passes, while launch-safety warnings should be reviewed before deployment.
+- **lighthouse_seo_lab_score_meta_description_observation** — Rerun Lighthouse SEO scores are 54 with meta-description audit observations, while repo schema/metadata QA pass. This is a validation discrepancy to review before deployment, not a certification blocker for launch preparation.
+
+## Post-launch backlog
+
+- **indexnow** (LOW) — IndexNow absence affects Bing rapid discovery only and is not a Google/local launch blocker.
+- **chatbot_runtime_sync** (LOW) — Chatbot alignment passes with 17 mappings; runtimeMutation remains false.
+- **answer_refinement** (LOW) — Answer QA passes; length warnings are refinement-only.
+- **intent_cannibalisation_monitoring** (MEDIUM) — Launch-safety reports high-risk topic clusters for audit; no hard route/schema failure is present.
+- **search_console_learning** (MEDIUM) — AI Mode, zero-click, and local dominance tuning require live query data.
+- **semrush_learning** (MEDIUM) — Competitor and cannibalisation monitoring require live market data.
+- **competitor_analysis** (LOW) — Competitive readiness is adequate for launch preparation; market response should guide refinements.
+- **cosmetic_dentistry_packet_approval** (LOW) — Cosmetic dentistry answer packet is unapproved and contained.
+
+## Risk acceptance matrix
+
+| Level | Item | Impact | Mitigation | Launch recommendation |
+| --- | --- | --- | --- | --- |
+| MEDIUM | high_total_blocking_time_inp_proxy | Potential interaction latency / INP-proxy concern in lab evidence. | Review during launch-owner acceptance; remediate if owner requires, otherwise explicitly accept and monitor after launch. | Do not block deployment planning; require owner acceptance before actual deploy approval. |
+| MEDIUM | lcp_above_good_lab_threshold | Potential above-the-fold loading delay on measured treatment routes. | Review during launch-owner acceptance; remediate if owner requires, otherwise explicitly accept and monitor after launch. | Do not block deployment planning; require owner acceptance before actual deploy approval. |
+| MEDIUM | seo_launch_safety_treatment_layout_warnings | Pre-deploy SEO review item from launch-safety evidence. | Review during launch-owner acceptance; remediate if owner requires, otherwise explicitly accept and monitor after launch. | Do not block deployment planning; require owner acceptance before actual deploy approval. |
+| MEDIUM | lighthouse_seo_lab_score_meta_description_observation | Validation discrepancy between Lighthouse SEO lab observations and repo metadata/schema QA. | Review during launch-owner acceptance; remediate if owner requires, otherwise explicitly accept and monitor after launch. | Do not block deployment planning; require owner acceptance before actual deploy approval. |
+| LOW | lighthouse_accessibility_below_100 | Refinement opportunity only; current QA evidence remains passing or contained. | Schedule as optional pre-deploy or post-launch backlog work. | Do not block deployment planning or deploy approval unless scope is expanded. |
+| LOW | answer_length_warnings | Refinement opportunity only; current QA evidence remains passing or contained. | Schedule as optional pre-deploy or post-launch backlog work. | Do not block deployment planning or deploy approval unless scope is expanded. |
+| LOW | cosmetic_dentistry_packet_unapproved | Refinement opportunity only; current QA evidence remains passing or contained. | Schedule as optional pre-deploy or post-launch backlog work. | Do not block deployment planning or deploy approval unless scope is expanded. |
+| LOW | indexnow_absent | Slower Bing discovery only. | Schedule IndexNow after launch stabilization if Bing rapid discovery becomes a priority. | Do not block deployment planning or deploy approval. |
+| MEDIUM | intent_cannibalisation_clusters | Possible ranking dilution if live query data shows competing page intent. | Monitor Search Console and Semrush after launch; adjust only with evidence. | Do not block deployment planning; include in post-launch monitoring. |
+| LOW | chatbot_runtime_sync_absent | Runtime chatbot may not consume all newly aligned packet flags until a separately authorized sync mission. | Keep runtime unchanged for launch; schedule a bounded chatbot sync mission after launch if needed. | Do not block deployment planning or deploy approval. |
+| HIGH | none_remaining | No high-risk launch-preparation blocker identified from current evidence. | Keep guards and final deploy-candidate verification in place. | Proceed to deployment planning. |
+
+## Deployment readiness assessment
+
+| Area | Status | Evidence |
+| --- | --- | --- |
+| Build status | READY | pnpm run verify passed during this acceptance packet run. |
+| Route status | READY | 8/8 required routes returned HTTP 200; route reconciliation status pass. |
+| Schema status | READY | Schema QA status pass; 16 approved schema answers, 5 verified team members, 11 priority services. |
+| SEO status | CONDITIONAL_READY | Final hardening QA pass_with_known_warnings; final recheck certified readiness; medium SEO review items remain for owner acceptance. |
+| Mobile status | READY | 8/8 routes passed mobile readiness. |
+| Accessibility status | READY | 8/8 routes passed accessibility heuristics; scores 96-100. |
+
+## Final recommendation
+
+Proceed to deployment planning, not deployment. Deployment approval remains conditional on launch-owner acceptance of medium-risk items and fresh deploy-candidate verification.

--- a/tools/audits/launch-preparation-acceptance/CHAMPAGNE_POSTLAUNCH_BACKLOG_V1.json
+++ b/tools/audits/launch-preparation-acceptance/CHAMPAGNE_POSTLAUNCH_BACKLOG_V1.json
@@ -1,0 +1,63 @@
+{
+  "version": "CHAMPAGNE_POSTLAUNCH_BACKLOG_V1",
+  "generatedAt": "2026-06-03T01:53:18.708Z",
+  "status": "POST_LAUNCH_BACKLOG_DEFINED_NOT_BLOCKING_DEPLOYMENT_PLANNING",
+  "items": [
+    {
+      "id": "indexnow",
+      "classification": "POST_LAUNCH",
+      "priority": "LOW",
+      "evidence": "IndexNow absence affects Bing rapid discovery only and is not a Google/local launch blocker.",
+      "recommendedTiming": "After launch stabilization."
+    },
+    {
+      "id": "chatbot_runtime_sync",
+      "classification": "POST_LAUNCH",
+      "priority": "LOW",
+      "evidence": "Chatbot alignment passes with 17 mappings; runtimeMutation remains false.",
+      "recommendedTiming": "After launch, under a dedicated chatbot runtime authorization."
+    },
+    {
+      "id": "answer_refinement",
+      "classification": "POST_LAUNCH",
+      "priority": "LOW",
+      "evidence": "Answer QA passes; length warnings are refinement-only.",
+      "recommendedTiming": "After Search Console/query evidence is available."
+    },
+    {
+      "id": "intent_cannibalisation_monitoring",
+      "classification": "POST_LAUNCH",
+      "priority": "MEDIUM",
+      "evidence": "Launch-safety reports high-risk topic clusters for audit; no hard route/schema failure is present.",
+      "recommendedTiming": "After Search Console and Semrush learning starts."
+    },
+    {
+      "id": "search_console_learning",
+      "classification": "POST_LAUNCH",
+      "priority": "MEDIUM",
+      "evidence": "AI Mode, zero-click, and local dominance tuning require live query data.",
+      "recommendedTiming": "Begin immediately after deployment and indexing submission."
+    },
+    {
+      "id": "semrush_learning",
+      "classification": "POST_LAUNCH",
+      "priority": "MEDIUM",
+      "evidence": "Competitor and cannibalisation monitoring require live market data.",
+      "recommendedTiming": "After first indexing and ranking signals."
+    },
+    {
+      "id": "competitor_analysis",
+      "classification": "POST_LAUNCH",
+      "priority": "LOW",
+      "evidence": "Competitive readiness is adequate for launch preparation; market response should guide refinements.",
+      "recommendedTiming": "Post-launch month 1."
+    },
+    {
+      "id": "cosmetic_dentistry_packet_approval",
+      "classification": "POST_LAUNCH",
+      "priority": "LOW",
+      "evidence": "Cosmetic dentistry answer packet is unapproved and contained.",
+      "recommendedTiming": "Only if activation becomes a product/SEO priority."
+    }
+  ]
+}

--- a/tools/audits/launch-preparation-acceptance/CHAMPAGNE_PRELAUNCH_CHECKLIST_V1.json
+++ b/tools/audits/launch-preparation-acceptance/CHAMPAGNE_PRELAUNCH_CHECKLIST_V1.json
@@ -1,0 +1,80 @@
+{
+  "version": "CHAMPAGNE_PRELAUNCH_CHECKLIST_V1",
+  "generatedAt": "2026-06-03T01:53:18.708Z",
+  "status": "READY_FOR_DEPLOYMENT_PLANNING_WITH_OWNER_ACCEPTANCE_REQUIRED",
+  "requiredBeforeDeploy": [
+    {
+      "id": "launch_owner_acceptance_of_certification_recheck",
+      "classification": "REQUIRED BEFORE DEPLOY",
+      "evidence": "Final recheck is CERTIFIED_READY_FOR_LAUNCH_PREPARATION with 0 blockers and 0 high-risk items.",
+      "acceptanceCriterion": "Launch owner records acceptance of the certification decision and remaining medium-risk items."
+    },
+    {
+      "id": "main_thread_tbt_inp_proxy_review",
+      "classification": "REQUIRED BEFORE DEPLOY",
+      "riskLevel": "MEDIUM",
+      "owner": "performance mission",
+      "evidence": "8 medium TBT/INP-proxy risk entries in rerun.",
+      "acceptanceCriterion": "Review and either remediate or explicitly accept before deployment approval."
+    },
+    {
+      "id": "lcp_threshold_review",
+      "classification": "REQUIRED BEFORE DEPLOY",
+      "riskLevel": "MEDIUM",
+      "owner": "performance mission",
+      "evidence": "5 medium LCP threshold risk entries in rerun.",
+      "acceptanceCriterion": "Review and either remediate or explicitly accept before deployment approval."
+    },
+    {
+      "id": "seo_launch_safety_layout_warning_review",
+      "classification": "REQUIRED BEFORE DEPLOY",
+      "riskLevel": "MEDIUM",
+      "owner": "SEO launch-safety mission",
+      "evidence": "Carried from previous final audit as review-only because SMH layout guard passed.",
+      "acceptanceCriterion": "Review and either remediate or explicitly accept before deployment approval."
+    },
+    {
+      "id": "lighthouse_seo_meta_description_discrepancy_review",
+      "classification": "REQUIRED BEFORE DEPLOY",
+      "riskLevel": "MEDIUM",
+      "owner": "SEO validation mission",
+      "evidence": "Lighthouse rerun SEO score 54/meta-description observation conflicts with repo metadata/schema QA pass evidence.",
+      "acceptanceCriterion": "Review and either remediate or explicitly accept before deployment approval."
+    },
+    {
+      "id": "fresh_production_build_verification_before_deploy_window",
+      "classification": "REQUIRED BEFORE DEPLOY",
+      "evidence": "pnpm run verify passed during the acceptance packet run; repeat immediately before deploy window if code changes land after this packet.",
+      "acceptanceCriterion": "Production build verification passes on the deploy candidate commit."
+    },
+    {
+      "id": "no_deployment_or_runtime_mutation_in_this_packet",
+      "classification": "REQUIRED BEFORE DEPLOY",
+      "evidence": "This packet is governance/planning only and does not deploy, merge, alter production infrastructure, touch PHI/PMS/Dentally, or mutate chatbot runtime.",
+      "acceptanceCriterion": "Launch owner confirms deployment remains a separately approved event."
+    }
+  ],
+  "optionalBeforeDeploy": [
+    {
+      "id": "accessibility_score_96_refinement",
+      "classification": "OPTIONAL BEFORE DEPLOY",
+      "riskLevel": "LOW",
+      "evidence": "Three Lighthouse accessibility scores are 96 while all eight required routes passed accessibility heuristics.",
+      "acceptanceCriterion": "Optional refinement may be deferred because readiness evidence passes."
+    },
+    {
+      "id": "answer_length_refinement",
+      "classification": "OPTIONAL BEFORE DEPLOY",
+      "riskLevel": "LOW",
+      "evidence": "Answer foundation QA passes with over-length warnings only.",
+      "acceptanceCriterion": "Optional copy-length refinement may be scheduled without blocking deploy planning."
+    },
+    {
+      "id": "cosmetic_dentistry_packet_approval",
+      "classification": "OPTIONAL BEFORE DEPLOY",
+      "riskLevel": "LOW",
+      "evidence": "Cosmetic dentistry packet remains contained/unactivated without fresh approval.",
+      "acceptanceCriterion": "Do not activate unless a fresh clinical approval packet is completed."
+    }
+  ]
+}

--- a/tools/audits/launch-preparation-acceptance/CHAMPAGNE_RISK_ACCEPTANCE_MATRIX_V1.json
+++ b/tools/audits/launch-preparation-acceptance/CHAMPAGNE_RISK_ACCEPTANCE_MATRIX_V1.json
@@ -1,0 +1,101 @@
+{
+  "version": "CHAMPAGNE_RISK_ACCEPTANCE_MATRIX_V1",
+  "generatedAt": "2026-06-03T01:53:18.708Z",
+  "summary": {
+    "LOW": 5,
+    "MEDIUM": 5,
+    "HIGH": 0,
+    "BLOCKER": 0,
+    "POST_LAUNCH_TRACKED": 3
+  },
+  "risks": [
+    {
+      "level": "MEDIUM",
+      "id": "high_total_blocking_time_inp_proxy",
+      "risk": "Rerun records TBT as a lab INP proxy and classifies these entries as medium; no field INP evidence is available in local Lighthouse.",
+      "impact": "Potential interaction latency / INP-proxy concern in lab evidence.",
+      "mitigation": "Review during launch-owner acceptance; remediate if owner requires, otherwise explicitly accept and monitor after launch.",
+      "launchRecommendation": "Do not block deployment planning; require owner acceptance before actual deploy approval."
+    },
+    {
+      "level": "MEDIUM",
+      "id": "lcp_above_good_lab_threshold",
+      "risk": "Treatment LCP observations range from 2.5 s to 2.7 s in the rerun and are medium-risk optimization items.",
+      "impact": "Potential above-the-fold loading delay on measured treatment routes.",
+      "mitigation": "Review during launch-owner acceptance; remediate if owner requires, otherwise explicitly accept and monitor after launch.",
+      "launchRecommendation": "Do not block deployment planning; require owner acceptance before actual deploy approval."
+    },
+    {
+      "level": "MEDIUM",
+      "id": "seo_launch_safety_treatment_layout_warnings",
+      "risk": "Carried from the previous audit as review-only: SMH layout guard passes, while launch-safety warnings should be reviewed before deployment.",
+      "impact": "Pre-deploy SEO review item from launch-safety evidence.",
+      "mitigation": "Review during launch-owner acceptance; remediate if owner requires, otherwise explicitly accept and monitor after launch.",
+      "launchRecommendation": "Do not block deployment planning; require owner acceptance before actual deploy approval."
+    },
+    {
+      "level": "MEDIUM",
+      "id": "lighthouse_seo_lab_score_meta_description_observation",
+      "risk": "Rerun Lighthouse SEO scores are 54 with meta-description audit observations, while repo schema/metadata QA pass. This is a validation discrepancy to review before deployment, not a certification blocker for launch preparation.",
+      "impact": "Validation discrepancy between Lighthouse SEO lab observations and repo metadata/schema QA.",
+      "mitigation": "Review during launch-owner acceptance; remediate if owner requires, otherwise explicitly accept and monitor after launch.",
+      "launchRecommendation": "Do not block deployment planning; require owner acceptance before actual deploy approval."
+    },
+    {
+      "level": "LOW",
+      "id": "lighthouse_accessibility_below_100",
+      "risk": "Affected routes still scored 96 and all required routes passed basic accessibility heuristics.",
+      "impact": "Refinement opportunity only; current QA evidence remains passing or contained.",
+      "mitigation": "Schedule as optional pre-deploy or post-launch backlog work.",
+      "launchRecommendation": "Do not block deployment planning or deploy approval unless scope is expanded."
+    },
+    {
+      "level": "LOW",
+      "id": "answer_length_warnings",
+      "risk": "Answer foundation warnings remain non-blocking; packet QA and rendering QA pass.",
+      "impact": "Refinement opportunity only; current QA evidence remains passing or contained.",
+      "mitigation": "Schedule as optional pre-deploy or post-launch backlog work.",
+      "launchRecommendation": "Do not block deployment planning or deploy approval unless scope is expanded."
+    },
+    {
+      "level": "LOW",
+      "id": "cosmetic_dentistry_packet_unapproved",
+      "risk": "Contained because the packet remains unactivated/out of scope without fresh approval.",
+      "impact": "Refinement opportunity only; current QA evidence remains passing or contained.",
+      "mitigation": "Schedule as optional pre-deploy or post-launch backlog work.",
+      "launchRecommendation": "Do not block deployment planning or deploy approval unless scope is expanded."
+    },
+    {
+      "level": "LOW",
+      "id": "indexnow_absent",
+      "risk": "IndexNow absence affects Bing discovery speed but not Google/local launch preparation readiness.",
+      "impact": "Slower Bing discovery only.",
+      "mitigation": "Schedule IndexNow after launch stabilization if Bing rapid discovery becomes a priority.",
+      "launchRecommendation": "Do not block deployment planning or deploy approval."
+    },
+    {
+      "level": "MEDIUM",
+      "id": "intent_cannibalisation_clusters",
+      "risk": "High-risk intent clusters need live Search Console/Semrush learning after launch.",
+      "impact": "Possible ranking dilution if live query data shows competing page intent.",
+      "mitigation": "Monitor Search Console and Semrush after launch; adjust only with evidence.",
+      "launchRecommendation": "Do not block deployment planning; include in post-launch monitoring."
+    },
+    {
+      "level": "LOW",
+      "id": "chatbot_runtime_sync_absent",
+      "risk": "Chatbot runtime mutation remains intentionally absent while alignment evidence passes.",
+      "impact": "Runtime chatbot may not consume all newly aligned packet flags until a separately authorized sync mission.",
+      "mitigation": "Keep runtime unchanged for launch; schedule a bounded chatbot sync mission after launch if needed.",
+      "launchRecommendation": "Do not block deployment planning or deploy approval."
+    },
+    {
+      "level": "HIGH",
+      "id": "none_remaining",
+      "risk": "No high-risk items remain in the certification recheck blocker matrix.",
+      "impact": "No high-risk launch-preparation blocker identified from current evidence.",
+      "mitigation": "Keep guards and final deploy-candidate verification in place.",
+      "launchRecommendation": "Proceed to deployment planning."
+    }
+  ]
+}


### PR DESCRIPTION
### Motivation

- Close the previous certification evidence gap by recording the independent re-evaluation after the Lighthouse/CWV/mobile/accessibility rerun and surface a single, auditable decision artifact. 
- Produce machine- and human-readable artifacts that capture route, performance, accessibility, schema, answer, clinical and approval-flag evidence without making any functional or content changes.

### Description

- Add a new audit packet under `tools/audits/final-launch-certification-recheck/` containing `CHAMPAGNE_FINAL_LAUNCH_CERTIFICATION_RECHECK_V1.{md,json}`, `CHAMPAGNE_FINAL_RECHECK_SCORECARD_V1.json`, `CHAMPAGNE_FINAL_RECHECK_BLOCKER_MATRIX_V1.json`, `CHAMPAGNE_FINAL_RECHECK_PRELAUNCH_VS_POSTLAUNCH_V1.json`, and `CHAMPAGNE_FINAL_RECHECK_RECOMMENDATION_V1.md` that summarize the recheck. 
- Record the certification decision `CERTIFIED_READY_FOR_LAUNCH_PREPARATION` and the decision rationale that the prior evidence gap is resolved (8/8 routes HTTP 200; 8/8 Lighthouse mobile lab measurements; 8/8 mobile readiness; 8/8 accessibility heuristic passes). 
- Surface the remaining items and their classifications (no BLOCKER or HIGH items; MEDIUM/LOW/POST_LAUNCH entries remain) and provide a single next recommendation to proceed to launch-preparation with focused prelaunch performance/SEO validation. 
- Include scorecard metrics (overall score 86), measured performance ranges and the performance/accessibility risk register entries (TBT/INP-proxy and LCP observations called out). 

### Testing

- Ran `pnpm run guard:canon` which passed and reported canonical/brand checks passed. 
- Ran `pnpm run guard:hero` which passed and verified sacred hero lock and hero guard. 
- Ran SEO/answer/schema QA commands `pnpm run seo:schema-qa`, `pnpm run seo:answer-foundation-qa` (pass with registry warnings), `pnpm run seo:answer-packet-qa`, and `pnpm run seo:answer-rendering-qa` (all passing for required checks). 
- Ran `pnpm run verify` which completed (build and verification ran; guard pipeline, lint, typecheck and production build executed) and `git diff --check` which reported no whitespace errors, and the binary file check returned no added binaries.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f18b555048332bf117a3a70e0e160)