### PR TITLE
docs(typography): add forensic typography audit and mission queue

### DIFF
--- a/FONT_LOADING_AND_PERFORMANCE_AUDIT.md
+++ b/FONT_LOADING_AND_PERFORMANCE_AUDIT.md
@@ -1,0 +1,91 @@
+# FONT_LOADING_AND_PERFORMANCE_AUDIT
+
+Status: `FORENSIC_AUDIT_ONLY`  
+Evidence date: 2026-06-05
+
+## Executive finding
+
+The repository declares font-family names but does not implement web font loading for the public web app. There is no production evidence of `next/font`, `@font-face`, Google Fonts imports, local font assets, or font preload hints.
+
+## Font-loading scan results
+
+Audited search categories:
+
+- `next/font`
+- `@font-face`
+- `fonts.googleapis`
+- `fonts.gstatic`
+- `rel="preload"` with font intent
+- `font-display`
+- font import/preload patterns in `apps`, `packages`, `docs`, `reports`, and `scripts`
+
+Result: no active production font-loading implementation found.
+
+## Runtime consequence
+
+| Font family name | Declared where | Loaded by repository? | Runtime consequence |
+| --- | --- | --- | --- |
+| Inter | `theme.css`, `.text-lead`, `.text-body`, `.text-eyebrow` | No | Uses local Inter if installed; otherwise falls to system stack for body. |
+| Playfair Display | `.text-hero`, `.text-title`, imported manifests | No | Uses local Playfair if installed; otherwise fallback behavior is uncontrolled because active utility lacks an explicit serif fallback. |
+| Montserrat | Historical Director doc | No | Not used by active runtime. |
+| Lora | Historical Director doc | No | Not used by active runtime. |
+| Poppins | Historical Blueprint doc | No | Not used by active runtime. |
+| IBM Plex Mono | Historical Blueprint doc | No | Not used by active runtime. |
+
+## Current fallback truth
+
+### Body fallback stack
+
+The active body fallback stack is:
+
+```css
+Inter, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif
+```
+
+This is explicit and browser-safe. Because Inter is not loaded in-repo, the practical result for many users may be system UI.
+
+### Display/title fallback stack
+
+The active display/title utilities use:
+
+```css
+'Playfair Display'
+```
+
+No `Georgia`, `serif`, or other fallback is declared in the active token utility. If the font is unavailable, browser fallback resolution is not canon-controlled.
+
+## Performance assessment
+
+### Positive findings
+
+- No external font CSS requests are currently introduced by the repository.
+- No font files are bundled, so no direct font asset weight is added.
+- The body stack can fall through to system fonts, which can be fast.
+
+### Risk findings
+
+- Brand typography is non-deterministic because named fonts are declared without controlled loading.
+- If a future implementation adds remote font loading without `next/font` or self-hosting strategy, it could introduce render-blocking CSS, extra DNS/TLS costs, FOIT/FOUT, and Core Web Vitals risk.
+- Because Playfair is declared without a fallback stack in active utilities, layout/appearance can vary more sharply by device.
+- There is no repository budget for font files, subsets, weights, preload strategy, or `font-display` behavior.
+
+## Weight/subset inventory
+
+No implemented font files or configured font weights were found. The only active numeric weights are component declarations such as 600, 700, and 800. These are CSS weights, not loaded font assets.
+
+## Performance readiness gaps
+
+A future font implementation needs a decision record for:
+
+1. Self-hosted vs `next/font/google` vs system-only.
+2. Which weights are truly needed for display/body/UI.
+3. Latin subset requirements.
+4. `display` behavior (`swap`, `optional`, etc.).
+5. Preload strategy for critical display/body fonts.
+6. Fallback metrics/adjustment strategy to limit CLS.
+7. CWV budgets for added font bytes.
+8. Font license/provenance evidence.
+
+## Do-not-implement recommendation
+
+This audit does not recommend a final font. It recommends that any future typography decision pack treat font loading as unresolved and high-impact, not as already solved.

