### PR TITLE
Add concierge booking handoff fallback safety

### DIFF
--- a/apps/web/app/components/concierge/_handoff/HandoffModal.fallback-copy.test.ts
+++ b/apps/web/app/components/concierge/_handoff/HandoffModal.fallback-copy.test.ts
@@ -1,0 +1,29 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const currentDir = dirname(fileURLToPath(import.meta.url));
+const modalSource = readFileSync(join(currentDir, "HandoffModal.tsx"), "utf8");
+const routerSource = readFileSync(join(currentDir, "postbackRouter.ts"), "utf8");
+
+describe("HandoffModal fallback copy", () => {
+  it("keeps visible booking/contact handoff safety copy", () => {
+    expect(modalSource).toContain(
+      "Captain can guide you to contact or booking options, but Captain does not confirm appointments.",
+    );
+    expect(modalSource).toContain(
+      "This form sends a request/handoff to the practice team only, unless a separate governed confirmed-booking flow tells you otherwise.",
+    );
+    expect(modalSource).toContain("Please do not include personal health information or sensitive details.");
+    expect(modalSource).toContain("For urgent dental issues, contact the practice directly.");
+    expect(modalSource).toContain("It is not a confirmed appointment.");
+  });
+
+  it("points fallback navigation to the existing contact surface only", () => {
+    expect(routerSource).toContain('export const SAFE_HANDOFF_FALLBACK_HREF = "/contact";');
+    expect(modalSource).toContain("Contact the practice directly");
+    expect(modalSource).not.toContain("dentally");
+    expect(modalSource).not.toContain("pms");
+  });
+});

--- a/apps/web/app/components/concierge/_handoff/HandoffModal.module.css
+++ b/apps/web/app/components/concierge/_handoff/HandoffModal.module.css
@@ -41,6 +41,37 @@
   font-size: 0.8125rem;
 }
 
+.safetyNotice {
+  margin-top: 0.9rem;
+  border: 1px solid var(--border-subtle);
+  border-radius: 0.875rem;
+  background: var(--surface-0);
+  color: var(--text-medium);
+  padding: 0.75rem;
+  font-size: 0.75rem;
+}
+
+.safetyNotice p {
+  margin: 0;
+}
+
+.safetyNotice p + p {
+  margin-top: 0.35rem;
+}
+
+.contactLink {
+  display: inline-flex;
+  margin-top: 0.55rem;
+  color: var(--text-high);
+  text-decoration: underline;
+  text-underline-offset: 0.18em;
+}
+
+.contactLink:focus-visible {
+  outline: 2px solid var(--text-high);
+  outline-offset: 2px;
+}
+
 .closeButton {
   border: 1px solid var(--border-subtle);
   border-radius: 999px;

--- a/apps/web/app/components/concierge/_handoff/HandoffModal.tsx
+++ b/apps/web/app/components/concierge/_handoff/HandoffModal.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useMemo, useState } from "react";
 import type { FormEvent } from "react";
 import styles from "./HandoffModal.module.css";
