### PR TITLE
Document Hero V2 navigation flash failure analysis and next-step plan

### DIFF
--- a/BOUNDED_NAVIGATION_FLASH_FIX_OPTIONS.md
+++ b/BOUNDED_NAVIGATION_FLASH_FIX_OPTIONS.md
@@ -1,0 +1,135 @@
+# BOUNDED_NAVIGATION_FLASH_FIX_OPTIONS
+
+Role: `HERO_V2_NAVIGATION_FLASH_FAILURE_RESPONSE_DIRECTOR`  
+Evidence date: 2026-06-05
+
+## Option A — Make Hero V2 persistent across route transitions if architecture allows
+
+### Strategy
+
+Move or restructure the Hero V2 surface/motion stack so it is not recreated during public route navigation. Keep page-specific content/model changes separate from the persistent motion/base stack.
+
+### Potential benefits
+
+- Best match for the user-visible symptom: motion layers would not restart because video DOM nodes and CSS animation phase would survive route changes.
+- Reduces need for repeated media readiness/reveal gates.
+- Aligns with the concept of a sacred hero that appears globally.
+
+### Risks
+
+- Requires high confidence in Next App Router layout lifecycle and current `headers()` usage.
+- May conflict with route-specific hero model/variant identity if those are meant to change per route later.
+- Could require splitting stable visual stack from route-dependent content; that is more architectural than a one-line fix.
+
+### Evidence needed before implementation
+
+- Vercel Preview proof that stack id changes on navigation.
+- Confirmation whether full document reloads are occurring. If navigation is full document reload, React persistence alone cannot solve the reset; link/navigation behavior must be addressed first.
+
+### Safety rating
+
+**Potentially high impact, medium safety.** Best if architecture permits a stable client island under root layout and navigation is same-document.
+
+## Option B — Prevent motion initial replay after first hero mount
+
+### Strategy
+
+Track a first-hero-mount/session flag and render subsequent route navigations with motion videos already at target opacity and with minimized initial reveal behavior. This can reduce perceived flash even if media elements remount.
+
+### Potential benefits
+
+- Smaller than a persistence refactor.
+- Builds on the existing `window.__heroMotionEverRevealed` concept.
+- Can avoid opacity/readiness flashes on remount.
+
+### Limits
+
+- Does not preserve video `currentTime` or CSS animation phase.
+- User may still perceive a motion reset if the video content begins from frame zero.
+- If navigation is a full document reload, window memory is lost and this option will not survive.
+
+### Safety rating
+
+**Medium impact, medium-high safety** for same-document remounts; **low impact** for hard reloads.
+
+## Option C — Stabilize route-level hero model/key identity
+
+### Strategy
+
+Ensure the global sacred hero uses a stable identity/key/model across routes, or explicitly separate stable sacred visual model from route page metadata.
+
+### Potential benefits
+
+- Avoids unnecessary stack replacement caused by changing identity props or model object churn.
+- Useful if evidence shows React is remounting because route-specific props/key identity change.
+
+### Limits
+
+- No explicit route key was found on the V2 frame/stack path.
+- Captured evidence points to parent/document replacement, not only child key churn.
+- Route-specific variants are explicitly out of scope for this mission.
+
+### Safety rating
+
+**Medium safety, uncertain impact** until React key/parent replacement is proven in Vercel.
+
+## Option D — Add transition-aware reduced remount/reveal gating
+
+### Strategy
+
+Detect route transitions and avoid hiding/revealing the hero/content/motion stack during navigation after first load. This could include making `HeroContentFade` first-load-only or disabling it for the sacred global hero.
+
+### Potential benefits
+
+- Directly addresses a known remaining replay gate: `HeroContentFade` sets opacity to 0 on every pathname change.
+- Smaller than making the entire stack persistent.
+- Can be flag-gated or bounded to Hero V2.
+
+### Limits
+
+- Does not preserve video currentTime if the stack is remounted.
+- May solve content flash but not motion reset.
+
+### Safety rating
+
+**High safety for content fade only**, **medium impact**. Good first bounded implementation if Vercel evidence shows same-document route changes with content opacity flash but persistent stack.
+
+## Option E — Rollback previous fix if irrelevant or harmful
+
+### Strategy
+
+Revert the root/base local `--hero-gradient` first-paint stabilization.
+
+### Benefits
+
+- Removes an irrelevant change if it is proven to cause a new visual regression.
+
+### Risks
+
+- The previous direct-load proof showed root/body ink exposure through transparent hero surfaces. Rolling back may reintroduce or worsen direct-load first-frame flash.
+- Current evidence does not show the previous fix is harmful; it shows it is insufficient for navigation reset.
+
+### Safety rating
+
+**Not recommended on current evidence.** Keep as a contingency only if visual proof shows the local gradient base is materially wrong or causing the Vercel flash.
+
+## Comparative recommendation
+
+| Option | Current recommendation | Why |
+| --- | --- | --- |
+| A | Investigate first, likely best long-term if same-document navigation can be guaranteed. | It solves true motion continuity. |
+| B | Consider as bounded mitigation. | It reduces reveal replay but not media phase reset. |
+| C | Hold unless key/model churn is proven. | No explicit route key found. |
+| D | Strong small-fix candidate for content flash. | Known route-change fade replay exists. |
+| E | Do not do now. | Previous fix likely still helps direct-load first paint. |
+
+## Bounded implementation prompt only if evidence supports it
+
+Use this prompt only after Vercel Preview confirms same-document navigation and either stack persistence or remount behavior:
+
+> ROLE: HERO_V2_NAVIGATION_FLASH_BOUNDED_FIX_IMPLEMENTER  
+> Scope: Fix only the confirmed Hero V2 navigation flash/reset cause. Do not redesign hero, do not change brand colours, do not implement Persian Midnight, typography, variants, or global theming. Preserve sacred engine/manifests.  
+> Evidence gate: Use Vercel/local production debug evidence to choose exactly one of: persistent stack island, first-mount-only content fade, or motion reveal replay suppression.  
+> Allowed files: only the minimal Hero V2 client/renderer files required by the chosen option; no layout/global/header/footer/token edits unless separately authorized.  
+> Requirements: preserve token-only styling, preserve existing layer ids and PRM behavior, add or use debug logs proving stack id and video currentTime before/after navigation, run guards and production capture.  
+> Stop if navigation is a full document reload; in that case produce a navigation behavior report instead of patching hero visuals.