--- a/LUXURY_TYPOGRAPHY_DECISION_READINESS.md
+++ b/LUXURY_TYPOGRAPHY_DECISION_READINESS.md
@@ -1,0 +1,99 @@
+# LUXURY_TYPOGRAPHY_DECISION_READINESS
+
+Status: `FORENSIC_AUDIT_ONLY`  
+Evidence date: 2026-06-05
+
+## Readiness verdict
+
+The repository is **not ready for implementation** of a final luxury typography system, but it **is ready for a structured decision pack**. The current evidence is sufficient to define decision questions, risks, and migration boundaries.
+
+## What is already knowable
+
+1. Runtime body typography is Inter-first with system fallbacks.
+2. Active token utilities imply Playfair Display for hero/title and Inter for body/lead/eyebrow.
+3. Historical imports conflict with active utilities by naming Montserrat/Lora/Inter and Poppins/Inter/IBM Plex Mono.
+4. No web font loading is implemented.
+5. Tailwind has no typography extension.
+6. Component typography is distributed and drift-prone.
+7. No typography guard exists.
+
+## What is not yet decided
+
+| Decision | Current state |
+| --- | --- |
+| Final luxury display font | Undecided; evidence conflicts. |
+| Final heading font | Undecided; runtime mostly inherits Inter. |
+| Final body font | Runtime Inter-first; historical Lora conflict unresolved. |
+| UI font | Runtime Inter-first; historical Director also names Inter UI. |
+| Numeric/mono font | Historical IBM Plex Mono mention only; no active implementation. |
+| Font loading strategy | Not implemented. |
+| Tailwind type token strategy | Not implemented. |
+| Global heading binding strategy | Not implemented. |
+| Component migration strategy | Not implemented. |
+| Typography guard strategy | Not implemented. |
+
+## Decision pack readiness checklist
+
+| Input | Status | Notes |
+| --- | --- | --- |
+| Runtime truth | Ready | Active theme/type files and component usage are identifiable. |
+| Canon conflict inventory | Ready | Playfair vs Montserrat vs Poppins; Inter vs Lora. |
+| Font loading inventory | Ready | No loading found. |
+| Component drift inventory | Ready | High-level map complete. |
+| Performance risk framing | Ready | Need budgets and chosen loading method. |
+| Accessibility framing | Partial | Requires chosen fonts and contrast/legibility testing. |
+| Brand/legal licensing | Missing | No license/provenance evidence for future fonts. |
+| Migration plan | Missing | Needs final typography authority. |
+| Guard plan | Missing | Needs agreed allowed APIs/classes/variables. |
+
+## Recommended decision pack structure
+
+A future luxury typography decision pack should contain:
+
+1. **Typography authority statement**
+   - Display font.
+   - Heading font.
+   - Body font.
+   - UI font.
+   - Numeric/mono font if any.
+   - Fallback stacks for each role.
+
+2. **Runtime loading strategy**
+   - Self-hosted or Next/font.
+   - Weights/subsets.
+   - Preload/display policy.
+   - Performance budget.
+
+3. **Token architecture**
+   - CSS variables such as `--font-display`, `--font-body`, `--font-ui`, `--font-mono`.
+   - Semantic size/line-height/letter-spacing tokens.
+   - Relationship between CSS token classes and Tailwind theme.
+
+4. **Component binding rules**
+   - Hero/title usage.
+   - Section heading/body/eyebrow usage.
+   - CTA/nav/footer usage.
+   - Portal/ops exceptions if applicable.
+
+5. **Migration and guard plan**
+   - Allowed files.
+   - Sacred file restrictions.
+   - Audit-only vs implementation phases.
+   - New guard coverage.
+
+6. **Validation plan**
+   - Visual regression targets.
+   - Font loading inspection.
+   - Lighthouse/Core Web Vitals.
+   - Accessibility/legibility checks.
+
+## Non-goals for the decision pack
+
+- Do not change fonts without Director authorization.
+- Do not edit sacred hero engine files unless explicitly authorized.
+- Do not introduce raw colors or style bypasses.
+- Do not rely on imported historical docs as active authority without explicit promotion.
+
+## Readiness conclusion
+
+The future agent should begin with a decision record, not code. The current repo provides enough evidence to define typography truth and mismatch, but it does not contain a final approved luxury typography canon or a safe implementation pathway.