-import { resolveHandoffEndpoint, type HandoffKind } from "./postbackRouter";
+import { resolveHandoffEndpoint, SAFE_HANDOFF_FALLBACK_HREF, type HandoffKind } from "./postbackRouter";
 
 type HandoffModalProps = {
   kind: HandoffKind;
@@ -36,6 +36,13 @@ type FormState = BaseFields & {
   enquiry: string;
 };
 
+export const HANDOFF_FALLBACK_COPY = [
+  "Captain can guide you to contact or booking options, but Captain does not confirm appointments.",
+  "This form sends a request/handoff to the practice team only, unless a separate governed confirmed-booking flow tells you otherwise.",
+  "Please do not include personal health information or sensitive details.",
+  "For urgent dental issues, contact the practice directly.",
+] as const;
+
 const initialState = (): FormState => ({
   name: "",
   phone: "",
@@ -55,23 +62,23 @@ function getModalMeta(kind: HandoffKind) {
   if (kind === "BOOKING") {
     return {
       title: "Booking / call-back request",
-      description: "Share details and a preferred time window for a concierge call-back.",
-      successMessage: "Thanks — your booking request was sent.",
+      description: "Share contact details and a preferred time window for a practice team call-back.",
+      successMessage: "Thanks — your booking request was sent to the practice team. It is not a confirmed appointment.",
     };
   }
 
   if (kind === "EMERGENCY_CALLBACK") {
     return {
       title: "Emergency call-back",
-      description: "Share your details so the team can call you back quickly.",
-      successMessage: "Thanks — your emergency callback request was sent.",
+      description: "Share contact details so the team can call you back quickly; contact the practice directly for urgent dental issues.",
+      successMessage: "Thanks — your emergency callback request was sent to the practice team.",
     };
   }
 
   return {
     title: "New patient enquiry",
-    description: "Share your details and what you are looking for.",
-    successMessage: "Thanks — your new patient enquiry was sent.",
+    description: "Share contact details and what you are looking for without sensitive details.",
+    successMessage: "Thanks — your new patient enquiry was sent to the practice team.",
   };
 }
 
@@ -180,6 +187,15 @@ export function HandoffModal({ kind, onClose }: HandoffModalProps) {
           </button>
         </header>
 
+        <aside className={styles.safetyNotice} aria-label="Booking and contact handoff safety">
+          {HANDOFF_FALLBACK_COPY.map((copy) => (
+            <p key={copy}>{copy}</p>
+          ))}
+          <a className={styles.contactLink} href={SAFE_HANDOFF_FALLBACK_HREF}>
+            Contact the practice directly
+          </a>
+        </aside>
+
         {submission.status === "success" ? (
           <p className={styles.message}>{submission.message}</p>
         ) : (
@@ -247,7 +263,7 @@ export function HandoffModal({ kind, onClose }: HandoffModalProps) {
                   />
                 </label>
                 <label className={styles.label}>
-                  Reason
+                  Reason (no personal health information or sensitive details)
                   <textarea
                     className={styles.textarea}
                     rows={3}
@@ -271,7 +287,7 @@ export function HandoffModal({ kind, onClose }: HandoffModalProps) {
                   />
                 </label>
                 <label className={styles.label}>
-                  Brief issue summary
+                  Brief issue summary (no personal health information or sensitive details)
                   <textarea
                     className={styles.textarea}
                     rows={3}
@@ -284,7 +300,7 @@ export function HandoffModal({ kind, onClose }: HandoffModalProps) {
 
             {kind === "NEW_PATIENT" ? (
               <label className={styles.label}>
-                What are you looking for?
+                What are you looking for? (no sensitive details)
                 <textarea
                   className={styles.textarea}
                   rows={3}

--- a/apps/web/app/components/concierge/_handoff/postbackRouter.ts
+++ b/apps/web/app/components/concierge/_handoff/postbackRouter.ts
@@ -1,5 +1,7 @@
 export type HandoffKind = "BOOKING" | "EMERGENCY_CALLBACK" | "NEW_PATIENT";
 
+export const SAFE_HANDOFF_FALLBACK_HREF = "/contact";
+
 const HANDOFF_ENDPOINTS: Record<HandoffKind, "/api/handoff/booking" | "/api/handoff/emergency-callback" | "/api/handoff/new-patient"> = {
   BOOKING: "/api/handoff/booking",
   EMERGENCY_CALLBACK: "/api/handoff/emergency-callback",

--- a/reports/M28B_CHAMPAGNE_002_BOOKING_HANDOFF_FALLBACK_REPORT_V1.md
+++ b/reports/M28B_CHAMPAGNE_002_BOOKING_HANDOFF_FALLBACK_REPORT_V1.md
@@ -1,0 +1,73 @@
+# M28B_CHAMPAGNE_002_BOOKING_HANDOFF_FALLBACK_REPORT_V1
+
+## Packet
+
+M28B-CHAMPAGNE-002-BOOKING-HANDOFF-FALLBACK.
+
+## Files changed
+
+- `apps/web/app/components/concierge/_handoff/HandoffModal.tsx`
+- `apps/web/app/components/concierge/_handoff/HandoffModal.module.css`
+- `apps/web/app/components/concierge/_handoff/postbackRouter.ts`
+- `apps/web/app/components/concierge/_handoff/HandoffModal.fallback-copy.test.ts`
+- `reports/M28B_CHAMPAGNE_002_BOOKING_HANDOFF_FALLBACK_REPORT_V1.md`
+
+## Public handoff surface located
+
+- Public Captain concierge shell: `apps/web/app/components/concierge/ConciergeShell.tsx`
+- Public Captain concierge layer and handoff modal entry: `apps/web/app/components/concierge/ConciergeLayer.tsx`
+- Booking/contact handoff modal: `apps/web/app/components/concierge/_handoff/HandoffModal.tsx`
+- Safe fallback contact surface verified: `/contact` route in `apps/web/app/contact/page.tsx`
+
+## Exact handoff/fallback copy added or verified
+
+Added/verified visible handoff notice copy:
+
+- "Captain can guide you to contact or booking options, but Captain does not confirm appointments."
+- "This form sends a request/handoff to the practice team only, unless a separate governed confirmed-booking flow tells you otherwise."
+- "Please do not include personal health information or sensitive details."
+- "For urgent dental issues, contact the practice directly."
+- "Contact the practice directly"
+
+Updated modal status/field copy:
+
+- "Share contact details and a preferred time window for a practice team call-back."
+- "Thanks — your booking request was sent to the practice team. It is not a confirmed appointment."
+- "Share contact details so the team can call you back quickly; contact the practice directly for urgent dental issues."
+- "Thanks — your emergency callback request was sent to the practice team."
+- "Share contact details and what you are looking for without sensitive details."
+- "Thanks — your new patient enquiry was sent to the practice team."
+- "Reason (no personal health information or sensitive details)"
+- "Brief issue summary (no personal health information or sensitive details)"
+- "What are you looking for? (no sensitive details)"
+
+Existing public-boundary wording verified in `ConciergeShell.tsx`:
+
+- "Captain is our public concierge, not a clinician."
+- "Captain cannot diagnose, triage, or provide treatment-specific clinical advice."
+- "Please do not enter personal health information or sensitive details."
+- "For urgent dental problems, contact the practice directly or follow emergency guidance."
+- "Captain can help with general navigation, service information, and safe signposting."
+- "Contact or booking handoffs send a request to the team; they do not confirm an appointment."
+
+## Tests run
+
+- `pnpm exec vitest run apps/web/app/components/concierge/ConciergeShell.boundary-copy.test.ts apps/web/app/components/concierge/_handoff/postbackRouter.test.ts apps/web/app/components/concierge/_handoff/HandoffModal.fallback-copy.test.ts`
+- `pnpm run lint`
+- `pnpm run build`
+- `npm run guard:hero`
+- `npm run guard:canon`
+- `npm run verify`
+
+## Remaining blockers
+
+- None identified for M28B-CHAMPAGNE-002 booking/contact handoff fallback closure.
+- M29 remains NOT_READY_FOR_M29; this packet does not approve launch or production certification.
+
+## Explicit exclusions
+
+This packet introduced no PHI storage, no memory, no model calls, no agent runtime calls, no PMS mutation, no Dentally mutation, no receptionist logic, no recall logic, and no treatment coordinator logic.
+
+## Packet status
+
+PASS


### PR DESCRIPTION
### Motivation
- Ensure the public Captain concierge handoff UI explicitly states safe fallback behaviour for booking/contact handoffs and prevents users from entering PHI or assuming confirmed appointments.
- Point any fallback navigation to the existing safe contact surface (`/contact`) only and keep all changes token-only for styling.
- Preserve existing guards and canonical constraints while keeping the public concierge a non-clinical signposting surface.

### Description
- Added visible fallback copy constant `HANDOFF_FALLBACK_COPY` and injected a safety notice into `apps/web/app/components/concierge/_handoff/HandoffModal.tsx` to explain that Captain guides to contact/booking options but does not confirm appointments. 
- Updated modal copy and success messages to clarify submissions are requests to the practice team and added field hints that discourage entering personal health information. 
- Centralised safe fallback destination as `SAFE_HANDOFF_FALLBACK_HREF = "/contact"` in `apps/web/app/components/concierge/_handoff/postbackRouter.ts` and added a token-only `safetyNotice` UI with link styling in `HandoffModal.module.css`. 
- Added a unit test `apps/web/app/components/concierge/_handoff/HandoffModal.fallback-copy.test.ts` that verifies the fallback copy and safe-surface link, and committed the packet report `reports/M28B_CHAMPAGNE_002_BOOKING_HANDOFF_FALLBACK_REPORT_V1.md` documenting changes and scope.
- Files changed: `HandoffModal.tsx`, `HandoffModal.module.css`, `postbackRouter.ts`, `HandoffModal.fallback-copy.test.ts`, and `reports/M28B_CHAMPAGNE_002_BOOKING_HANDOFF_FALLBACK_REPORT_V1.md`.
- Explicit safety exclusions: this change introduces no PHI storage, no memory, no model calls, no agent runtime calls, no PMS/Dentally mutation, and no receptionist/recall/treatment-coordinator logic.

### Testing
- Ran unit tests with `pnpm exec vitest run apps/web/app/components/concierge/ConciergeShell.boundary-copy.test.ts apps/web/app/components/concierge/_handoff/postbackRouter.test.ts apps/web/app/components/concierge/_handoff/HandoffModal.fallback-copy.test.ts`, which completed successfully (3 test files, 9 tests passed).
- Ran lint with `pnpm run lint`, which passed with no errors for the web project and workspace linters.
- Built the site with `pnpm run build`, which completed successfully and produced the expected routes including `/contact` and handoff APIs.
- Ran guards `npm run guard:hero` and `npm run guard:canon`, both of which passed.
- Ran full verification `npm run verify`, which completed and passed the token-purity and guard checks; no remaining blockers for this packet were found.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a227d0d47248332895b080e9d2e197d)