--- a/HERO_V2_MOTION_RESTART_TRACE.md
+++ b/HERO_V2_MOTION_RESTART_TRACE.md
@@ -1,0 +1,59 @@
+# HERO_V2_MOTION_RESTART_TRACE
+
+Role: `HERO_V2_NAVIGATION_FLASH_FAILURE_RESPONSE_DIRECTOR`  
+Evidence date: 2026-06-05
+
+## Motion implementation trace
+
+## 1. CSS animation layer
+
+Hero V2 CSS assigns `animation-name: heroMotionTide`, long animation duration, infinite iteration, and opacity transitions to `.hero-surface--motion` video layers. If the DOM node is recreated, the CSS animation begins again from its initial keyframe.
+
+## 2. Video media layer
+
+`HeroSurfaceStackV2` renders each motion entry as a `<video>` element with:
+
+- `autoPlay`
+- `playsInline`
+- `loop`
+- `muted`
+- `preload="metadata"`
+- `data-ready="false"`
+- `onLoadedData={handleVideoReady}`
+- `onCanPlay={handleVideoReady}`
+- `style={entry.style}`
+
+The video key is `entry.id`, but if the surface stack remounts, each video element is new and starts at `currentTime=0`.
+
+## 3. Motion reveal script
+
+`HeroV2Frame` injects a script that initializes `.hero-surface--motion` videos. It stores `window.__heroMotionEverRevealed = true` after the first reveal, so later video instances can apply target opacity immediately. This helps avoid opacity blackout after the first reveal but does not preserve video playback time, CSS animation phase, or stack continuity.
+
+## 4. Visual-ready gate
+
+The client fallback `HeroRendererV2` tracks `isHeroVisuallyReady`, resets it to false on `[pathnameKey, renderModel]`, and marks ready after video frame/playback callbacks. The server-built `HeroMount` path does not use this client fallback state directly, but the presence of this logic is important if future fixes target the fallback path.
+
+## 5. Content fade replay
+
+`HeroContentFade` watches `usePathname()`. On every pathname change, unless PRM is active or `NEXT_PUBLIC_HERO_CONTENT_FADE=0`, it sets `isVisible=false`, schedules `isVisible=true` on the next animation frame, and applies an opacity transition of 220ms. This is an intentional route-change reveal gate and can contribute to perceived hero “flash/reset” even if the surface stack were persistent.
+
+## Captured motion restart evidence
+
+| Transition | Layer set | Before `currentTime` | +120ms `currentTime` | +1500ms `currentTime` | Readiness after +120ms |
+| --- | --- | --- | --- | --- | --- |
+| `/` → `/treatments` | four sacred motion videos | ~0.417–0.423s | `0` | ~1.105–1.106s | `data-ready=false`, `motionReady=null` at +120ms |
+| `/treatments` → `/treatments/composite-bonding` | four sacred motion videos | ~2.074–2.117s | `0` | ~1.059–1.060s | already `true/true` due global ever-revealed shortcut |
+| `/treatments/composite-bonding` → `/` | four sacred motion videos | ~1.400–1.432s | `0` | ~0.968–0.969s | `data-ready=false`, `motionReady=null` at +120ms |
+
+The same four layer ids were present in each route:
+
+- `sacred.motion.waveCaustics`
+- `sacred.motion.glassShimmer`
+- `sacred.motion.particleDrift`
+- `sacred.motion.goldDust`
+
+## Motion restart conclusion
+
+The remaining flash/reset is consistent with motion media and CSS animation restart. The current global `__heroMotionEverRevealed` shortcut can restore opacity, but it cannot keep motion phase continuous after new video elements are created.
+
+Therefore, a bounded fix that only removes a transparent base cannot solve the reported reset. The next mission should either make the motion stack truly persistent across route transitions or intentionally suppress/reduce motion initial replay after the first mount.