--- a/TYPOGRAPHY_CANON_RUNTIME_MISMATCH_REPORT.md
+++ b/TYPOGRAPHY_CANON_RUNTIME_MISMATCH_REPORT.md
@@ -1,0 +1,78 @@
+# TYPOGRAPHY_CANON_RUNTIME_MISMATCH_REPORT
+
+Status: `FORENSIC_AUDIT_ONLY`  
+Evidence date: 2026-06-05
+
+## Primary mismatch summary
+
+There is no single complete active typography canon. Runtime typography is governed by active CSS inheritance plus component-local overrides. Historical imported canon files name different font systems that are not implemented.
+
+## Mismatch matrix
+
+| Area | Canon / intent evidence | Runtime evidence | Mismatch |
+| --- | --- | --- | --- |
+| Heading font | Active `.text-title` says `'Playfair Display'`; historical Director says Montserrat; historical Blueprint says Poppins. | Most headings use Tailwind or inline size/weight only and inherit body `Inter`. | Heading authority is ambiguous; runtime mostly Inter. |
+| Body font | Active theme says Inter-first stack; active `.text-body` says Inter; historical Director says Lora body. | Body receives Inter-first stack from `theme.css`. | Historical Lora body canon is not implemented. |
+| Hero/display font | Active `.text-hero` says `'Playfair Display'`; imported hero manifests say Playfair Display display. | `ChampagneHeroFrame` h1 only sets fontSize/fontWeight/lineHeight; no fontFamily/class. | Hero display font token exists but is not applied in current hero frame. |
+| Font loading | Historical docs mention font prefetch/preload direction. | No `next/font`, `@font-face`, Google stylesheet, or preload found. | Named fonts may not resolve unless installed locally. |
+| Fallback stack | Theme body stack is explicit for Inter. | `.text-hero` and `.text-title` specify only `'Playfair Display'` without serif fallback in active token CSS. | Display/title utility fallback stack is incomplete. |
+| Tailwind type tokens | Expected design systems normally encode font family/scale in Tailwind. | `tailwind.config.cjs` has empty `theme.extend` and no typography plugin. | Tailwind typography is not canonized. |
+| Component typography | Token classes exist. | Components duplicate font sizes, weights, line heights, letter spacing inline and via Tailwind. | High drift risk. |
+| Guards | Canon/hero/token guards exist. | No typography-specific guard found. | Typography drift can pass existing guard suite. |
+
+## Runtime facts that supersede assumptions
+
+1. The active app has no Next font import in `apps/web/app/layout.tsx`.
+2. The app loads typography only through CSS imports, not through font files or external font CSS.
+3. Body font-family is defined only in theme CSS.
+4. Active display/title font-family utilities exist, but application is opt-in.
+5. Hero and section heading elements largely do not opt in to `.text-hero` or `.text-title`.
+6. The browser receives font-family names for Playfair/Inter but no repository-provided font source.
+
+## Canon conflict log
+
+### Conflict A: Playfair Display vs Montserrat vs Poppins
+
+- Active token utility: Playfair Display for `.text-hero` and `.text-title`.
+- Imported Director: Montserrat for headings.
+- Imported Blueprint: Poppins for display.
+- Runtime semantic headings: inherited Inter unless explicitly classed.
+
+Conclusion: final heading/display authority is unresolved.
+
+### Conflict B: Inter body vs Lora body
+
+- Active theme CSS: Inter-first body stack.
+- Imported Director: Lora body.
+- Runtime: Inter-first stack.
+
+Conclusion: implemented runtime body authority is Inter-first, not Lora.
+
+### Conflict C: token classes vs component-local typography
+
+- Active typography token classes define a small type vocabulary.
+- Components define sizes, weights, and tracking inline or via Tailwind.
+
+Conclusion: the token classes are not the universal component contract.
+
+## Severity assessment
+
+| Risk | Severity | Why |
+| --- | --- | --- |
+| Named web fonts not actually loading | High | Brand typography may differ by user device. |
+| Display font token not applied to hero runtime | High | Hero is a primary brand surface. |
+| Conflicting historical canons | High | Future agents could choose wrong authority. |
+| No Tailwind font family extension | Medium | Tailwind classes remain generic and unconstrained. |
+| No typography drift guard | Medium | Component-local drift can continue silently. |
+| Missing display fallback stack | Medium | If Playfair is unavailable, fallback is UA/default rather than canon-controlled. |
+
+## Required future decision inputs
+
+A future luxury typography decision pack must decide:
+
+1. Whether active authority should be Playfair/Inter, Montserrat/Lora/Inter, Poppins/Inter/IBM Plex Mono, or a new luxury system.
+2. Whether display/title should be web-loaded or system-only.
+3. Whether headings should bind globally (`h1`-`h6`) or via semantic classes/components.
+4. Whether Tailwind should expose `font-display`, `font-body`, `font-ui`, `font-mono`.
+5. Whether token classes should become CSS variables or stay utility classes.
+6. Whether typography drift must be guarded like color/token drift.

