### PR TITLE
Add Captain public boundary copy to Practice Concierge

### DIFF
--- a/apps/web/app/components/concierge/ConciergeShell.boundary-copy.test.ts
+++ b/apps/web/app/components/concierge/ConciergeShell.boundary-copy.test.ts
@@ -1,0 +1,26 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const currentDir = dirname(fileURLToPath(import.meta.url));
+const shellSource = readFileSync(join(currentDir, "ConciergeShell.tsx"), "utf8");
+
+describe("ConciergeShell boundary copy", () => {
+  it("keeps visible Captain public-boundary wording near the concierge entry surface", () => {
+    expect(shellSource).toContain("Before you chat with Captain");
+    expect(shellSource).toContain("Captain is our public concierge, not a clinician.");
+    expect(shellSource).toContain("Captain cannot diagnose, triage, or provide treatment-specific clinical advice.");
+    expect(shellSource).toContain("Please do not enter personal health information or sensitive details.");
+    expect(shellSource).toContain("For urgent dental problems, contact the practice directly or follow emergency guidance.");
+    expect(shellSource).toContain("Captain can help with general navigation, service information, and safe signposting.");
+    expect(shellSource).toContain(
+      "Contact or booking handoffs send a request to the team; they do not confirm an appointment.",
+    );
+  });
+
+  it("does not invite treatment-specific clinical advice in the input placeholder", () => {
+    expect(shellSource).toContain("Ask general navigation or service-information questions");
+    expect(shellSource).not.toContain("Ask about treatment options, appointments, or what to do next");
+  });
+});

--- a/apps/web/app/components/concierge/ConciergeShell.tsx
+++ b/apps/web/app/components/concierge/ConciergeShell.tsx
@@ -46,6 +46,15 @@ type ConciergeShellProps = {
 
 const LEAD_SENTENCE_MIN_LENGTH = 80;
 
+export const CONCIERGE_BOUNDARY_COPY = [
+  "Captain is our public concierge, not a clinician.",
+  "Captain cannot diagnose, triage, or provide treatment-specific clinical advice.",
+  "Please do not enter personal health information or sensitive details.",
+  "For urgent dental problems, contact the practice directly or follow emergency guidance.",
+  "Captain can help with general navigation, service information, and safe signposting.",
+  "Contact or booking handoffs send a request to the team; they do not confirm an appointment.",
+] as const;
+
 function splitLeadSentence(content: string) {
   if (content.length < LEAD_SENTENCE_MIN_LENGTH) {
     return null;
@@ -241,6 +250,17 @@ export function ConciergeShell({
               </button>
             </header>
 
+            <section className={styles.boundaryNotice} aria-labelledby="concierge-boundary-title">
+              <p id="concierge-boundary-title" className={styles.boundaryTitle}>
+                Before you chat with Captain
+              </p>
+              <ul className={styles.boundaryList}>
+                {CONCIERGE_BOUNDARY_COPY.map((item) => (
+                  <li key={item}>{item}</li>
+                ))}
+              </ul>
+            </section>
+
             <div className={styles.messages} aria-live="polite">
               {messages.map((message) => (
                 <article key={message.id} className={styles.message}>
@@ -306,7 +326,7 @@ export function ConciergeShell({
                 rows={1}
                 value={inputValue}
                 onChange={(event) => onInputChange(event.target.value)}
-                placeholder="Ask about treatment options, appointments, or what to do next"
+                placeholder="Ask general navigation or service-information questions"
                 disabled={isLoading}
               />
               <button type="submit" className={styles.sendButton} disabled={isLoading || inputValue.trim().length === 0}>

--- a/apps/web/app/components/concierge/concierge.module.css
+++ b/apps/web/app/components/concierge/concierge.module.css
@@ -159,6 +159,31 @@
   cursor: pointer;
 }
 
+.boundaryNotice {
+  border-bottom: 1px solid var(--border-subtle);
+  background: color-mix(in srgb, var(--surface-1) 84%, transparent);
+  padding: 0.85rem 1.2rem 0.95rem;
+}
+
+.boundaryTitle {
+  margin: 0;
+  color: var(--text-high);
+  font-size: 0.78rem;
+  font-weight: 650;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.boundaryList {
+  margin: 0.55rem 0 0;
+  padding-inline-start: 1rem;
+  color: var(--text-medium);
+  display: grid;
+  gap: 0.32rem;
+  font-size: 0.78rem;
+  line-height: 1.45;
+}
+
 .messages {
   flex: 1 1 auto;
   min-height: 0;


### PR DESCRIPTION
### Motivation
- Add visible boundary copy at the public concierge mount so users understand Captain is a public concierge (not a clinician), cannot provide diagnosis/triage/treatment advice, and is safe to use for navigation and signposting per the M28B packet.

### Description
- Inserted a `CONCIERGE_BOUNDARY_COPY` constant and rendered a "Before you chat with Captain" notice in `apps/web/app/components/concierge/ConciergeShell.tsx` immediately above the concierge messages panel.
- Updated the composer input placeholder to `Ask general navigation or service-information questions` and added token-only styling for the notice in `apps/web/app/components/concierge/concierge.module.css` to follow the Brand Canon.
- Added a Vitest content test `apps/web/app/components/concierge/ConciergeShell.boundary-copy.test.ts` which asserts the exact boundary copy and placeholder wording are present.

### Testing
- Files changed: `apps/web/app/components/concierge/ConciergeShell.tsx`, `apps/web/app/components/concierge/concierge.module.css`, and `apps/web/app/components/concierge/ConciergeShell.boundary-copy.test.ts`.
- Exact boundary copy added/verified: "Before you chat with Captain"; "Captain is our public concierge, not a clinician."; "Captain cannot diagnose, triage, or provide treatment-specific clinical advice."; "Please do not enter personal health information or sensitive details."; "For urgent dental problems, contact the practice directly or follow emergency guidance."; "Captain can help with general navigation, service information, and safe signposting."; and "Contact or booking handoffs send a request to the team; they do not confirm an appointment.", and the input placeholder is now "Ask general navigation or service-information questions".
- Checks run: `pnpm exec vitest run apps/web/app/components/concierge/ConciergeShell.boundary-copy.test.ts` — PASS; `npm run guard:hero` — PASS; `npm run guard:canon` — PASS; `npm run lint` — PASS; `npm run build` — PASS; `npm run verify` — PASS; root `npm test` is not present (not applicable).
- Remaining blockers: none for this M28B public boundary-copy packet; launch/production certification/M29 remain explicitly out of scope.
- Safety statement: this change introduces no PHI, no memory, no model calls, no agent runtime calls, no PMS/Dentally mutation, and no receptionist/recall/treatment-coordinator logic.
- Packet status: PASS for `M28B-CHAMPAGNE-001-PUBLIC-MOUNT-BOUNDARY-COPY`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2277cb267c83328c51adb162fb2cc3)