--- a/HERO_V2_NAVIGATION_FLASH_FAILURE_REPORT.md
+++ b/HERO_V2_NAVIGATION_FLASH_FAILURE_REPORT.md
@@ -1,0 +1,84 @@
+# HERO_V2_NAVIGATION_FLASH_FAILURE_REPORT
+
+Role: `HERO_V2_NAVIGATION_FLASH_FAILURE_RESPONSE_DIRECTOR`  
+Evidence date: 2026-06-05  
+Mode: failure-response diagnostic and correction planning; documentation-only; no code correction implemented.
+
+## Executive finding
+
+The previous Hero V2 first-paint/base-surface stabilization must be treated as **partial or failed for the user-visible navigation flash**. It addressed a direct-load transparency gap by giving the Hero V2 root/frame a local `--hero-gradient` base, but the current route-navigation evidence still shows the hero stack and video motion layers being recreated on navigation.
+
+The remaining user-visible problem is therefore not certified as fixed. The most likely remaining cause is **navigation lifecycle reset of the Hero V2 stack and media motion layers**, with the page transition behaving like a route/document replacement in the captured production-local environment.
+
+## What the previous fix addressed
+
+The prior report says the implemented change was limited to `apps/web/app/components/hero/v2/HeroRendererV2.tsx` and applied the same approved hero gradient to the Hero V2 root and base surface before child layers settle.
+
+The prior report explicitly left these concerns out of scope:
+
+- route-specific Hero V2 identity binding;
+- hero variant selection;
+- Hero V2 copy/content identity;
+- motion layer governance;
+- global root/body surfaces;
+- nav/header translucency;
+- Persian Midnight naming or implementation.
+
+Those out-of-scope items overlap with the current user report, especially the route lifecycle and motion reset symptoms.
+
+## Current code-path facts
+
+1. The public root layout renders `HeroMount` before route children whenever the page is public and the brand hero flag is enabled.
+2. `HeroMount` reads `NEXT_PUBLIC_HERO_ENGINE`, normalizes it, and chooses V2 only when the value is exactly `v2`.
+3. In the V2 server path, `HeroMount` reads `next-url`, derives `pathname`, builds a V2 model, and renders `HeroV2Frame` plus `HeroSurfaceStackV2` directly when a model exists.
+4. The root layout computes page category/mode/treatment slug from `next-url`, then passes those props into `HeroMount`.
+5. Header navigation uses `next/link`, but the debug click capture logged `defaultPrevented=false` and the Playwright execution context was destroyed during navigation, which is consistent with a hard navigation/document replacement in the capture.
+6. `HeroSurfaceStackV2` creates a random `data-v2-stack-instance` per mounted stack; the captured stack instance changed after every navigation.
+7. The motion videos are rendered with `autoPlay`, `loop`, `preload="metadata"`, and stable keys by motion-layer id; stable keys only preserve elements if the parent stack is not replaced.
+8. `HeroContentFade` intentionally sets opacity to `0` and then `1` on each pathname change unless reduced motion is active or `NEXT_PUBLIC_HERO_CONTENT_FADE=0`.
+
+## Browser evidence captured in this mission
+
+A local production build was run with:
+
+```bash
+NEXT_PUBLIC_FEATURE_BRAND_HERO=1 NEXT_PUBLIC_HERO_ENGINE=v2 NEXT_PUBLIC_HERO_DEBUG=1 pnpm run build:web
+PORT=3100 NEXT_PUBLIC_FEATURE_BRAND_HERO=1 NEXT_PUBLIC_HERO_ENGINE=v2 NEXT_PUBLIC_HERO_DEBUG=1 pnpm --filter web start
+node .tmp/hero-nav-diagnostic.cjs > /tmp/hero-nav-diagnostic.json
+```
+
+Playwright dependencies needed installation in this container. `pnpm exec playwright install chromium` succeeded after a blocked CDN endpoint fell back to the Microsoft mirror; `pnpm exec playwright install-deps chromium` succeeded with a warning for an unrelated `mise.jdx.dev` apt source.
+
+Captured transitions:
+
+| Transition | Before stack | After stack | Motion currentTime before | Motion currentTime after +120ms | Evidence interpretation |
+| --- | --- | --- | --- | --- | --- |
+| `/` → `/treatments` | `v2-stack-bmaim9rt` | `v2-stack-12ppn9wd` | ~0.417–0.423s | `0` | Stack and video elements were recreated; motion restarted. |
+| `/treatments` → `/treatments/composite-bonding` | `v2-stack-rr6q1vz5` | `v2-stack-6ql16e0r` | ~2.074–2.117s | `0` | Stack and video elements were recreated; motion restarted. |
+| `/treatments/composite-bonding` → `/` | `v2-stack-76a941jw` | `v2-stack-dl9b9di7` | ~1.400–1.432s | `0` | Stack and video elements were recreated; motion restarted. |
+
+Additional captured signals:
+
+- Each transition logged `[HERO_DIAG_NAV] ... defaultPrevented=false`.
+- Immediate post-click evaluation often failed with `Execution context was destroyed`, which prevented a true same-document compositor filmstrip in this run.
+- Post-navigation logs contained new `HERO_V2_MOUNT` and `HERO_V2_MOTION_EVENT` / `HERO_V2_MOTION_REVEAL` sequences.
+- At +120ms after navigation, motion layer `currentTime` was `0`, confirming user-visible media reset risk even when opacity had already been restored.
+
+## What this does and does not prove
+
+### Proves / strongly supports
+
+- The previous fix did not remove the observed route-navigation reset class.
+- Hero V2 motion layers restart during captured navigations.
+- The stack instance changes across captured navigations.
+- The current debug signals are sufficient to target lifecycle/motion reset next, not to certify first-paint stabilization.
+
+### Does not fully prove
+
+- Whether Vercel preview is performing hard document navigations for the same reason as this local capture.
+- Whether the user-visible Vercel flash is dominated by full document replacement, RSC/root-layout replay, content fade replay, video restart, or a combination.
+- Whether a persistent layout strategy is architecturally safe without additional App Router lifecycle proof.
+
+## Failure-response decision
+
+The prior fix should be considered **a first-paint sub-issue fix only**. It may reduce root/body ink exposure on direct load, but it does **not** address navigation lifecycle reset and does **not** certify the Vercel preview symptom as fixed.