--- a/TYPOGRAPHY_CAPABILITY_GAP_AUDIT.md
+++ b/TYPOGRAPHY_CAPABILITY_GAP_AUDIT.md
@@ -1,0 +1,73 @@
+# TYPOGRAPHY_CAPABILITY_GAP_AUDIT
+
+Status: `FORENSIC_AUDIT_ONLY`  
+Evidence date: 2026-06-05
+
+## Executive finding
+
+Champagne currently has typography declarations but lacks a full typography system capability. The strongest implemented capability is a global body font stack and a small CSS utility vocabulary. Missing capabilities include font loading, semantic tokens, Tailwind integration, component contracts, guards, and performance budgets.
+
+## Capability matrix
+
+| Capability | Current state | Gap |
+| --- | --- | --- |
+| Body font stack | Implemented in theme CSS. | Web font source not controlled. |
+| Display/title utility classes | Implemented in typography CSS. | Not globally applied; fallback incomplete; font not loaded. |
+| Semantic font variables | Not found. | Need `--font-display`, `--font-body`, `--font-ui`, etc. if selected. |
+| Type scale tokens | Partial class sizes only. | No comprehensive scale/line-height/tracking token system. |
+| Tailwind typography integration | Empty `theme.extend`; no plugins. | Need mapped font families and semantic type utilities if Tailwind remains API. |
+| Next/font or self-hosted loading | Not found. | Need deterministic loading strategy. |
+| Heading binding | Not found. | Need global or component-level heading contract. |
+| Hero display binding | Not found in hero frame. | Need chosen display token applied safely if authorized. |
+| Component contract | Not found. | Need standardized `Eyebrow`, `SectionTitle`, `BodyCopy`, etc. or equivalent. |
+| Typography guard | Not found. | Need no-drift guard after contract exists. |
+| Font performance budget | Not found. | Need max bytes/weights/subsets/preload rules. |
+| License/provenance registry | Not found. | Need source/license record for chosen fonts. |
+| Accessibility type checks | Not found. | Need legibility/contrast/zoom/reflow checks once fonts chosen. |
+
+## Structural gaps
+
+### 1. Authority gap
+
+The repo contains conflicting typography evidence and no active file that explicitly resolves it.
+
+### 2. Loading gap
+
+The repo names fonts but does not load font assets. This makes brand typography dependent on local machine fonts or system fallback.
+
+### 3. Token model gap
+
+The active typography file uses classes, not a semantic variable system. This limits reuse in Tailwind, inline styles, CSS modules, and component props.
+
+### 4. Component API gap
+
+Sections and hero components independently define sizes and weights. There is no shared typography primitive layer.
+
+### 5. Guard gap
+
+No guard prevents future font-family drift, unapproved font loading, raw arbitrary type values, or heading/display token bypass.
+
+### 6. Performance governance gap
+
+No font performance budget exists. A future implementation could add too many weights or block rendering unless constrained.
+
+### 7. Product-surface gap
+
+Marketing site, patient portal, stock app, concierge, and future cockpit surfaces do not have documented typography inheritance/exception rules.
+
+## Gap priority
+
+| Priority | Gap | Why |
+| --- | --- | --- |
+| P0 | Authority gap | Cannot safely implement without choosing active canon. |
+| P0 | Loading gap | Declared fonts are not deterministic. |
+| P1 | Hero/display binding gap | Primary brand surface may not use intended display typography. |
+| P1 | Token model gap | Component migrations need a shared API. |
+| P1 | Guard gap | Drift will continue silently. |
+| P2 | Tailwind integration gap | Needed if Tailwind remains component authoring surface. |
+| P2 | Performance budget gap | Needed before adding font files. |
+| P2 | Product-surface exception gap | Needed for portal/ops/cockpit consistency. |
+
+## Capability readiness conclusion
+
+Champagne typography is currently at **declaration maturity**, not **system maturity**. It can support an audit and decision pack. It should not yet support a broad typography implementation without prior canon and guard work.

