### PR TITLE
Prove concierge no-PHI safe redirect surface

### DIFF
--- a/apps/web/app/api/converse/route.test.ts
+++ b/apps/web/app/api/converse/route.test.ts
@@ -31,6 +31,7 @@ describe("POST /api/converse", () => {
 
     const request = new Request("http://localhost/api/converse", {
       method: "POST",
+      cache: "no-store",
       headers: {
         "Content-Type": "application/json",
         "x-debug-chat": "1",
@@ -42,6 +43,7 @@ describe("POST /api/converse", () => {
 
     expect(fetchMock).toHaveBeenCalledWith("https://engine.test/v1/converse", {
       method: "POST",
+      cache: "no-store",
       headers: {
         "Content-Type": "application/json",
         "x-debug-chat": "1",
@@ -64,6 +66,7 @@ describe("POST /api/converse", () => {
 
     const request = new Request("http://localhost/api/converse", {
       method: "POST",
+      cache: "no-store",
       headers: {
         "Content-Type": "application/json",
         "x-debug-chat": "0",
@@ -75,6 +78,7 @@ describe("POST /api/converse", () => {
 
     expect(fetchMock).toHaveBeenCalledWith("https://engine.test/v1/converse", {
       method: "POST",
+      cache: "no-store",
       headers: {
         "Content-Type": "application/json",
       },

--- a/apps/web/app/components/concierge/ConciergeLayer.tsx
+++ b/apps/web/app/components/concierge/ConciergeLayer.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useState } from "react";
 import { usePathname } from "next/navigation";
 import { getPageManifest } from "@champagne/manifests";
 import { ConciergeShell, type ConciergeMessage } from "./ConciergeShell";
+import { normalizeConverseDisplayMessage, type ConverseResponse } from "./_helpers/converseDisplay";
 import { HandoffModal } from "./_handoff/HandoffModal";
 import { resolveHandoffKind, type HandoffKind } from "./_handoff/postbackRouter";
 import {
@@ -13,22 +14,6 @@ import {
   setIntentStage,
   updateVisitedPath,
 } from "./_helpers/sessionMemory";
-
-type ConverseCard = {
-  title?: string;
-  description?: string;
-  body?: string;
-  actions?: Array<{ type?: string; label?: string; href?: string; payload?: unknown }>;
-};
-
-type ConverseResponse = {
-  conversationId?: string;
-  content?: string;
-  ui?: {
-    kind?: string;
-    cards?: ConverseCard[];
-  };
-};
 
 function resolveConciergeEnabled(pathname: string): boolean {
   const manifest = getPageManifest(pathname) as { conciergeEnabled?: boolean } | undefined;
@@ -128,44 +113,14 @@ export function ConciergeLayer() {
         setSessionState(setConversationId(nextConversationId));
       }
 
-      const cards = payload.ui?.kind === "cards" && Array.isArray(payload.ui.cards)
-        ? payload.ui.cards.map((card, cardIndex) => ({
-            id: `${idSeed}-card-${cardIndex}`,
-            title: card.title,
-            description: card.description ?? card.body ?? "",
-            actions: card.actions
-              ?.map((action) => {
-                if (action.type === "link" && action.href && action.label) {
-                  return { type: "link" as const, href: action.href, label: action.label };
-                }
-
-                if (
-                  action.type === "postback" &&
-                  (typeof action.payload === "string" || (action.payload && typeof action.payload === "object")) &&
-                  action.label
-                ) {
-                  return { type: "postback" as const, payload: action.payload, label: action.label };
-                }
-
-                return null;
-              })
-              .filter(
-                (
-                  action,
-                ): action is
-                  | { type: "link"; href: string; label: string }
-                  | { type: "postback"; payload: string | Record<string, unknown>; label: string } => Boolean(action),
-              ),
-          }))
-        : undefined;
+      const displayMessage = normalizeConverseDisplayMessage(payload, idSeed);
 
       setMessages((previous) => [
         ...previous,
         {
           id: `${idSeed}-assistant`,
           role: "assistant",
-          content: payload.content ?? "I can help with another question whenever you are ready.",
-          cards,
+          ...displayMessage,
         },
       ]);
     } catch {

--- a/apps/web/app/components/concierge/_helpers/converseDisplay.test.ts
+++ b/apps/web/app/components/concierge/_helpers/converseDisplay.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import { normalizeConverseDisplayMessage, type ConverseResponse } from "./converseDisplay";
+
+function visibleMessageText(message: ReturnType<typeof normalizeConverseDisplayMessage>) {
+  return [
+    message.content,
+    ...(message.cards ?? []).flatMap((card) => [
+      card.title ?? "",
+      card.description ?? "",
+      ...(card.actions ?? []).map((action) => action.label),
+    ]),
+  ].join("\n");
+}
+
+describe("normalizeConverseDisplayMessage", () => {
+  it("renders blocked safe-redirect responses without exposing certification or personality metadata", () => {
+    const payload = {
+      content:
+        "I cannot help with personal dental details here. Please contact the practice directly or use the contact page for a safe handoff.",
+      certification: "DO_NOT_SHOW_CERTIFICATION_METADATA",
+      personality: { internalName: "DO_NOT_SHOW_PERSONALITY_METADATA" },
+      ui: {
+        kind: "cards",
+        cards: [
+          {
+            title: "Safe contact options",
+            description: "Use the contact page or request a practice team call-back without sensitive details.",
+            actions: [
+              { type: "link", label: "Contact the practice", href: "/contact" },
+              { type: "postback", label: "Request a booking call-back", payload: { kind: "handoff", form: "booking" } },
+            ],
+          },
+        ],
+      },
+    } satisfies ConverseResponse & { certification: string; personality: { internalName: string } };
+
+    const message = normalizeConverseDisplayMessage(payload, "blocked-safe-redirect");
+    const visibleText = visibleMessageText(message);
+
+    expect(visibleText).toContain("Please contact the practice directly");
+    expect(visibleText).toContain("Contact the practice");
+    expect(visibleText).toContain("Request a booking call-back");
+    expect(visibleText).not.toMatch(/certification|personality|DO_NOT_SHOW/i);
+  });
+
+  it("constrains response actions to safe contact links and governed handoff postbacks", () => {
+    const message = normalizeConverseDisplayMessage(
+      {
+        content: "I can point you to safe contact options.",
+        ui: {
+          kind: "cards",
+          cards: [
+            {
+              title: "Options",
+              actions: [
+                { type: "link", label: "Contact", href: "/contact" },
+                { type: "link", label: "Dev bridge", href: "/api/dev/codex" },
+                { type: "link", label: "Dentally", href: "https://dentally.example/internal" },
+                { type: "postback", label: "Booking request", payload: "BOOKING_REQUEST" },
+                { type: "postback", label: "Recall receptionist", payload: "RECALL" },
+              ],
+            },
+          ],
+        },
+      },
+      "safe-actions",
+    );
+
+    expect(message.cards?.[0]?.actions).toEqual([
+      { type: "link", href: "/contact", label: "Contact" },
+      { type: "postback", payload: "BOOKING_REQUEST", label: "Booking request" },
+    ]);
+    expect(visibleMessageText(message)).not.toMatch(/dev bridge|dentally|recall|receptionist/i);
+  });
+});

--- a/apps/web/app/components/concierge/_helpers/converseDisplay.ts
+++ b/apps/web/app/components/concierge/_helpers/converseDisplay.ts
@@ -1,0 +1,97 @@
+import { resolveHandoffKind } from "../_handoff/postbackRouter";
+import type { ConciergeMessage } from "../ConciergeShell";
+
+type ConverseCard = {
+  title?: string;
+  description?: string;
+  body?: string;
+  actions?: Array<{ type?: string; label?: string; href?: string; payload?: unknown }>;
+};
+
+export type ConverseResponse = {
+  conversationId?: string;
+  content?: string;
+  ui?: {
+    kind?: string;
+    cards?: ConverseCard[];
+  };
+};
+
+const SAFE_PUBLIC_LINK_HREFS = new Set(["/contact"]);
+
+const FORBIDDEN_USER_FACING_METADATA_PATTERN =
+  /certification|personality|codex|agent\s+(?:execution|runtime|bridge)|dev\s+(?:execution|bridge|console)|dentally|pms|receptionist|recall|treatment coordinator/i;
+
+function isSafeUserFacingText(value: string | undefined): value is string {
+  return typeof value === "string" && !FORBIDDEN_USER_FACING_METADATA_PATTERN.test(value);
+}
+
+function stringifyPayload(payload: unknown): string | null {
+  if (typeof payload === "string") {
+    return payload;
+  }
+
+  if (payload && typeof payload === "object") {
+    return JSON.stringify(payload);
+  }
+
+  return null;
+}
+
+function isSafePublicLink(href: string | undefined): href is string {
+  if (!href) return false;
+  return SAFE_PUBLIC_LINK_HREFS.has(href) || href.startsWith("/contact?") || href.startsWith("/contact#");
+}
+
+export function normalizeConverseDisplayMessage(payload: ConverseResponse, idSeed: string): Omit<ConciergeMessage, "id" | "role"> {
+  const cards =
+    payload.ui?.kind === "cards" && Array.isArray(payload.ui.cards)
+      ? payload.ui.cards
+          .map((card, cardIndex) => {
+            const title = isSafeUserFacingText(card.title) ? card.title : undefined;
+            const descriptionSource = card.description ?? card.body ?? "";
+            const description = isSafeUserFacingText(descriptionSource) ? descriptionSource : "";
+            const actions = card.actions
+              ?.map((action) => {
+                if (action.type === "link" && isSafePublicLink(action.href) && isSafeUserFacingText(action.label)) {
+                  return { type: "link" as const, href: action.href, label: action.label };
+                }
+
+                if (action.type === "postback" && isSafeUserFacingText(action.label)) {
+                  const payloadText = stringifyPayload(action.payload);
+                  if (payloadText && resolveHandoffKind(payloadText)) {
+                    return { type: "postback" as const, payload: payloadText, label: action.label };
+                  }
+                }
+
+                return null;
+              })
+              .filter(
+                (
+                  action,
+                ): action is
+                  | { type: "link"; href: string; label: string }
+                  | { type: "postback"; payload: string; label: string } => Boolean(action),
+              );
+
+            if (!title && !description && !actions?.length) {
+              return null;
+            }
+
+            return {
+              id: `${idSeed}-card-${cardIndex}`,
+              title,
+              description,
+              actions,
+            };
+          })
+          .filter((card): card is NonNullable<typeof card> => Boolean(card))
+      : undefined;
+
+  return {
+    content: isSafeUserFacingText(payload.content)
+      ? payload.content
+      : "I can guide you to safe contact options, but the practice team must advise on personal or urgent concerns.",
+    cards: cards?.length ? cards : undefined,
+  };
+}


### PR DESCRIPTION
### Motivation
- Prove the public concierge (Captain) surface presents safe redirect / no-PHI behaviour and visible boundary copy so users are not invited to share PHI or receive clinical diagnoses.  
- Changes must be limited to presentation and tests only, with no runtime API wiring, model/agent calls, memory, PMS/Dentally mutation, or tracking introduced.

### Description
- Files changed: `apps/web/app/components/concierge/ConciergeLayer.tsx`, `apps/web/app/components/concierge/_helpers/converseDisplay.ts`, `apps/web/app/components/concierge/_helpers/converseDisplay.test.ts`, and `apps/web/app/api/converse/route.test.ts`.  
- Added `normalizeConverseDisplayMessage` to sanitize/normalize mock/API responses so certification/personality/dev/Codex/Dentally/PMS/receptionist/recall/treatment-coordinator metadata is never rendered to users and unsafe links are filtered.  
- Constrained visible response actions to safe public contact links (whitelist `/contact` variants) and governed handoff postbacks that resolve via the existing `postbackRouter`, and wired `ConciergeLayer` to use the normalizer before rendering assistant messages without adding new runtime wiring.  
- Minor test adjustment to `apps/web/app/api/converse/route.test.ts` to reflect the upstream `fetch` contract (`cache: "no-store"`) used when forwarding to the engine.

### Testing
- Ran targeted unit tests with `pnpm exec vitest run apps/web/app/components/concierge apps/web/app/api/converse apps/web/app/api/handoff` and all targeted tests passed (local run: all test suites listed succeeded).  
- Ran lint and build checks with `pnpm run lint` and `pnpm run build` and both completed successfully.  
- Ran the required guards and verification commands `npm run guard:hero`, `npm run guard:canon`, and `npm run verify` (which exercises token purity, guard pipeline, and the web build) and they passed in this environment.  
- Remaining blockers: inherited blockers remain and were not addressed by this packet: `M28-TECH-002`, `M28-GOV-002`, `M28-OPS-002`.

M28B_CHAMPAGNE_004_NO_PHI_SAFE_REDIRECT_SURFACE_PROOF_REPORT_V1

Surface proof summary: added a dedicated display-normalization helper to ensure blocked/safe-redirect responses render only user-safe copy and allowed `/contact` or governed handoff actions while suppressing any certification/personality/dev/Codex/Dentally/PMS/receptionist/recall/treatment-coordinator metadata from user-facing UI.

Tests run: `pnpm exec vitest run apps/web/app/components/concierge apps/web/app/api/converse apps/web/app/api/handoff`, `pnpm run lint`, `pnpm run build`, `npm run guard:hero`, `npm run guard:canon`, `npm run verify` (all passed in the local environment). 

Remaining blockers: `M28-TECH-002`, `M28-GOV-002`, `M28-OPS-002` (inherited and not resolved here). 

Explicit statement: No PHI introduced; no memory introduced; no model calls introduced; no agent runtime calls introduced; no PMS or Dentally mutation introduced; no receptionist/recall/treatment coordinator surfaces introduced; no dev/Codex/agent execution bridge introduced or exposed; and no behavioural tracking, cookies, analytics, personalisation, or runtime API wiring was added in this packet. 

Packet status: PASS

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a228f35d0488332a2a810400be6e1d1)