--- a/HERO_V2_ROUTE_LIFECYCLE_TRACE.md
+++ b/HERO_V2_ROUTE_LIFECYCLE_TRACE.md
@@ -1,0 +1,76 @@
+# HERO_V2_ROUTE_LIFECYCLE_TRACE
+
+Role: `HERO_V2_NAVIGATION_FLASH_FAILURE_RESPONSE_DIRECTOR`  
+Evidence date: 2026-06-05
+
+## Route/lifecycle topology
+
+## 1. Root layout placement
+
+`apps/web/app/layout.tsx` renders the sacred/public hero globally in the root layout, before route children:
+
+- reads `next-url` from `headers()`;
+- computes `isPublicPage`, `isHeroEnabled`, `pathname`, `pageCategory`, `mode`, and `treatmentSlug`;
+- renders `<HeroMount ... />` inside `<main>` when public and enabled;
+- renders `{children}` after the hero.
+
+This means the intended architecture appears to be a global hero above page content, not page-local builder hero output. However, because the root layout is dynamic (`headers()`), production navigation behavior must be verified rather than assumed.
+
+## 2. Page templates
+
+The home page and treatment pages render `ChampagnePageBuilder` as route content. `ChampagnePageBuilder` has `shouldRenderBuilderHero = previewMode === true`, so normal public pages do not render an additional builder hero. The sacred/public hero observed on every page is therefore coming from root layout + `HeroMount`, not from every page body independently.
+
+## 3. HeroMount server path
+
+`HeroMount` is an async server component. In V2 mode it:
+
+- normalizes `NEXT_PUBLIC_HERO_ENGINE`;
+- reads `next-url` from request headers;
+- derives `pathname` and optional debug query state;
+- imports V2 renderer/build modules;
+- calls `buildHeroV2Model` with `pageSlugOrPath: pathname`;
+- renders a wrapper with `data-hero-engine="v2"`;
+- if a model exists, renders `HeroV2Frame` + `HeroSurfaceStackV2` + `HeroContentFade` directly;
+- otherwise falls back to the client `HeroRendererV2` path.
+
+The dominant path in production evidence appears to be the server-built frame path.
+
+## 4. Client path fallback
+
+`HeroRendererV2` is a client component fallback that uses `usePathname()` and a per-path `heroV2ModelCache`. This path has route-aware model rebuilding and a `lastResolvedHeroV2Model` memory cache. That fallback path is not the normal path when `HeroMount` successfully builds the model server-side.
+
+## 5. React key observations
+
+No explicit route key was found on `HeroMount`, `HeroV2Frame`, or `HeroSurfaceStackV2` in the inspected path. Surface layers use `key={layer.id}` and motion layers use `key={entry.id}`. Those keys are stable only within a persistent parent. They do not prevent reset if the entire stack parent is replaced.
+
+## 6. Captured stack lifecycle evidence
+
+The browser capture sampled `data-v2-stack-instance`, which is generated from `Math.random()` in `HeroSurfaceStackV2` at component mount.
+
+| Transition | Before stack | After stack | Conclusion |
+| --- | --- | --- | --- |
+| `/` → `/treatments` | `v2-stack-bmaim9rt` | `v2-stack-12ppn9wd` | New stack mounted. |
+| `/treatments` → `/treatments/composite-bonding` | `v2-stack-rr6q1vz5` | `v2-stack-6ql16e0r` | New stack mounted. |
+| `/treatments/composite-bonding` → `/` | `v2-stack-76a941jw` | `v2-stack-dl9b9di7` | New stack mounted. |
+
+The random stack id changes are direct evidence that the surface stack did not remain persistent across captured navigations.
+
+## 7. Navigation mode evidence
+
+Captured console logs reported:
+
+- `[HERO_DIAG_NAV] href=/treatments defaultPrevented=false`
+- `[HERO_DIAG_NAV] href=/treatments/composite-bonding defaultPrevented=false`
+- `[HERO_DIAG_NAV] href=/ defaultPrevented=false`
+
+The capture also saw `Execution context was destroyed` immediately after click attempts. This is consistent with document/context replacement. It is not enough to conclude that all Vercel preview navigations are always hard reloads, but it is sufficient to treat navigation lifecycle as the leading failure class.
+
+## 8. Route identity observations
+
+`HeroMount` only attaches `data-hero-pathname-key`, `data-hero-identity-key`, and `data-hero-has-model` when `heroDebugEnabled` is true on the server-derived request URL. In the local click capture, those mount data attributes were `null` after route clicks because the target hrefs did not preserve `?heroDebug=1&heroTruth=1`.
+
+That limits post-click route identity proof. It does not change the stack reset finding, because the stack instance and media currentTime are available independently of those attributes.
+
+## Lifecycle conclusion
+
+Hero V2 is structurally placed in the root layout, but captured route navigation still replaced/recreated the Hero V2 surface stack and restarted its media layers. The next mission should treat “persistent in source placement” and “persistent in user-visible navigation lifecycle” as different questions.