--- a/TYPOGRAPHY_DRIFT_AND_COMPONENT_USAGE_AUDIT.md
+++ b/TYPOGRAPHY_DRIFT_AND_COMPONENT_USAGE_AUDIT.md
@@ -1,0 +1,111 @@
+# TYPOGRAPHY_DRIFT_AND_COMPONENT_USAGE_AUDIT
+
+Status: `FORENSIC_AUDIT_ONLY`  
+Evidence date: 2026-06-05
+
+## Executive finding
+
+Typography usage is decentralized. Active token classes exist, but many production components set typography through Tailwind utility classes, inline `CSSProperties`, and CSS modules. Most component typography controls size/weight/tracking/line-height while inheriting the global body font.
+
+## Drift categories
+
+| Category | Evidence pattern | Drift risk |
+| --- | --- | --- |
+| Inline typography styles | `fontSize`, `fontWeight`, `letterSpacing`, `lineHeight` in section and hero components. | High: repeated values are not centrally governed. |
+| Tailwind typography utilities | `text-sm`, `text-xl`, `font-semibold`, `tracking-tight`, `leading-relaxed`, etc. | Medium/high: Tailwind has no Champagne font extension. |
+| CSS module typography | Footer, concierge, handoff, and preview modules define local font sizes/weights/line heights. | Medium: localized but outside type-token file. |
+| Token class underuse | `.text-hero`, `.text-title`, `.text-lead`, `.text-body`, `.text-eyebrow` exist. | High: components often recreate these roles manually. |
+| Semantic heading inheritance | `h1`, `h2`, `h3` often set size/weight only. | High: heading font remains body font unless explicitly classed. |
+| Portal raw utilities | Patient portal uses generic Tailwind typography and neutral colors. | High for canon alignment; portal may be intentionally separate but not documented as typography exception. |
+
+## Component usage findings
+
+### Root/layout
+
+- Root body applies `antialiased` and inherits global theme font-family.
+- No root font variable or Next/font class is applied.
+
+### Header/navigation
+
+- Logo/brand text uses `text-lg font-semibold tracking-tight`.
+- Strapline uses `text-xs`.
+- Nav uses `text-sm`.
+- Font family is inherited from body.
+
+### Footer
+
+- Footer CSS module defines local heading, copy, legal, and control typography with `font-size`, `font-weight`, and `line-height`.
+- No footer-specific font-family override found.
+
+### Hero
+
+- `ChampagneHeroFrame` sets hero eyebrow size/tracking and h1 size/weight/line-height inline.
+- It does not set `fontFamily` or use `.text-hero`.
+- Therefore the active hero heading inherits body font.
+
+### Section package
+
+Representative section patterns:
+
+- `Section_TextBlock`: inline `fontSize`, `fontWeight`, `lineHeight`, `letterSpacing` for eyebrow/heading/body.
+- `Section_FeatureList`: inline font weights, sizes, and tracking plus local pill/badge typography.
+- `Section_TreatmentOverviewRich`: inline heading/body/bullet typography.
+- `Section_TreatmentMediaFeature`: inline eyebrow/heading/caption/stat typography.
+- `Section_FAQ`: style block and inline heading/body typography.
+- `Section_TreatmentRoutingCards`: shared inline style objects for eyebrow/title/card meta/card title/body and injected CSS for data surfaces.
+- `Section_PeopleGrid`: Tailwind typography utilities for eyebrow, title, copy, names, roles, summaries.
+- `Section_MediaBlock`: inline caption/headline/eyebrow/stat typography.
+
+### CTA package
+
+- `ChampagneCTAButton` uses Tailwind `font-semibold`, `leading-none`, and `tracking-tight`.
+- Font family is inherited.
+
+### Patient portal
+
+- Patient portal uses generic Tailwind type utilities and neutral color classes.
+- It does not consume the active Champagne type utilities.
+
+## Repeated local role approximations
+
+The following roles are repeatedly re-created instead of referencing one semantic contract:
+
+- Eyebrow: uppercase, 0.08em–0.14em tracking, 0.68rem–0.92rem size.
+- Section heading: clamp around 1.15rem–1.85rem, weight 700.
+- Body copy: 0.95rem–1.08rem, line-height 1.55–1.7.
+- Card title: 1.05rem–1.2rem, weight 600–700.
+- CTA/link text: text-sm or inherited, weight 600.
+
+## Drift map by surface
+
+| Surface | Current typography mode | Drift status |
+| --- | --- | --- |
+| Marketing public body | Inherited Inter-first theme stack | Stable but font not loaded. |
+| Marketing sections | Inline/Tailwind values, inherited font | Drift active. |
+| Hero frame | Inline values, inherited font | Drift active; display token not applied. |
+| Header | Tailwind values, inherited font | Drift active but compact. |
+| Footer | CSS module values, inherited font | Drift active but localized. |
+| CTA | Tailwind values, inherited font | Drift active but compact. |
+| Concierge | CSS module values, inherited font | Drift active. |
+| Patient portal | Generic Tailwind values | Potentially separate product typography; not documented in canon. |
+| Stock app | Separate CSS stack in `apps/stock/app/styles/stock-ui.css` | Out-of-scope product but uses Inter/system stack. |
+
+## Guard visibility
+
+Existing guards focus on hero integrity, color/token purity, route safety, SEO safety, and build/type/lint. No typography token purity, font loading, heading binding, or component typography drift guard was identified.
+
+## Highest-risk drift examples
+
+1. Hero h1 not using active display token.
+2. Section heading styles hard-coded inline across many components.
+3. Eyebrow styles duplicated with slight tracking/size variance.
+4. Patient portal generic Tailwind typography outside Champagne token roles.
+5. Active display/title utility lacks fallback family.
+
+## Future audit automation candidates
+
+- Static scan for `fontSize`, `fontWeight`, `letterSpacing`, `lineHeight` outside approved type token files.
+- Static scan for `font-family` declarations outside token/theme files.
+- Static scan for `font-*`, `text-*`, `tracking-*`, and `leading-*` Tailwind classes outside approved wrappers.
+- Check that hero/title components consume a semantic display class/variable once chosen.
+- Check that loaded font names match declared canon names.