--- a/NEXT_MISSION_RECOMMENDATION.md
+++ b/NEXT_MISSION_RECOMMENDATION.md
@@ -1,35 +1,84 @@
 # NEXT_MISSION_RECOMMENDATION
 
-Role: `HERO_V2_FIRST_PAINT_BASE_SURFACE_STABILIZATION_IMPLEMENTER`
+Role: `HERO_V2_NAVIGATION_FLASH_FAILURE_RESPONSE_DIRECTOR`  
 Evidence date: 2026-06-05
 
 ## Recommendation
 
-Proceed with a read-only Hero V2 route identity and variant-binding diagnostic mission only after this stabilization is reviewed.
+Do **not** certify the previous first-paint/base-surface fix as solving the Vercel navigation flash. The next mission should be a narrow lifecycle proof gate followed by one bounded implementation mission only if the proof gate identifies a safe target.
 
-## Why
+## Next mission name
 
-This mission stabilized the first-paint/base-surface pathway without touching global surfaces or hero variants. Recapture still showed unset/null debug identity attributes on the Hero V2 root for the sampled routes. The proof gate already classified route-specific Hero V2 identity/content as a separate concern.
+`HERO_V2_NAVIGATION_LIFECYCLE_PROOF_GATE`
 
-## Suggested next mission scope
+## Mission goal
 