--- a/TYPOGRAPHY_MASTER_TRUTH_AUDIT.md
+++ b/TYPOGRAPHY_MASTER_TRUTH_AUDIT.md
@@ -1,0 +1,100 @@
+# TYPOGRAPHY_MASTER_TRUTH_AUDIT
+
+Status: `FORENSIC_AUDIT_ONLY`  
+Role: `CHAMPAGNE_TYPOGRAPHY_FORENSIC_AUDITOR`  
+Repository: `drnickmaxwell-wq/champagne`  
+Evidence date: 2026-06-05  
+Scope: Repository evidence only. No font choice, no implementation, no sacred-file edits.
+
+## Executive truth
+
+The current runtime typography truth is not a single complete typography canon. It is a partial token/CSS implementation plus component-local typography decisions.
+
+| Question | Implemented truth |
+| --- | --- |
+| Authoritative active production body font | `Inter, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif` via `packages/champagne-tokens/styles/champagne/theme.css`. |
+| Authoritative tokenized display/heading intent | `.text-hero` and `.text-title` use `'Playfair Display'`, but those utility classes are not globally applied to semantic headings by default. |
+| Implemented heading font at runtime | Headings inherit body `Inter` unless a component explicitly uses `.text-hero`, `.text-title`, or its own font-family. Most audited headings do not set font-family. |
+| Implemented body font at runtime | `Inter` stack from `body, .champagne-page`. |
+| Implemented hero/display font at runtime | Hero frame heading uses inline size/weight/line-height only; it inherits body `Inter`. Token class `.text-hero` exists but is not used there. |
+| Font loading | No `next/font`, no `@font-face`, no Google Fonts stylesheet import, no font preload evidence found in production `apps/web`, `packages`, `docs`, `reports`, or `scripts` scan. |
+| Tailwind typography setup | Tailwind content scans `apps/web/app` and `packages`; `theme.extend` is empty; no typography plugin is registered. |
+| Typography guard coverage | Existing guards enforce color/token/hero/canon issues. No dedicated typography drift guard was found. |
+
+## Source hierarchy discovered
+
+### Active runtime source chain
+
+1. `apps/web/app/layout.tsx` imports `./globals.css` and renders `<body className="min-h-screen antialiased">`.
+2. `apps/web/app/globals.css` imports `packages/champagne-tokens/styles/champagne/theme.css`.
+3. `theme.css` imports `typography.css` and defines the actual `body, .champagne-page` font-family stack.
+4. Components either inherit this body stack or override typography locally with Tailwind classes / inline styles / CSS modules.
+
+### Active typography token file
+
+`packages/champagne-tokens/styles/champagne/typography.css` defines only five class utilities:
+
+- `.text-hero` = `'Playfair Display'`, clamp size, weight 600.
+- `.text-title` = `'Playfair Display'`, 2rem, weight 600.
+- `.text-lead` = `Inter`, 1.05rem, opacity 0.95.
+- `.text-body` = `Inter`, 0.98rem, opacity 0.95.
+- `.text-eyebrow` = `Inter`, 0.8rem, uppercase, letter spacing 0.12em, opacity 0.75.
+
+These are class utilities, not CSS variables, not Tailwind theme tokens, and not automatically bound to `h1`-`h6`, `p`, `body`, hero renderer, or page-builder primitives.
+
+## Canon evidence discovered
+
+### Active canon files do not define a complete type canon
+
+The active material/token canon defines material, color, surface, and token philosophy, including that product surfaces may adjust typography scale, but it does not name a canonical heading/body/display font pair.
+
+The active Champagne OS master spec lists canon domains but does not include typography as a dedicated domain.
+
+### Historical/imported typography evidence conflicts
+
+Imported/historical design files contain multiple competing typography statements:
+
+| Evidence source | Typography statement | Runtime status |
+| --- | --- | --- |
+| Imported hero manifest | `display: Playfair Display`, `body: Inter` | Partially mirrored by active `typography.css`, but not loaded as actual web fonts. |
+| Imported Director file | `Montserrat (Headings) · Lora (Body) · Inter (UI)` | Not implemented in active runtime body or tokens. |
+| Imported Blueprint | Display `Poppins`, body `Inter`, numeric `IBM Plex Mono` | Not implemented in active runtime body, Tailwind theme, or font loading. |
+| Active token typography CSS | `Playfair Display` display/title and `Inter` lead/body/eyebrow | Implemented as CSS classes only; not globally enforced. |
+| Active theme CSS | `Inter, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif` | Implemented as global runtime body stack. |
+
+## Current authoritative typography canon determination
+
+Repository truth supports this conclusion:
+
+1. **The current operational authority is the active token/theme CSS, not the imported historical canons.** The active web app imports `globals.css`, which imports active Champagne theme CSS.
+2. **The active token/theme CSS canon is incomplete.** It declares a body font stack and five utility classes, but it does not define semantic type roles, CSS variables, a Tailwind type scale, heading bindings, font loading, fallback governance, or drift guards.
+3. **The current heading font cannot truthfully be described as Playfair Display at runtime.** Playfair Display exists in `.text-hero` and `.text-title`, but most headings inherit the body font because they only set size/weight/line-height.
+4. **The current implemented body font is Inter-first with system fallbacks.** Because Inter is not loaded, browser behavior depends on local availability; otherwise the stack falls through to system UI fonts.
+
+## Implemented typography roles
+
+| Role | Current implementation | Audit confidence |
+| --- | --- | --- |
+| Body | `Inter, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif` from theme CSS. | High |
+| Lead | Optional `.text-lead` class with `Inter`, `1.05rem`, opacity. Not globally bound. | High |
+| Body utility | Optional `.text-body` class with `Inter`, `0.98rem`, opacity. Not globally bound. | High |
+| Eyebrow | Optional `.text-eyebrow`; many components independently recreate eyebrow styles inline/Tailwind. | High |
+| Display/Hero | `.text-hero` declares Playfair Display, but hero frame does not use it. | High |
+| Title | `.text-title` declares Playfair Display, but most section headings do not use it. | High |
+| Navigation | Header uses Tailwind size/weight/tracking classes and inherits body font. | High |
+| CTA | CTA button uses Tailwind `font-semibold`, `leading-none`, `tracking-tight`, inherits body font. | High |
+| Portal | Patient portal uses raw Tailwind typography and neutral color classes, inherits body font. | High |
+| Numeric/mono | Historical Blueprint mentions IBM Plex Mono; no active production implementation found. | High |
+
+## File evidence index
+
+- `apps/web/app/layout.tsx`: root CSS import and body class.
+- `apps/web/app/globals.css`: theme import and antialiasing.
+- `packages/champagne-tokens/styles/champagne/theme.css`: global body stack.
+- `packages/champagne-tokens/styles/champagne/typography.css`: display/body utility classes.
+- `apps/web/tailwind.config.cjs`: no Tailwind typography extension.
+- `packages/champagne-hero/src/ChampagneHeroFrame.tsx`: hero heading inherits body font.
+- `apps/web/app/components/layout/Header.tsx`: navigation typography via Tailwind classes.
+- `packages/champagne-sections/src/*`: section typography mostly inline size/weight/line-height and inherited font family.
+- `_imports/champagne-hero/code/hero-engine/DIRECTOR.md`: historical Montserrat/Lora/Inter statement.
+- `_imports/champagne-hero/code/hero-engine/docs/Blueprint.md`: historical Poppins/Inter/IBM Plex Mono statement.