-Read-only diagnostics for:
+Determine whether Vercel Preview navigation is:
 
-1. `data-hero-engine` and Hero V2 mount identity on representative routes.
-2. `getHeroBindingForPathnameKey()` output for `/`, `/treatments/composite-bonding`, and `/treatments/teeth-whitening`.
-3. selected runtime `heroId` / `variantId` / `effectiveVariantId`.
-4. manifest source selected for each route.
-5. whether treatment routes are intended to share the general hero copy at this stage.
+1. hard document navigation;
+2. same-document App Router navigation with root/layout remount;
+3. same-document navigation with persistent root layout but remounting hero child;
+4. persistent hero stack with only content fade/motion reveal replay.
 
-## Explicit no-go boundaries for next mission
+## Required captures
 
-Do not combine identity diagnostics with:
+For Vercel Preview and local production build:
 
-- Persian Midnight implementation;
-- token or global background changes;
-- nav/header changes;
-- typography changes;
-- hero visual redesign;
-- hero variant rollout;
-- sacred manifest edits;
-- sacred hero engine surgery unless separately authorized.
+1. DOM before click:
+   - `data-hero-engine`
+   - hero root presence
+   - `data-v2-stack-instance`
+   - motion layer ids
+   - motion video `currentTime`
+   - content fade opacity
+2. During/immediate after click:
+   - whether JS execution context survives
+   - whether browser makes a document request
+   - first visible hero frame screenshot
+3. After navigation +120ms:
+   - stack instance
+   - motion `currentTime`
+   - data-ready/motionReady
+   - content fade opacity
+4. After navigation +1500ms:
+   - stack instance
+   - motion `currentTime`
+   - console warnings/errors
+5. Environment parity:
+   - `NEXT_PUBLIC_FEATURE_BRAND_HERO`
+   - `NEXT_PUBLIC_HERO_ENGINE`
+   - `NEXT_PUBLIC_HERO_MOTION_ALLOWLIST`
+   - `NEXT_PUBLIC_HERO_CONTENT_FADE`
+
+## Stop conditions
+
+Stop without code changes if:
+
+- Vercel Preview is not actually running Hero V2;
+- brand hero flag differs from local proof;
+- navigation is a full document reload and no same-document continuity is possible from Hero code alone;
+- the observed flash is from missing/slow media assets rather than React lifecycle;
+- evidence points to sacred engine/manifests, which require separate explicit authority.
+
+## Candidate implementation after proof
+
+If stack remount is proven under same-document navigation:
+
+- prefer Option A if a persistent client island can be created without touching forbidden layout/global/sacred files;
+- otherwise consider Option B as a bounded mitigation.
+
+If stack persists but content flashes:
+
+- implement Option D: make content fade first-load-only or disable route-change fade for the global sacred Hero V2.
+
+If key/model churn is proven:
+
+- implement Option C: stabilize hero model/key identity without changing variants or visual design.
+
+If full document reload is proven:
+
+- do not patch hero visuals first; diagnose why internal `next/link` navigation is not preserving client context, or accept that only first-paint mitigations can reduce but not eliminate the reset.
+
+## Why this should be next
+
+The current evidence shows the remaining symptom is a navigation lifecycle/motion continuity failure, not merely a background first-paint gap. A future Codex mission can safely target the actual user-visible navigation flash only after it separates hard reload, layout remount, stack remount, content fade, and motion replay.

--- a/REMAINING_FLASH_ROOT_CAUSE_DECISION.md
+++ b/REMAINING_FLASH_ROOT_CAUSE_DECISION.md
@@ -1,0 +1,72 @@
+# REMAINING_FLASH_ROOT_CAUSE_DECISION
+
+Role: `HERO_V2_NAVIGATION_FLASH_FAILURE_RESPONSE_DIRECTOR`  
+Evidence date: 2026-06-05
+
+## Decision statement
+
+The previous fix **partially helped or addressed a different issue**. It targeted direct-load first-paint/base-surface exposure. It did **not** resolve the remaining user-visible navigation flash/reset reported in Vercel preview.
+
+## Most likely remaining cause
+
+**Most likely cause:** Hero V2 surface/motion stack lifecycle reset during navigation, causing motion video elements and CSS animation phases to restart. This may be due to hard document navigation in preview/local capture, dynamic root-layout replacement, or another route lifecycle boundary that recreates the stack.
+
+**Secondary contributors:**
+
+1. `HeroContentFade` opacity replay on every pathname change.
+2. Motion reveal/readiness events replaying after new video elements are created.
+3. Debug/env parity gaps between local proof and Vercel Preview.
+4. Direct-load background first-paint exposure may still be relevant during full document reloads, but it is no longer the only plausible issue.
+
+## Confidence level
+
+**Medium-high** for motion/stack reset as the remaining cause.  
+**Medium** for hard document navigation as the reason for the reset in Vercel Preview.  
+**Low** that another base-surface-only patch would solve the reported issue.
+
+## Evidence
+
+1. The captured surface stack instance changed after every tested navigation.
+2. Motion video `currentTime` reset to `0` after navigation.
+3. Console logs showed new `HERO_V2_MOUNT` and motion media events after navigation.
+4. Click diagnostics logged `defaultPrevented=false`.
+5. Immediate post-click Playwright evaluation hit `Execution context was destroyed`, consistent with document/context replacement during captured navigation.
+6. The previous fix report explicitly left route identity and motion governance out of scope.
+7. `HeroContentFade` still intentionally replays opacity on pathname changes.
+8. The root/frame now has a local gradient base, so an unchanged navigation flash after merge points beyond the direct-load transparent-base gap.
+
+## Missing evidence
+
+1. Direct Vercel Preview DOM trace with stack ids before/after user navigation.
+2. Direct Vercel Preview network trace proving whether document requests occur on nav clicks.
+3. A real compositor filmstrip from Vercel Preview capturing frames before/during/after navigation.
+4. Confirmation of Vercel Preview values for:
+   - `NEXT_PUBLIC_FEATURE_BRAND_HERO`
+   - `NEXT_PUBLIC_HERO_ENGINE`
+   - `NEXT_PUBLIC_HERO_MOTION_ALLOWLIST`
+   - `NEXT_PUBLIC_HERO_CONTENT_FADE`
+5. Whether App Router prefetch/cache state differs between local production and Vercel Preview.
+
+## Is a bounded fix safe?
+
+A bounded fix is **safe only after one more narrow evidence gate** that confirms which lifecycle path Vercel Preview uses.
+
+Safe targets likely include:
+
+- disabling/suppressing content fade replay after first mount;
+- suppressing motion initial/reveal replay after first mount;
+- stabilizing the hero stack outside the remounting route boundary if architecture allows.
+
+Unsafe targets now:
+
+- another broad visual/base/background patch;
+- Persian Midnight;
+- typography;
+- hero variants;
+- brand colour changes;
+- global root/body theming;
+- sacred engine/manifest edits.
+
+## Final diagnostic decision
+
+The next implementation should target **navigation lifecycle continuity**, not direct-load first-paint alone. The prior fix should not be rolled back solely on current evidence, because it is not shown to be harmful, but it should not be certified as solving the Vercel navigation flash.