--- a/TYPOGRAPHY_MISSION_QUEUE_V1.md
+++ b/TYPOGRAPHY_MISSION_QUEUE_V1.md
@@ -1,0 +1,198 @@
+# TYPOGRAPHY_MISSION_QUEUE_V1
+
+Status: `FORENSIC_AUDIT_ONLY`  
+Evidence date: 2026-06-05
+
+## Mission protocol
+
+This queue is audit-derived. It does not authorize implementation by itself. Every implementation mission must separately respect AGENTS.md sacred zones, guard requirements, and Director scope.
+
+## Recommended mission sequence
+
+### TYP-00 — Typography Authority Decision Pack
+
+Role: `CHAMPAGNE_TYPOGRAPHY_DIRECTOR_PACKET`  
+Type: Decision / no code  
+Priority: P0
+
+Decide and record:
+
+- Display font.
+- Heading font.
+- Body font.
+- UI font.
+- Numeric/mono font, if any.
+- Fallback stacks.
+- Whether historical imported canons are retired, superseded, or promoted.
+
+Acceptance criteria:
+
+- One active typography authority statement exists.
+- Conflicting Playfair/Montserrat/Poppins/Lora evidence is explicitly resolved.
+- No runtime code changes.
+
+### TYP-01 — Font Loading Strategy Packet
+
+Role: `CHAMPAGNE_FONT_LOADING_ARCHITECT`  
+Type: Decision / no code  
+Priority: P0
+
+Define:
+
+- `next/font` vs self-hosted vs system-only.
+- Weights and subsets.
+- `font-display` policy.
+- Preload policy.
+- Performance budget.
+- License/provenance requirements.
+
+Acceptance criteria:
+
+- Chosen loading path has CWV risk notes.
+- No final font implementation yet.
+
+### TYP-02 — Type Token Architecture Spec
+
+Role: `CHAMPAGNE_TYPE_TOKEN_ARCHITECT`  
+Type: Design spec / no code unless separately authorized  
+Priority: P1
+
+Define:
+
+- Font-family variables.
+- Semantic type roles.
+- Size/line-height/tracking scale.
+- Tailwind mapping plan.
+- CSS module/inline style replacement rules.
+
+Acceptance criteria:
+
+- Components can migrate without guessing.
+- Token-only styling law remains intact.
+
+### TYP-03 — Typography Guard Design
+
+Role: `CHAMPAGNE_TYPOGRAPHY_GUARD_DESIGNER`  
+Type: Guard specification  
+Priority: P1
+
+Define future guard checks for:
+
+- Unauthorized `font-family` declarations.
+- Unapproved font loading imports.
+- Arbitrary typography values outside allowed files.
+- Hero/display binding after a canon exists.
+- Tailwind type utility exceptions.
+
+Acceptance criteria:
+
+- Guard plan lists exact target files and allowlists.
+- Guard does not conflict with token purity or hero sacred guards.
+
+### TYP-04 — Runtime Font Loading Implementation
+
+Role: `CHAMPAGNE_FONT_LOADING_IMPLEMENTER`  
+Type: Code / requires Director authorization  
+Priority: P2
+
+Prerequisites:
+
+- TYP-00 complete.
+- TYP-01 complete.
+- Allowed file scope explicitly granted.
+
+Likely files (not authorized by this audit):
+
+- `apps/web/app/layout.tsx` if using `next/font` classes.
+- token/theme files if adding font variables.
+- package config if adding local assets.
+
+Acceptance criteria:
+
+- Deterministic loaded fonts.
+- Font fallback stacks explicit.
+- Guards pass.
+- Performance evidence captured.
+
+### TYP-05 — Hero and Heading Binding Mission
+
+Role: `CHAMPAGNE_HERO_TYPOGRAPHY_BINDER`  
+Type: Code / requires explicit scope and sacred-zone review  
+Priority: P2
+
+Prerequisites:
+
+- TYP-00 through TYP-03 complete.
+- Explicit authority if touching sacred hero renderer paths.
+
+Objective:
+
+- Bind hero/display headings to the chosen semantic display role.
+- Preserve hero engine and renderer semantics.
+
+Acceptance criteria:
+
+- No sacred file violation.
+- No layout/structure drift.
+- Typography guard passes.
+
+### TYP-06 — Section Typography Consolidation
+
+Role: `CHAMPAGNE_SECTION_TYPOGRAPHY_MIGRATOR`  
+Type: Code / staged  
+Priority: P3
+
+Objective:
+
+- Replace repeated inline/Tailwind typography values with approved semantic tokens/primitives.
+- Preserve copy, layout, and token-only styling.
+
+Acceptance criteria:
+
+- No visual guessing; evidence screenshots if perceptible change.
+- Guard suite passes.
+- Drift count decreases.
+
+### TYP-07 — Navigation/Footer/CTA Typography Consolidation
+
+Role: `CHAMPAGNE_CHROME_TYPOGRAPHY_MIGRATOR`  
+Type: Code / staged  
+Priority: P3
+
+Objective:
+
+- Align header, footer, CTA, and concierge typography to chosen UI/body roles.
+
+Acceptance criteria:
+
+- Header/footer restrictions explicitly authorized.
+- No copy/layout changes.
+- Guard suite passes.
+
+### TYP-08 — Portal/Ops Typography Exception Policy
+
+Role: `CHAMPAGNE_PRODUCT_SURFACE_TYPE_GOVERNOR`  
+Type: Policy + optional later implementation  
+Priority: P3
+
+Objective:
+
+- Decide whether patient portal and stock/ops surfaces inherit marketing typography or use calmer operational typography.
+
+Acceptance criteria:
+
+- Exceptions are documented.
+- Future agents know whether generic Tailwind typography in portal is drift or intentional.
+
+## Stop conditions
+
+Stop and report if:
+
+- Required guards are missing or not wired.
+- A mission requires sacred file edits without explicit authority.
+- A final font is requested without licensing/loading/performance decisions.
+- A component migration would change layout/copy outside scope.
+
+## Current next best mission
+
+Run **TYP-00 — Typography Authority Decision Pack** before any implementation.


### PR DESCRIPTION
### Motivation

- Capture definitive, repo-evidence‑based findings about typography truth, drift, and readiness for a luxury typography decision pack.  
- Provide a minimal, non-invasive audit artifact set so future agents can act without guessing or changing sacred files.  

### Description

- Adds seven audit-only reports: `TYPOGRAPHY_MASTER_TRUTH_AUDIT.md`, `TYPOGRAPHY_CANON_RUNTIME_MISMATCH_REPORT.md`, `FONT_LOADING_AND_PERFORMANCE_AUDIT.md`, `TYPOGRAPHY_DRIFT_AND_COMPONENT_USAGE_AUDIT.md`, `LUXURY_TYPOGRAPHY_DECISION_READINESS.md`, `TYPOGRAPHY_CAPABILITY_GAP_AUDIT.md`, and `TYPOGRAPHY_MISSION_QUEUE_V1.md`.  
- Documents that runtime body font is `Inter` (with system fallbacks), Playfair Display appears only as opt-in utilities, no repo-controlled font loading exists, Tailwind has no typography extension, and component typography is decentralized.  
- No runtime behavior, font files, sacred hero files, or token values were modified; this is audit-only documentation and a commit (`docs: add typography forensic audit`).  

### Testing

- Ran `pnpm run guard:hero` which passed.  
- Ran `pnpm run guard:canon` which passed (emitted existing Browserslist / Tailwind advisory warnings).  
- Ran `pnpm run verify` which passed the guard and build chain (noting pre-existing workspace dependency, SEO/Tailwind/Next lint advisories), and `pnpm --filter web build` completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a226b6898748332ad5a1054dd1bc657)