--- a/VERCEL_PREVIEW_ENV_PARITY_NOTE.md
+++ b/VERCEL_PREVIEW_ENV_PARITY_NOTE.md
@@ -1,0 +1,61 @@
+# VERCEL_PREVIEW_ENV_PARITY_NOTE
+
+Role: `HERO_V2_NAVIGATION_FLASH_FAILURE_RESPONSE_DIRECTOR`  
+Evidence date: 2026-06-05
+
+## Environment-sensitive switches
+
+## 1. Brand hero enablement
+
+`isBrandHeroEnabled()` returns:
+
+- in production, disabled by default unless `NEXT_PUBLIC_FEATURE_BRAND_HERO` is exactly `true` or `1`;
+- in non-production, enabled by default when the flag is undefined.
+
+Vercel Preview uses a production build/runtime profile, so the preview must have `NEXT_PUBLIC_FEATURE_BRAND_HERO=1` or `true` for this code path to match local proof captures.
+
+## 2. Hero engine selection
+
+`HeroMount` selects Hero V2 only when normalized `NEXT_PUBLIC_HERO_ENGINE` equals `v2`. Any missing, misspelled, quoted incorrectly, or differently cased value after normalization may fall back to V1.
+
+## 3. Debug and truth query behavior
+
+`HeroMount` server-side debug attributes depend on `heroDebug` being present in the server-derived `next-url`. During click navigation, target links generally do not preserve `?heroDebug=1&heroTruth=1`, so post-click debug attributes may disappear even while the issue remains visible.
+
+## 4. Motion allowlist
+
+`buildHeroV2Model` reads `NEXT_PUBLIC_HERO_MOTION_ALLOWLIST`. If set in Vercel Preview but not local, it can change which motion layers exist. If unset locally but set in Vercel, local proof may not match preview motion composition.
+
+## 5. Content fade switch
+
+`HeroContentFade` is enabled unless `NEXT_PUBLIC_HERO_CONTENT_FADE=0`. A Vercel preview with this unset will replay content opacity on every pathname change.
+
+## 6. Production build evidence from this mission
+
+Local production build with the relevant flags succeeded:
+
+```bash
+NEXT_PUBLIC_FEATURE_BRAND_HERO=1 NEXT_PUBLIC_HERO_ENGINE=v2 NEXT_PUBLIC_HERO_DEBUG=1 pnpm run build:web
+```
+
+Local production server was started with the same flags:
+
+```bash
+PORT=3100 NEXT_PUBLIC_FEATURE_BRAND_HERO=1 NEXT_PUBLIC_HERO_ENGINE=v2 NEXT_PUBLIC_HERO_DEBUG=1 pnpm --filter web start
+```
+
+This proves the local diagnostic exercised a production build with Hero V2 enabled. It does not prove that Vercel Preview has identical environment variables.
+
+## Parity risks
+
+| Risk | Why it matters | Needed evidence |
+| --- | --- | --- |
+| Preview missing `NEXT_PUBLIC_FEATURE_BRAND_HERO` | Preview could be exercising a different hero path. | Vercel preview env dump or debug overlay showing `data-hero-flag`. |
+| Preview missing `NEXT_PUBLIC_HERO_ENGINE=v2` | Preview could fall back to V1. | DOM `data-hero-engine` in preview. |
+| Preview has a motion allowlist | Preview may include/exclude different videos. | DOM motion layer count and ids in preview. |
+| Preview navigation uses hard document reload | Full document replacement will remount hero regardless of root layout source placement. | Browser devtools: network document request, console context persistence, stack id continuity. |
+| Debug query not preserved on links | Can hide debug attributes after click. | Capture with a route-preserving debug instrumentation or browser snippet independent of query. |
+
+## Vercel parity conclusion
+
+The environment most likely matters less than lifecycle because the same reset class reproduced in a local production build. However, Vercel Preview parity is still not proven. The next mission should require a preview DOM/env capture before choosing an implementation.


### PR DESCRIPTION
### Motivation
- The previous bounded Hero V2 first-paint/base-surface stabilization addressed a direct-load transparency gap but did not eliminate the user-visible navigation flash in preview, so a failure-response diagnostic was required.
- The change aims to determine whether the remaining visible flash comes from stack remounts, motion/video restarts, route lifecycle behavior, or environment differences between local and Vercel preview.
- The goal is to produce a bounded decision and a safe set of fix options rather than implement a code change.

### Description
- Add a failure-response packet composed of new diagnostic artifacts: `HERO_V2_NAVIGATION_FLASH_FAILURE_REPORT.md`, `HERO_V2_ROUTE_LIFECYCLE_TRACE.md`, `HERO_V2_MOTION_RESTART_TRACE.md`, `VERCEL_PREVIEW_ENV_PARITY_NOTE.md`, `REMAINING_FLASH_ROOT_CAUSE_DECISION.md`, `BOUNDED_NAVIGATION_FLASH_FIX_OPTIONS.md`, and an updated `NEXT_MISSION_RECOMMENDATION.md`. 
- Documents summarize code-path facts (`HeroMount`, `HeroRendererV2`, `HeroSurfaceStackV2`, `HeroContentFade`), captured Playwright navigation traces, stack instance / video `currentTime` evidence, and environment parity risks. 
- Produce an explicit decision: the prior fix is partial (addressed direct-load), the most likely remaining cause is Hero V2 stack/motion lifecycle reset during navigation, and propose five bounded fix options (A–E) with evidence gates and safety constraints.

### Testing
- Ran hero-specific and repo guards: `npm run guard:hero` and `npm run guard:canon`, both passed. 
- Built and served a production build with flags: `NEXT_PUBLIC_FEATURE_BRAND_HERO=1 NEXT_PUBLIC_HERO_ENGINE=v2 NEXT_PUBLIC_HERO_DEBUG=1 pnpm run build:web` and `PORT=3100 ... pnpm --filter web start`, and the build/start completed successfully. 
- Installed Playwright and deps (`pnpm exec playwright install chromium` and `pnpm exec playwright install-deps chromium`) and executed a Playwright-based navigation diagnostic which produced the captured traces (note: initial CDN fallback/logs were observed but final diagnostic output was produced). 
- Ran the repository-wide verification `npm run verify` which ran guards, lint, typecheck, and a production build, and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a22b717c89c83329c17088a094ab4f3)