### PR TITLE
Strengthen bounded SEO entity registries

### DIFF
--- a/packages/champagne-manifests/data/seo-ai-answer-foundation/ai-answer-registry.v1.smh.json
+++ b/packages/champagne-manifests/data/seo-ai-answer-foundation/ai-answer-registry.v1.smh.json
@@ -136,8 +136,8 @@
       "location_scope": "Shoreham-by-Sea",
       "intent_type": "urgent",
       "question": "What should I do if I need an emergency dentist in Shoreham-by-Sea?",
-      "short_answer": "If you have tooth pain, swelling, trauma, bleeding that does not settle, or signs of infection, contact St Mary\u2019s House Dental Care in Shoreham-by-Sea for urgent dental guidance. The team can help decide how quickly you should be seen. Rapid facial swelling, fever, difficulty swallowing, or breathing problems need urgent medical help first.",
-      "expanded_answer": "Emergency dentistry at St Mary\u2019s House Dental Care is focused on calm assessment, stabilising the immediate problem, and explaining the next sensible step. The public treatment content describes urgent situations such as severe toothache, swelling, dental trauma, infection signs, bleeding that does not settle, broken or cracked teeth, knocked-out teeth, and lost crowns, veneers, or fillings. An emergency visit may include an examination, X-rays where clinically needed, an explanation of what can be seen, and a temporary or definitive step to reduce pain and risk. Website content cannot determine the cause: the right care depends on the tooth, symptoms, medical history, and clinical findings. If there is rapid facial swelling, fever, difficulty swallowing, or breathing difficulty, seek urgent medical help through A&E or 999 first, then contact the practice when safe.",
+      "short_answer": "If you have tooth pain, swelling, trauma, bleeding that does not settle, or signs of infection, contact St Mary’s House Dental Care in Shoreham-by-Sea for urgent dental guidance. The team can help decide how quickly you should be seen. Rapid facial swelling, fever, difficulty swallowing, or breathing problems need urgent medical help first.",
+      "expanded_answer": "Emergency dentistry at St Mary’s House Dental Care is focused on calm assessment, stabilising the immediate problem, and explaining the next sensible step. The public treatment content describes urgent situations such as severe toothache, swelling, dental trauma, infection signs, bleeding that does not settle, broken or cracked teeth, knocked-out teeth, and lost crowns, veneers, or fillings. An emergency visit may include an examination, X-rays where clinically needed, an explanation of what can be seen, and a temporary or definitive step to reduce pain and risk. Website content cannot determine the cause: the right care depends on the tooth, symptoms, medical history, and clinical findings. If there is rapid facial swelling, fever, difficulty swallowing, or breathing difficulty, seek urgent medical help through A&E or 999 first, then contact the practice when safe.",
       "evidence_source": [
         "approved-facts.smh.json:priorityServices",
         "local-identity.smh.json:priorityServices.emergency-dentist",
@@ -148,7 +148,10 @@
       "approved_for_voice": true,
       "approved_for_chatbot": true,
       "approved_for_schema": true,
-      "packet_scope": "SEO_AI_ANSWER_PRIORITY_SERVICE_PACKET_V1"
+      "packet_scope": "SEO_AI_ANSWER_PRIORITY_SERVICE_PACKET_V1",
+      "source_label": "Approved emergency dentistry answer packet",
+      "local_entity_summary": "St Mary's House Dental Care provides approved emergency dentistry answer coverage for Shoreham-by-Sea from the existing emergency dentistry route.",
+      "authority_summary": "Authority evidence is limited to approved facts, local identity, and page-truth content; emergency escalation remains safety-gated."
     },
     {
       "id": "smh-answer-priority-dental-implants-packet-v1",
@@ -159,8 +162,8 @@
       "location_scope": "Shoreham-by-Sea",
       "intent_type": "informational",
       "question": "What are dental implants and who may they help?",
-      "short_answer": "Dental implants replace missing teeth with a small titanium post that supports a crown, bridge, or implant-retained denture. At St Mary\u2019s House Dental Care in Shoreham-by-Sea, implant care is planning-led, using assessment, medical history review, CBCT where indicated, scans, and option discussion before treatment decisions are made.",
-      "expanded_answer": "Dental implants are one option for replacing missing teeth. The approved implant page explains that an implant is a small post placed in the jawbone to act like a replacement tooth root, supporting a crown, bridge, or denture once healing and planning allow. Implant suitability is individual. Bone levels, gum health, bite forces, space, neighbouring teeth, medical history, and maintenance all matter. St Mary\u2019s House Dental Care describes a planning-first approach in Shoreham-by-Sea, including clinical examination, digital scans, and CBCT imaging where appropriate, so options and trade-offs can be discussed before surgery. Alternatives may include bridges, removable dentures, implant-retained dentures, or sometimes leaving a space after discussing the consequences. Fees and timelines depend on diagnostics and the final plan, so they should be confirmed at consultation.",
+      "short_answer": "Dental implants replace missing teeth with a small titanium post that supports a crown, bridge, or implant-retained denture. At St Mary’s House Dental Care in Shoreham-by-Sea, implant care is planning-led, using assessment, medical history review, CBCT where indicated, scans, and option discussion before treatment decisions are made.",
+      "expanded_answer": "Dental implants are one option for replacing missing teeth. The approved implant page explains that an implant is a small post placed in the jawbone to act like a replacement tooth root, supporting a crown, bridge, or denture once healing and planning allow. Implant suitability is individual. Bone levels, gum health, bite forces, space, neighbouring teeth, medical history, and maintenance all matter. St Mary’s House Dental Care describes a planning-first approach in Shoreham-by-Sea, including clinical examination, digital scans, and CBCT imaging where appropriate, so options and trade-offs can be discussed before surgery. Alternatives may include bridges, removable dentures, implant-retained dentures, or sometimes leaving a space after discussing the consequences. Fees and timelines depend on diagnostics and the final plan, so they should be confirmed at consultation.",
       "evidence_source": [
         "approved-facts.smh.json:priorityServices",
         "local-identity.smh.json:priorityServices.dental-implants",
@@ -172,7 +175,10 @@
       "approved_for_voice": true,
       "approved_for_chatbot": true,
       "approved_for_schema": true,
-      "packet_scope": "SEO_AI_ANSWER_PRIORITY_SERVICE_PACKET_V1"
+      "packet_scope": "SEO_AI_ANSWER_PRIORITY_SERVICE_PACKET_V1",
+      "source_label": "Approved dental implants answer packet",
+      "local_entity_summary": "Dental implants are linked to the Shoreham-by-Sea practice entity and the existing implants route.",
+      "authority_summary": "Authority evidence covers planning-led implant care, CBCT/digital scan references, and suitability boundaries from approved page-truth sources."
     },
     {
       "id": "smh-answer-priority-private-dentist-packet-v1",
@@ -182,9 +188,9 @@
       "route_path": "/contact",
       "location_scope": "Shoreham-by-Sea",
       "intent_type": "commercial",
-      "question": "What does a private dentist appointment include at St Mary\u2019s House Dental Care?",
-      "short_answer": "A private dentist appointment at St Mary\u2019s House Dental Care in Shoreham-by-Sea is a clinician-led visit to understand your oral health, concerns, and goals. The approved public facts confirm the practice location, contact details, opening hours, and priority services, while specific treatment recommendations require an examination.",
-      "expanded_answer": "St Mary\u2019s House Dental Care is a private dental practice on St Mary\u2019s Road in Shoreham-by-Sea. A private dental appointment can be used to discuss symptoms, routine care, cosmetic goals, urgent concerns, or treatment options already listed as priority services, such as examinations, hygiene, implants, orthodontics, Spark Aligners, cosmetic dentistry, sedation support, and emergency dentistry. The website should not be used to identify the cause of a dental problem or promise a treatment outcome. A clinician needs to examine your teeth, gums, bite, soft tissues, medical history, and any relevant images before recommending options. Fees, appointment sequencing, and any referral or treatment plan should be confirmed directly with the practice. If you are anxious, mention this when booking so the visit can be paced calmly.",
+      "question": "What does a private dentist appointment include at St Mary’s House Dental Care?",
+      "short_answer": "A private dentist appointment at St Mary’s House Dental Care in Shoreham-by-Sea is a clinician-led visit to understand your oral health, concerns, and goals. The approved public facts confirm the practice location, contact details, opening hours, and priority services, while specific treatment recommendations require an examination.",
+      "expanded_answer": "St Mary’s House Dental Care is a private dental practice on St Mary’s Road in Shoreham-by-Sea. A private dental appointment can be used to discuss symptoms, routine care, cosmetic goals, urgent concerns, or treatment options already listed as priority services, such as examinations, hygiene, implants, orthodontics, Spark Aligners, cosmetic dentistry, sedation support, and emergency dentistry. The website should not be used to identify the cause of a dental problem or promise a treatment outcome. A clinician needs to examine your teeth, gums, bite, soft tissues, medical history, and any relevant images before recommending options. Fees, appointment sequencing, and any referral or treatment plan should be confirmed directly with the practice. If you are anxious, mention this when booking so the visit can be paced calmly.",
       "evidence_source": [
         "approved-facts.smh.json:practice",
         "local-identity.smh.json:priorityServices.private-dentist",
@@ -195,7 +201,10 @@
       "approved_for_voice": true,
       "approved_for_chatbot": true,
       "approved_for_schema": true,
-      "packet_scope": "SEO_AI_ANSWER_PRIORITY_SERVICE_PACKET_V1"
+      "packet_scope": "SEO_AI_ANSWER_PRIORITY_SERVICE_PACKET_V1",
+      "source_label": "Approved private dentistry answer packet",
+      "local_entity_summary": "Private dentistry facts are anchored to the approved St Mary's House Dental Care NAP and Shoreham-by-Sea local identity.",
+      "authority_summary": "Authority is limited to approved public practice, contact, and priority-service facts; treatment recommendations require examination."
     },
     {
       "id": "smh-answer-priority-examinations-packet-v1",
@@ -206,8 +215,8 @@
       "location_scope": "Shoreham-by-Sea",
       "intent_type": "informational",
       "question": "Do dental check-ups include oral cancer screening?",
-      "short_answer": "Yes. The dental check-up content for St Mary\u2019s House Dental Care says routine examinations include visual oral cancer screening. Check-ups also review teeth, gums, bite, existing dental work, symptoms, and changes you have noticed, with X-rays recommended only where clinically justified.",
-      "expanded_answer": "Dental examinations at St Mary\u2019s House Dental Care are described as gentle, unhurried check-ups with attentive screening. The public treatment content states that oral cancer screening is included at every routine exam. A check-up may involve reviewing teeth, gums, bite, existing restorations, soft tissues, symptoms, habits, and any changes you have noticed. Digital X-rays or images may be recommended where clinically justified, and the team explains why they are useful before taking them. Routine examination content also notes that most people stay on track with six-monthly visits, while higher-risk situations may need a shorter cadence. This is general education only; if you notice ulcers that do not settle, new lumps, persistent soreness, or mouth or throat changes, contact the practice promptly for assessment.",
+      "short_answer": "Yes. The dental check-up content for St Mary’s House Dental Care says routine examinations include visual oral cancer screening. Check-ups also review teeth, gums, bite, existing dental work, symptoms, and changes you have noticed, with X-rays recommended only where clinically justified.",
+      "expanded_answer": "Dental examinations at St Mary’s House Dental Care are described as gentle, unhurried check-ups with attentive screening. The public treatment content states that oral cancer screening is included at every routine exam. A check-up may involve reviewing teeth, gums, bite, existing restorations, soft tissues, symptoms, habits, and any changes you have noticed. Digital X-rays or images may be recommended where clinically justified, and the team explains why they are useful before taking them. Routine examination content also notes that most people stay on track with six-monthly visits, while higher-risk situations may need a shorter cadence. This is general education only; if you notice ulcers that do not settle, new lumps, persistent soreness, or mouth or throat changes, contact the practice promptly for assessment.",
       "evidence_source": [
         "approved-facts.smh.json:priorityServices",
         "local-identity.smh.json:priorityServices.examinations",
@@ -229,8 +238,8 @@
       "location_scope": "Shoreham-by-Sea",
       "intent_type": "local",
       "question": "Can I get Spark Aligners in Shoreham-by-Sea?",
-      "short_answer": "Spark Aligners are listed as a priority service at St Mary\u2019s House Dental Care in Shoreham-by-Sea. The Spark page describes clinician-led planning with digital scans, clear staged trays, progress checks, and retention planning. Suitability depends on your bite, movement needs, oral health, and clinician assessment.",
-      "expanded_answer": "Spark clear aligner treatment at St Mary\u2019s House Dental Care is described as clinician-led planning using digital scans and staged trays to guide tooth movement. The approved page explains that patients can review expected movements, attachments, progress checks, and retention before committing. Spark may help people wanting a discreet orthodontic option, but it is not suitable for every case. Some complex movements may need fixed orthodontics or another approach. The page also notes that many Spark journeys run for several months to over a year, with the projected timeframe shared after scans and assessment. Cosmetic sequencing such as whitening, bonding, or veneers may be discussed where appropriate after movement. Fees depend on the treatment plan and should be confirmed at consultation.",
+      "short_answer": "Spark Aligners are listed as a priority service at St Mary’s House Dental Care in Shoreham-by-Sea. The Spark page describes clinician-led planning with digital scans, clear staged trays, progress checks, and retention planning. Suitability depends on your bite, movement needs, oral health, and clinician assessment.",
+      "expanded_answer": "Spark clear aligner treatment at St Mary’s House Dental Care is described as clinician-led planning using digital scans and staged trays to guide tooth movement. The approved page explains that patients can review expected movements, attachments, progress checks, and retention before committing. Spark may help people wanting a discreet orthodontic option, but it is not suitable for every case. Some complex movements may need fixed orthodontics or another approach. The page also notes that many Spark journeys run for several months to over a year, with the projected timeframe shared after scans and assessment. Cosmetic sequencing such as whitening, bonding, or veneers may be discussed where appropriate after movement. Fees depend on the treatment plan and should be confirmed at consultation.",
       "evidence_source": [
         "approved-facts.smh.json:priorityServices",
         "local-identity.smh.json:priorityServices.spark-aligners",
@@ -241,7 +250,10 @@
       "approved_for_voice": true,
       "approved_for_chatbot": true,
       "approved_for_schema": true,
-      "packet_scope": "SEO_AI_ANSWER_PRIORITY_SERVICE_PACKET_V1"
+      "packet_scope": "SEO_AI_ANSWER_PRIORITY_SERVICE_PACKET_V1",
+      "source_label": "Approved Spark Aligners answer packet",
+      "local_entity_summary": "Spark Aligners are linked to the Shoreham-by-Sea practice entity and existing clear aligners route.",
+      "authority_summary": "Authority evidence covers digital scans, staged trays, progress checks, retention planning, and clinical suitability boundaries from approved sources."
     },
     {
       "id": "smh-answer-priority-orthodontics-packet-v1",
@@ -252,8 +264,8 @@
       "location_scope": "Shoreham-by-Sea",
       "intent_type": "commercial",
       "question": "What orthodontic options are available in Shoreham-by-Sea?",
-      "short_answer": "Orthodontics is an approved priority service for St Mary\u2019s House Dental Care in Shoreham-by-Sea. Public treatment content links orthodontic planning with Spark clear aligners, fixed braces, retainers, digital scans, bite checks, and stability planning. The right option depends on assessment, goals, movement complexity, and retention needs.",
-      "expanded_answer": "Orthodontic care is used to plan tooth movement, bite improvement, and long-term stability. St Mary\u2019s House Dental Care lists orthodontics as a priority service and provides related pages for Spark clear aligners, clear aligners, fixed braces, and retainers. The public content emphasises clinician-led assessment, digital scans, bite checks, progress reviews, and retention rather than a one-size-fits-all option. Clear aligners may suit some mild or moderate goals, while more complex movements may need fixed orthodontics or another staged plan. Orthodontic suitability depends on gum health, decay risk, bite, tooth position, age, compliance, and the stability of the expected result. Timelines and fees are individual and should be confirmed after consultation, scans, and treatment planning. If a patient is nervous about orthodontic care, the appointment can focus first on questions, records, options, and what ongoing reviews would involve.",
+      "short_answer": "Orthodontics is an approved priority service for St Mary’s House Dental Care in Shoreham-by-Sea. Public treatment content links orthodontic planning with Spark clear aligners, fixed braces, retainers, digital scans, bite checks, and stability planning. The right option depends on assessment, goals, movement complexity, and retention needs.",
+      "expanded_answer": "Orthodontic care is used to plan tooth movement, bite improvement, and long-term stability. St Mary’s House Dental Care lists orthodontics as a priority service and provides related pages for Spark clear aligners, clear aligners, fixed braces, and retainers. The public content emphasises clinician-led assessment, digital scans, bite checks, progress reviews, and retention rather than a one-size-fits-all option. Clear aligners may suit some mild or moderate goals, while more complex movements may need fixed orthodontics or another staged plan. Orthodontic suitability depends on gum health, decay risk, bite, tooth position, age, compliance, and the stability of the expected result. Timelines and fees are individual and should be confirmed after consultation, scans, and treatment planning. If a patient is nervous about orthodontic care, the appointment can focus first on questions, records, options, and what ongoing reviews would involve.",
       "evidence_source": [
         "approved-facts.smh.json:priorityServices",
         "local-identity.smh.json:priorityServices.orthodontics",
@@ -264,7 +276,10 @@
       "approved_for_voice": true,
       "approved_for_chatbot": true,
       "approved_for_schema": true,
-      "packet_scope": "SEO_AI_ANSWER_PRIORITY_SERVICE_PACKET_V1"
+      "packet_scope": "SEO_AI_ANSWER_PRIORITY_SERVICE_PACKET_V1",
+      "source_label": "Approved orthodontics answer packet",
+      "local_entity_summary": "Orthodontics is linked to the Shoreham-by-Sea practice entity and the existing orthodontics route.",
+      "authority_summary": "Authority evidence covers Spark aligners, fixed braces, retainers, digital scans, bite checks, stability planning, and suitability boundaries."
     },
     {
       "id": "smh-answer-priority-3d-dentistry-packet-v1",
@@ -274,9 +289,9 @@
       "route_path": "/treatments/3d-dentistry-and-technology",
       "location_scope": "Shoreham-by-Sea",
       "intent_type": "informational",
-      "question": "What is 3D dentistry at St Mary\u2019s House Dental Care?",
-      "short_answer": "3D dentistry at St Mary\u2019s House Dental Care describes digital tools used to support assessment and planning, such as CBCT or 3D scanning, digital scans, guided planning, and 3D printing where appropriate. It is available through the Shoreham-by-Sea practice as part of clinician-led dental planning.",
-      "expanded_answer": "3D dentistry is a broad term for digital technology that supports dental assessment, planning, and fabrication. St Mary\u2019s House Dental Care lists 3D dentistry as a priority service and has public treatment content for 3D and digital dentistry, CBCT or 3D scanning, 3D printing lab work, 3D implant restorations, 3D printed dentures, and 3D printed veneers. These tools can help clinicians understand anatomy, plan implant positions, assess restorations, record digital impressions, and communicate options more clearly. They support clinical judgement but do not replace an examination or individual planning. Whether digital scanning, CBCT imaging, guided planning, or printed components are appropriate depends on the treatment, clinical findings, and radiation or safety considerations. Any fees or timelines should be confirmed as part of the treatment plan.",
+      "question": "What is 3D dentistry at St Mary’s House Dental Care?",
+      "short_answer": "3D dentistry at St Mary’s House Dental Care describes digital tools used to support assessment and planning, such as CBCT or 3D scanning, digital scans, guided planning, and 3D printing where appropriate. It is available through the Shoreham-by-Sea practice as part of clinician-led dental planning.",
+      "expanded_answer": "3D dentistry is a broad term for digital technology that supports dental assessment, planning, and fabrication. St Mary’s House Dental Care lists 3D dentistry as a priority service and has public treatment content for 3D and digital dentistry, CBCT or 3D scanning, 3D printing lab work, 3D implant restorations, 3D printed dentures, and 3D printed veneers. These tools can help clinicians understand anatomy, plan implant positions, assess restorations, record digital impressions, and communicate options more clearly. They support clinical judgement but do not replace an examination or individual planning. Whether digital scanning, CBCT imaging, guided planning, or printed components are appropriate depends on the treatment, clinical findings, and radiation or safety considerations. Any fees or timelines should be confirmed as part of the treatment plan.",
       "evidence_source": [
         "approved-facts.smh.json:priorityServices",
         "local-identity.smh.json:priorityServices.3d-dentistry",
@@ -287,7 +302,11 @@
       "approved_for_voice": true,
       "approved_for_chatbot": true,
       "approved_for_schema": true,
-      "packet_scope": "SEO_AI_ANSWER_PRIORITY_SERVICE_PACKET_V1"
+      "packet_scope": "SEO_AI_ANSWER_PRIORITY_SERVICE_PACKET_V1",
+      "source_label": "Approved 3D dentistry answer packet",
+      "local_entity_summary": "3D dentistry intent is anchored to the Shoreham-by-Sea practice entity and /treatments/3d-dentistry-and-technology.",
+      "authority_summary": "Authority evidence covers CBCT or 3D scanning, digital scans, guided planning, and 3D printing where appropriate.",
+      "canonical_intent": "Primary route for 3D dentistry capability; not the primary same-day veneers route."
     },
     {
       "id": "smh-answer-priority-same-day-crowns-veneers-packet-v1",
@@ -298,8 +317,8 @@
       "location_scope": "Shoreham-by-Sea",
       "intent_type": "commercial",
       "question": "Do you offer same-day crowns or veneers?",
-      "short_answer": "Same-day crowns and veneers are listed as an approved priority service for St Mary\u2019s House Dental Care. The 3D and digital dentistry route supports scanning, guided planning, and digital workflows, but whether a crown, veneer, or same-day approach is appropriate must be confirmed after clinical assessment.",
-      "expanded_answer": "Same-day crowns or veneers relate to digital dentistry workflows where scanning, design, milling, printing, or guided planning may reduce the number of visits for selected cases. St Mary\u2019s House Dental Care lists same-day crowns and veneers as a priority service and maps the service to the 3D digital dentistry treatment route. This does not mean every crown or veneer can or should be completed the same day. Suitability depends on tooth condition, bite, gum health, preparation needs, material choice, aesthetics, laboratory requirements, and whether further treatment is needed first. Alternatives may include conventional crowns, porcelain veneers, composite bonding, inlays or onlays, or staged cosmetic planning. Fees, timing, and suitability should be confirmed at consultation after examination and digital records. Patients who feel anxious can ask for the process to be explained step by step before any treatment commitment is made.",
+      "short_answer": "Same-day crowns and veneers are listed as an approved priority service for St Mary’s House Dental Care. The 3D and digital dentistry route supports scanning, guided planning, and digital workflows, but whether a crown, veneer, or same-day approach is appropriate must be confirmed after clinical assessment.",
+      "expanded_answer": "Same-day crowns or veneers relate to digital dentistry workflows where scanning, design, milling, printing, or guided planning may reduce the number of visits for selected cases. St Mary’s House Dental Care lists same-day crowns and veneers as a priority service and maps the service to the 3D digital dentistry treatment route. This does not mean every crown or veneer can or should be completed the same day. Suitability depends on tooth condition, bite, gum health, preparation needs, material choice, aesthetics, laboratory requirements, and whether further treatment is needed first. Alternatives may include conventional crowns, porcelain veneers, composite bonding, inlays or onlays, or staged cosmetic planning. Fees, timing, and suitability should be confirmed at consultation after examination and digital records. Patients who feel anxious can ask for the process to be explained step by step before any treatment commitment is made.",
       "evidence_source": [
         "approved-facts.smh.json:priorityServices",
         "local-identity.smh.json:priorityServices.same-day-crowns-veneers",
@@ -310,7 +329,11 @@
       "approved_for_voice": true,
       "approved_for_chatbot": true,
       "approved_for_schema": true,
-      "packet_scope": "SEO_AI_ANSWER_PRIORITY_SERVICE_PACKET_V1"
+      "packet_scope": "SEO_AI_ANSWER_PRIORITY_SERVICE_PACKET_V1",
+      "source_label": "Approved same-day crowns and veneers answer packet",
+      "local_entity_summary": "Same-day crown and veneer workflow intent is anchored to /treatments/3d-digital-dentistry.",
+      "authority_summary": "Authority evidence covers scanning, guided planning, and digital workflows while preserving clinical assessment boundaries.",
+      "canonical_intent": "Primary route for same-day crown and veneer workflow; /treatments/veneers remains the broader veneers route."
     },
     {
       "id": "smh-answer-priority-veneers-packet-v1",
@@ -321,8 +344,8 @@
       "location_scope": "Shoreham-by-Sea",
       "intent_type": "informational",
       "question": "What are dental veneers and when might they help?",
-      "short_answer": "Dental veneers are thin restorations placed on the front surface of teeth to change shape, shade, or proportions. St Mary\u2019s House Dental Care\u2019s veneer content describes assessment-led cosmetic planning in Shoreham-by-Sea, including enamel preservation, bite forces, gum health, whitening or alignment first, and maintenance needs.",
-      "expanded_answer": "Dental veneers may be considered when someone wants to improve the visible shape, shade, spacing, or proportions of teeth. St Mary\u2019s House Dental Care\u2019s answer-surface content explains that veneer assessment should consider enamel preservation, bite forces, gum health, shade, smile proportions, and long-term maintenance before recommending porcelain veneers or a conservative alternative. Veneers are not always reversible because some plans require enamel preparation. Depending on the goal and the teeth involved, alternatives may include composite bonding, whitening, orthodontics, crowns, inlays, or onlays. Planning can involve photographs, scans, mock-ups, or digital smile design where helpful. Fees and timelines depend on the number of teeth, preparation, lab or digital workflow, bite protection, and any treatment needed first, so they should be confirmed after assessment.",
+      "short_answer": "Dental veneers are thin restorations placed on the front surface of teeth to change shape, shade, or proportions. St Mary’s House Dental Care’s veneer content describes assessment-led cosmetic planning in Shoreham-by-Sea, including enamel preservation, bite forces, gum health, whitening or alignment first, and maintenance needs.",
+      "expanded_answer": "Dental veneers may be considered when someone wants to improve the visible shape, shade, spacing, or proportions of teeth. St Mary’s House Dental Care’s answer-surface content explains that veneer assessment should consider enamel preservation, bite forces, gum health, shade, smile proportions, and long-term maintenance before recommending porcelain veneers or a conservative alternative. Veneers are not always reversible because some plans require enamel preparation. Depending on the goal and the teeth involved, alternatives may include composite bonding, whitening, orthodontics, crowns, inlays, or onlays. Planning can involve photographs, scans, mock-ups, or digital smile design where helpful. Fees and timelines depend on the number of teeth, preparation, lab or digital workflow, bite protection, and any treatment needed first, so they should be confirmed after assessment.",
       "evidence_source": [
         "question-inventory.v1.smh.json:targetServices.veneers",
         "page-truth/treatments-veneers.txt",
@@ -344,8 +367,8 @@
       "location_scope": "Shoreham-by-Sea",
       "intent_type": "commercial",
       "question": "What cosmetic dentistry is available in Shoreham-by-Sea?",
-      "short_answer": "Cosmetic dentistry is an approved priority service at St Mary\u2019s House Dental Care in Shoreham-by-Sea. Related public pages include veneers, composite bonding, whitening, digital smile design, clear aligners, Spark Aligners, crowns, and full smile makeover planning. The appropriate route depends on assessment and goals.",
-      "expanded_answer": "Cosmetic dentistry at St Mary\u2019s House Dental Care is best understood as assessment-led planning for the appearance, health, function, and maintenance of a smile. The approved priority service list includes cosmetic dentistry, and the treatment ecosystem includes veneers, composite bonding, whitening, digital smile design, aligners, crowns, and full smile makeover planning. A clinician may first assess gum health, decay, tooth wear, bite forces, old restorations, tooth colour, spacing, and patient goals. Conservative options such as whitening, alignment, or bonding may sometimes be considered before irreversible treatments. The website should not be used to decide suitability or promise a result. Fees, sequencing, alternatives, and maintenance responsibilities should be confirmed after consultation and clinical records. Patients who feel anxious can ask for a slower planning visit so options are discussed before any irreversible treatment decisions are made.",
+      "short_answer": "Cosmetic dentistry is an approved priority service at St Mary’s House Dental Care in Shoreham-by-Sea. Related public pages include veneers, composite bonding, whitening, digital smile design, clear aligners, Spark Aligners, crowns, and full smile makeover planning. The appropriate route depends on assessment and goals.",
+      "expanded_answer": "Cosmetic dentistry at St Mary’s House Dental Care is best understood as assessment-led planning for the appearance, health, function, and maintenance of a smile. The approved priority service list includes cosmetic dentistry, and the treatment ecosystem includes veneers, composite bonding, whitening, digital smile design, aligners, crowns, and full smile makeover planning. A clinician may first assess gum health, decay, tooth wear, bite forces, old restorations, tooth colour, spacing, and patient goals. Conservative options such as whitening, alignment, or bonding may sometimes be considered before irreversible treatments. The website should not be used to decide suitability or promise a result. Fees, sequencing, alternatives, and maintenance responsibilities should be confirmed after consultation and clinical records. Patients who feel anxious can ask for a slower planning visit so options are discussed before any irreversible treatment decisions are made.",
       "evidence_source": [
         "approved-facts.smh.json:priorityServices",
         "local-identity.smh.json:priorityServices.cosmetic-dentistry",
@@ -367,8 +390,8 @@
       "location_scope": "Shoreham-by-Sea",
       "intent_type": "anxiety",
       "question": "Can sedation help if I feel anxious about dental treatment?",
-      "short_answer": "Sedation may help some nervous patients, but it is not right for everyone. St Mary\u2019s House Dental Care describes sedation as clinician-led, safety-first support for selected dental treatment, planned after medical history review. Many anxious patients may also benefit from pacing, communication, and comfort-first numbing options.",
-      "expanded_answer": "Sedation and anxiety dentistry at St Mary\u2019s House Dental Care is described as calm, clinician-led support for people who feel anxious, have a strong gag reflex, jaw tension, or need longer or more complex care. The sedation page explains that IV sedation supports relaxation while the patient remains responsive and monitored. It is not a substitute for communication or local anaesthetic, and it is not used routinely for everyone. Suitability is assessed in advance using medical history, medication review, previous experiences, and the treatment being planned. Public nervous-patient content also highlights alternatives such as slower pacing, clear explanations, staged care, comfort-first numbing with The Wand, and stopping if something does not feel right. Preparation, aftercare, extra recovery time, and fees should be confirmed at consultation.",
+      "short_answer": "Sedation may help some nervous patients, but it is not right for everyone. St Mary’s House Dental Care describes sedation as clinician-led, safety-first support for selected dental treatment, planned after medical history review. Many anxious patients may also benefit from pacing, communication, and comfort-first numbing options.",
+      "expanded_answer": "Sedation and anxiety dentistry at St Mary’s House Dental Care is described as calm, clinician-led support for people who feel anxious, have a strong gag reflex, jaw tension, or need longer or more complex care. The sedation page explains that IV sedation supports relaxation while the patient remains responsive and monitored. It is not a substitute for communication or local anaesthetic, and it is not used routinely for everyone. Suitability is assessed in advance using medical history, medication review, previous experiences, and the treatment being planned. Public nervous-patient content also highlights alternatives such as slower pacing, clear explanations, staged care, comfort-first numbing with The Wand, and stopping if something does not feel right. Preparation, aftercare, extra recovery time, and fees should be confirmed at consultation.",
       "evidence_source": [
         "approved-facts.smh.json:priorityServices",
         "local-identity.smh.json:priorityServices.sedation-anxiety-dentistry",
@@ -391,8 +414,8 @@
       "location_scope": "Shoreham-by-Sea",
       "intent_type": "local",
       "question": "Do you offer dental hygiene and recall appointments in Shoreham-by-Sea?",
-      "short_answer": "Dental hygiene and recall care is listed as a priority service at St Mary\u2019s House Dental Care in Shoreham-by-Sea. Public preventative dentistry content describes regular exams, hygiene support, oral cancer screening, tailored prevention advice, gum health support, and review intervals based on individual risk.",
-      "expanded_answer": "Hygiene and recall care helps keep oral health stable between treatment visits. St Mary\u2019s House Dental Care lists hygiene and recall as a priority service, and the public preventative dentistry page describes regular examinations, professional hygiene, gum support, oral cancer screening at check-ups, and tailored prevention advice. Hygiene appointments can support home care, gum health, and the maintenance of fillings, crowns, implants, and natural teeth. Recall intervals are individual rather than automatic for everyone. The public check-up content says most people stay on track with six-monthly visits, while higher decay or gum risk, recent treatment, or active orthodontic care may need a shorter cadence. Suitability, frequency, and fees should be confirmed with the practice or clinician. If you feel nervous about hygiene care, tell the team so explanations, pauses, and comfort measures can be built into the appointment.",
+      "short_answer": "Dental hygiene and recall care is listed as a priority service at St Mary’s House Dental Care in Shoreham-by-Sea. Public preventative dentistry content describes regular exams, hygiene support, oral cancer screening, tailored prevention advice, gum health support, and review intervals based on individual risk.",
+      "expanded_answer": "Hygiene and recall care helps keep oral health stable between treatment visits. St Mary’s House Dental Care lists hygiene and recall as a priority service, and the public preventative dentistry page describes regular examinations, professional hygiene, gum support, oral cancer screening at check-ups, and tailored prevention advice. Hygiene appointments can support home care, gum health, and the maintenance of fillings, crowns, implants, and natural teeth. Recall intervals are individual rather than automatic for everyone. The public check-up content says most people stay on track with six-monthly visits, while higher decay or gum risk, recent treatment, or active orthodontic care may need a shorter cadence. Suitability, frequency, and fees should be confirmed with the practice or clinician. If you feel nervous about hygiene care, tell the team so explanations, pauses, and comfort measures can be built into the appointment.",
       "evidence_source": [
         "approved-facts.smh.json:priorityServices",
         "local-identity.smh.json:priorityServices.hygiene-recall",

--- a/packages/champagne-manifests/data/seo-ai-answer-foundation/treatment-fact-registry.v1.smh.json
+++ b/packages/champagne-manifests/data/seo-ai-answer-foundation/treatment-fact-registry.v1.smh.json
@@ -32,7 +32,15 @@
         "personal_suitability",
         "outcome_promises"
       ],
-      "source_note": "Duration, recovery, finance, personal suitability, alternatives, and outcome promises remain null unless approved evidence is present."
+      "source_note": "Duration, recovery, finance, personal suitability, alternatives, and outcome promises remain null unless approved evidence is present.",
+      "source_label": "Approved emergency dentistry treatment fact",
+      "local_entity_summary": "Emergency dentistry is a priority service at St Mary's House Dental Care in Shoreham-by-Sea.",
+      "authority_summary": "Route evidence supports triage, pain/swelling/trauma/infection assessment, stabilisation, and safety boundaries.",
+      "target_queries_supported": [
+        "emergency dentist Shoreham-by-Sea",
+        "urgent dentist Shoreham-by-Sea",
+        "emergency dentist West Sussex"
+      ]
     },
     {
       "id": "smh-treatment-fact-dental-implants-v1",
@@ -62,7 +70,15 @@
         "personal_suitability",
         "outcome_promises"
       ],
-      "source_note": "Duration, recovery, finance, personal suitability, alternatives, and outcome promises remain null unless approved evidence is present."
+      "source_note": "Duration, recovery, finance, personal suitability, alternatives, and outcome promises remain null unless approved evidence is present.",
+      "source_label": "Approved dental implants treatment fact",
+      "local_entity_summary": "Dental implants are a priority service at St Mary's House Dental Care in Shoreham-by-Sea.",
+      "authority_summary": "Route evidence supports planning-led implant care, medical history review, CBCT imaging, digital scans, bone/nerve/bite planning, alternatives, aftercare, and maintenance.",
+      "target_queries_supported": [
+        "dental implants Shoreham-by-Sea",
+        "dental implants West Sussex",
+        "implant dentist Sussex"
+      ]
     },
     {
       "id": "smh-treatment-fact-spark-aligners-v1",
@@ -91,7 +107,15 @@
         "personal_suitability",
         "outcome_promises"
       ],
-      "source_note": "Duration, recovery, finance, personal suitability, alternatives, and outcome promises remain null unless approved evidence is present."
+      "source_note": "Duration, recovery, finance, personal suitability, alternatives, and outcome promises remain null unless approved evidence is present.",
+      "source_label": "Approved Spark Aligners treatment fact",
+      "local_entity_summary": "Spark Aligners are a priority service at St Mary's House Dental Care in Shoreham-by-Sea.",
+      "authority_summary": "Route evidence supports clinician-led planning, digital scans, staged aligner trays, progress checks, retention planning, and suitability boundaries.",
+      "target_queries_supported": [
+        "Spark Aligners Shoreham-by-Sea",
+        "clear aligners Shoreham-by-Sea",
+        "Spark Aligners West Sussex"
+      ]
     },
     {
       "id": "smh-treatment-fact-orthodontics-v1",
@@ -120,7 +144,15 @@
         "personal_suitability",
         "outcome_promises"
       ],
-      "source_note": "Duration, recovery, finance, personal suitability, alternatives, and outcome promises remain null unless approved evidence is present."
+      "source_note": "Duration, recovery, finance, personal suitability, alternatives, and outcome promises remain null unless approved evidence is present.",
+      "source_label": "Approved orthodontics treatment fact",
+      "local_entity_summary": "Orthodontics is a priority service at St Mary's House Dental Care in Shoreham-by-Sea.",
+      "authority_summary": "Route evidence supports Spark clear aligners, fixed braces, retainers, digital scans, bite checks, stability planning, and retention needs.",
+      "target_queries_supported": [
+        "orthodontics Shoreham-by-Sea",
+        "orthodontist Shoreham-by-Sea",
+        "clear aligners or braces Shoreham-by-Sea"
+      ]
     },
     {
       "id": "smh-treatment-fact-cosmetic-dentistry-v1",
@@ -181,7 +213,15 @@
         "personal_suitability",
         "outcome_promises"
       ],
-      "source_note": "Duration, recovery, finance, personal suitability, alternatives, and outcome promises remain null unless approved evidence is present."
+      "source_note": "Duration, recovery, finance, personal suitability, alternatives, and outcome promises remain null unless approved evidence is present.",
+      "source_label": "Approved preventative and general dentistry treatment fact",
+      "local_entity_summary": "Preventative and general dentistry is anchored to the existing Shoreham-by-Sea treatment route.",
+      "authority_summary": "Route evidence supports check-ups, gum and hygiene support, oral cancer screening, prevention advice, and risk-led review intervals.",
+      "target_queries_supported": [
+        "general dentistry Shoreham-by-Sea",
+        "private dental check-up Shoreham-by-Sea",
+        "dental hygiene Shoreham-by-Sea"
+      ]
     },
     {
       "id": "smh-treatment-fact-private-dentist-v1",
@@ -210,7 +250,15 @@
         "local-identity.smh.json:primaryMarket"
       ],
       "clinical_review_required": true,
-      "source_note": "Duration, recovery, finance, personal suitability, alternatives, and outcome promises remain null unless approved evidence is present."
+      "source_note": "Duration, recovery, finance, personal suitability, alternatives, and outcome promises remain null unless approved evidence is present.",
+      "source_label": "Approved private dentistry treatment fact",
+      "local_entity_summary": "Private dentist intent is anchored to the St Mary's House Dental Care approved NAP and Shoreham-by-Sea practice identity.",
+      "authority_summary": "Authority is limited to approved practice identity, contact, opening-hours, and priority-service facts; clinical recommendations require examination.",
+      "target_queries_supported": [
+        "private dentist Shoreham-by-Sea",
+        "private dentist West Sussex",
+        "general dentistry Shoreham-by-Sea"
+      ]
     },
     {
       "id": "smh-treatment-fact-examinations-v1",
@@ -268,7 +316,16 @@
         "page-truth/treatments-3d-dentistry-and-technology.txt"
       ],
       "clinical_review_required": true,
-      "source_note": "Duration, recovery, finance, personal suitability, alternatives, and outcome promises remain null unless approved evidence is present."
+      "source_note": "Duration, recovery, finance, personal suitability, alternatives, and outcome promises remain null unless approved evidence is present.",
+      "source_label": "Approved 3D dentistry treatment fact",
+      "local_entity_summary": "3D dentistry is anchored to the Shoreham-by-Sea practice entity and /treatments/3d-dentistry-and-technology.",
+      "authority_summary": "Route evidence supports CBCT, 3D scanning, guided planning, digital scans, and 3D printing where appropriate.",
+      "target_queries_supported": [
+        "3D dentistry Shoreham-by-Sea",
+        "3D dental scans Shoreham-by-Sea",
+        "digital dentistry Shoreham-by-Sea"
+      ],
+      "canonical_intent": "Primary route for 3D dentistry capability."
     },
     {
       "id": "smh-treatment-fact-same-day-crowns-veneers-v1",
@@ -297,7 +354,16 @@
         "page-truth/treatments-3d-digital-dentistry.txt"
       ],
       "clinical_review_required": true,
-      "source_note": "Duration, recovery, finance, personal suitability, alternatives, and outcome promises remain null unless approved evidence is present."
+      "source_note": "Duration, recovery, finance, personal suitability, alternatives, and outcome promises remain null unless approved evidence is present.",
+      "source_label": "Approved same-day crowns and veneers treatment fact",
+      "local_entity_summary": "Same-day crowns and veneers are anchored to /treatments/3d-digital-dentistry for workflow intent.",
+      "authority_summary": "Route evidence supports scanning, guided planning, and digital workflows while preserving suitability assessment boundaries.",
+      "target_queries_supported": [
+        "same-day veneers Shoreham-by-Sea",
+        "same-day crowns Shoreham-by-Sea",
+        "digital veneers Shoreham-by-Sea"
+      ],
+      "canonical_intent": "Primary route for same-day crown and veneer workflow."
     },
     {
       "id": "smh-treatment-fact-veneers-v1",
@@ -326,7 +392,15 @@
         "champagne_machine_manifest_full.json:pages.veneers.answerSurface"
       ],
       "clinical_review_required": true,
-      "source_note": "Duration, recovery, finance, personal suitability, alternatives, and outcome promises remain null unless approved evidence is present."
+      "source_note": "Duration, recovery, finance, personal suitability, alternatives, and outcome promises remain null unless approved evidence is present.",
+      "source_label": "Approved broader veneers treatment fact",
+      "local_entity_summary": "The veneers route remains supporting evidence for broad veneer treatment intent in Shoreham-by-Sea.",
+      "authority_summary": "Route evidence supports veneer suitability, planning, materials, aftercare, limitations, and alternatives without owning same-day workflow intent.",
+      "target_queries_supported": [
+        "veneers Shoreham-by-Sea",
+        "porcelain veneers Shoreham-by-Sea"
+      ],
+      "canonical_intent": "Supporting route for broader veneers treatment intent, not the same-day workflow primary."
     },
     {
       "id": "smh-treatment-fact-sedation-anxiety-dentistry-v1",

--- a/packages/champagne-manifests/data/seo/approved-facts.smh.json
+++ b/packages/champagne-manifests/data/seo/approved-facts.smh.json
@@ -9,7 +9,19 @@
     "telephone": "01273 453109",
     "email": "info@smhdental.co.uk",
     "primaryMarket": "Shoreham-by-Sea",
-    "supportMarkets": ["Brighton", "Hove", "Lancing", "Worthing", "Steyning"]
+    "supportMarkets": [
+      "Brighton",
+      "Hove",
+      "Lancing",
+      "Worthing",
+      "Steyning"
+    ],
+    "localEntitySummary": "St Mary's House Dental Care is the approved public brand for a private dental practice in Shoreham-by-Sea, West Sussex, with support market relevance across Brighton, Hove, Lancing, Worthing, and Steyning.",
+    "countyRelevance": [
+      "West Sussex",
+      "Sussex"
+    ],
+    "napSourceLabel": "Approved public NAP fact set"
   },
   "hours": {
     "Monday": "08:30-17:00",
@@ -21,11 +33,31 @@
     "Sunday": "Closed"
   },
   "team": [
-    { "name": "Dr Nick Maxwell", "role": "Principal Dentist", "gdcNumber": "74877" },
-    { "name": "Dr Sylvia Krafft", "role": "Associate Dentist", "gdcNumber": "174528" },
-    { "name": "Kitty Ingarfield", "role": "Associate Dentist", "gdcNumber": "302160" },
-    { "name": "Sara Burden", "role": "Dental Hygienist", "gdcNumber": "3966" },
-    { "name": "Evgenia Georgieva (Jenny)", "role": "Dental Hygienist", "gdcNumber": "275874" }
+    {
+      "name": "Dr Nick Maxwell",
+      "role": "Principal Dentist",
+      "gdcNumber": "74877"
+    },
+    {
+      "name": "Dr Sylvia Krafft",
+      "role": "Associate Dentist",
+      "gdcNumber": "174528"
+    },
+    {
+      "name": "Kitty Ingarfield",
+      "role": "Associate Dentist",
+      "gdcNumber": "302160"
+    },
+    {
+      "name": "Sara Burden",
+      "role": "Dental Hygienist",
+      "gdcNumber": "3966"
+    },
+    {
+      "name": "Evgenia Georgieva (Jenny)",
+      "role": "Dental Hygienist",
+      "gdcNumber": "275874"
+    }
   ],
   "priorityServices": [
     "Private dentist",
@@ -44,5 +76,17 @@
     "No diagnosis is provided from approved facts.",
     "No PHI or patient-specific information is included.",
     "Treatment advice requires a clinical assessment."
-  ]
+  ],
+  "canonicalIntentMap": {
+    "3d-dentistry-shoreham": {
+      "primaryRoute": "/treatments/3d-dentistry-and-technology",
+      "supportingRoute": "/treatments/3d-digital-dentistry",
+      "decision": "Use the 3D dentistry and technology route for technology-capability intent such as CBCT, 3D scanning, guided planning, and digital dentistry capability."
+    },
+    "same-day-veneers-shoreham": {
+      "primaryRoute": "/treatments/3d-digital-dentistry",
+      "supportingRoute": "/treatments/veneers",
+      "decision": "Use the 3D digital dentistry route for same-day workflow intent; keep the veneers route for broader veneer suitability, planning, materials, and alternatives."
+    }
+  }
 }

--- a/packages/champagne-manifests/data/seo/local-identity.smh.json
+++ b/packages/champagne-manifests/data/seo/local-identity.smh.json
@@ -55,13 +55,36 @@
     ]
   },
   "openingHours": [
-    { "dayOfWeek": "Monday", "opens": "08:30", "closes": "17:00" },
-    { "dayOfWeek": "Tuesday", "opens": "08:30", "closes": "17:00" },
-    { "dayOfWeek": "Wednesday", "opens": "08:30", "closes": "17:00" },
-    { "dayOfWeek": "Thursday", "opens": "08:30", "closes": "17:00" },
-    { "dayOfWeek": "Friday", "opens": "08:30", "closes": "16:00" }
+    {
+      "dayOfWeek": "Monday",
+      "opens": "08:30",
+      "closes": "17:00"
+    },
+    {
+      "dayOfWeek": "Tuesday",
+      "opens": "08:30",
+      "closes": "17:00"
+    },
+    {
+      "dayOfWeek": "Wednesday",
+      "opens": "08:30",
+      "closes": "17:00"
+    },
+    {
+      "dayOfWeek": "Thursday",
+      "opens": "08:30",
+      "closes": "17:00"
+    },
+    {
+      "dayOfWeek": "Friday",
+      "opens": "08:30",
+      "closes": "16:00"
+    }
   ],
-  "closedDays": ["Saturday", "Sunday"],
+  "closedDays": [
+    "Saturday",
+    "Sunday"
+  ],
   "openingHoursSources": [
     {
       "type": "live_site",
@@ -80,23 +103,297 @@
     ]
   },
   "supportMarkets": [
-    { "name": "Brighton", "sources": [{ "type": "user_prompt", "url": "mission_prompt" }] },
-    { "name": "Hove", "sources": [{ "type": "user_prompt", "url": "mission_prompt" }] },
-    { "name": "Lancing", "sources": [{ "type": "user_prompt", "url": "mission_prompt" }] },
-    { "name": "Worthing", "sources": [{ "type": "user_prompt", "url": "mission_prompt" }] },
-    { "name": "Steyning", "sources": [{ "type": "user_prompt", "url": "mission_prompt" }] }
+    {
+      "name": "Brighton",
+      "sources": [
+        {
+          "type": "user_prompt",
+          "url": "mission_prompt"
+        }
+      ]
+    },
+    {
+      "name": "Hove",
+      "sources": [
+        {
+          "type": "user_prompt",
+          "url": "mission_prompt"
+        }
+      ]
+    },
+    {
+      "name": "Lancing",
+      "sources": [
+        {
+          "type": "user_prompt",
+          "url": "mission_prompt"
+        }
+      ]
+    },
+    {
+      "name": "Worthing",
+      "sources": [
+        {
+          "type": "user_prompt",
+          "url": "mission_prompt"
+        }
+      ]
+    },
+    {
+      "name": "Steyning",
+      "sources": [
+        {
+          "type": "user_prompt",
+          "url": "mission_prompt"
+        }
+      ]
+    }
   ],
   "priorityServices": [
-    { "id": "private-dentist", "name": "Private dentist", "routePath": "/contact", "sources": [{ "type": "user_prompt", "url": "mission_prompt" }] },
-    { "id": "emergency-dentist", "name": "Emergency dentist", "routePath": "/treatments/emergency-dentistry", "sources": [{ "type": "user_prompt", "url": "mission_prompt" }, { "type": "live_site", "url": "https://www.smhdental.co.uk/contact-us/" }] },
-    { "id": "dental-implants", "name": "Dental implants", "routePath": "/treatments/implants", "sources": [{ "type": "user_prompt", "url": "mission_prompt" }, { "type": "live_site", "url": "https://www.smhdental.co.uk/" }] },
-    { "id": "3d-dentistry", "name": "3D dentistry", "routePath": "/treatments/3d-dentistry-and-technology", "sources": [{ "type": "user_prompt", "url": "mission_prompt" }] },
-    { "id": "same-day-crowns-veneers", "name": "Same-day crowns/veneers", "routePath": "/treatments/3d-digital-dentistry", "sources": [{ "type": "user_prompt", "url": "mission_prompt" }] },
-    { "id": "spark-aligners", "name": "Spark Aligners", "routePath": "/treatments/clear-aligners-spark", "sources": [{ "type": "user_prompt", "url": "mission_prompt" }] },
-    { "id": "orthodontics", "name": "Orthodontics", "routePath": "/treatments/orthodontics", "sources": [{ "type": "user_prompt", "url": "mission_prompt" }] },
-    { "id": "sedation-anxiety-dentistry", "name": "Sedation/anxiety dentistry", "routePath": "/treatments/sedation-dentistry", "sources": [{ "type": "user_prompt", "url": "mission_prompt" }] },
-    { "id": "cosmetic-dentistry", "name": "Cosmetic dentistry", "routePath": "/treatments/cosmetic-dentistry", "sources": [{ "type": "user_prompt", "url": "mission_prompt" }, { "type": "live_site", "url": "https://www.smhdental.co.uk/" }] },
-    { "id": "hygiene-recall", "name": "Hygiene/recall", "routePath": "/treatments/preventative-and-general-dentistry", "sources": [{ "type": "user_prompt", "url": "mission_prompt" }, { "type": "live_site", "url": "https://www.smhdental.co.uk/dental-hygienist/" }] },
-    { "id": "examinations", "name": "Examinations", "routePath": "/treatments/dental-checkups-oral-cancer-screening", "sources": [{ "type": "user_prompt", "url": "mission_prompt" }, { "type": "live_site", "url": "https://www.smhdental.co.uk/examination/" }] }
-  ]
+    {
+      "id": "private-dentist",
+      "name": "Private dentist",
+      "routePath": "/contact",
+      "sources": [
+        {
+          "type": "user_prompt",
+          "url": "mission_prompt"
+        }
+      ],
+      "canonicalIntent": "Private dentistry and general practice identity",
+      "targetQueries": [
+        "private dentist Shoreham-by-Sea",
+        "private dentist West Sussex",
+        "general dentistry Shoreham-by-Sea"
+      ],
+      "aiCitationSummary": "St Mary's House Dental Care is the approved private dental practice entity for Shoreham-by-Sea, with contact and NAP facts held in the local identity registry."
+    },
+    {
+      "id": "emergency-dentist",
+      "name": "Emergency dentist",
+      "routePath": "/treatments/emergency-dentistry",
+      "sources": [
+        {
+          "type": "user_prompt",
+          "url": "mission_prompt"
+        },
+        {
+          "type": "live_site",
+          "url": "https://www.smhdental.co.uk/contact-us/"
+        }
+      ],
+      "canonicalIntent": "Emergency dentistry",
+      "targetQueries": [
+        "emergency dentist Shoreham-by-Sea",
+        "urgent dentist Shoreham-by-Sea",
+        "emergency dentist West Sussex"
+      ],
+      "aiCitationSummary": "Emergency dentistry is an approved priority service mapped to the existing /treatments/emergency-dentistry route."
+    },
+    {
+      "id": "dental-implants",
+      "name": "Dental implants",
+      "routePath": "/treatments/implants",
+      "sources": [
+        {
+          "type": "user_prompt",
+          "url": "mission_prompt"
+        },
+        {
+          "type": "live_site",
+          "url": "https://www.smhdental.co.uk/"
+        }
+      ],
+      "canonicalIntent": "Dental implants",
+      "targetQueries": [
+        "dental implants Shoreham-by-Sea",
+        "dental implants West Sussex",
+        "implant dentist Sussex"
+      ],
+      "aiCitationSummary": "Dental implants are an approved priority service mapped to the existing /treatments/implants authority route."
+    },
+    {
+      "id": "3d-dentistry",
+      "name": "3D dentistry",
+      "routePath": "/treatments/3d-dentistry-and-technology",
+      "sources": [
+        {
+          "type": "user_prompt",
+          "url": "mission_prompt"
+        }
+      ],
+      "canonicalIntent": "3D dentistry technology capability",
+      "targetQueries": [
+        "3D dentistry Shoreham-by-Sea",
+        "3D dental scans Shoreham-by-Sea",
+        "digital dentistry Shoreham-by-Sea"
+      ],
+      "canonicalMappingNote": "/treatments/3d-dentistry-and-technology is the primary route for 3D dentistry capability and should not absorb same-day veneers intent."
+    },
+    {
+      "id": "same-day-crowns-veneers",
+      "name": "Same-day crowns/veneers",
+      "routePath": "/treatments/3d-digital-dentistry",
+      "sources": [
+        {
+          "type": "user_prompt",
+          "url": "mission_prompt"
+        }
+      ],
+      "canonicalIntent": "Same-day crown and veneer digital workflow",
+      "targetQueries": [
+        "same-day veneers Shoreham-by-Sea",
+        "same-day crowns Shoreham-by-Sea",
+        "digital veneers Shoreham-by-Sea"
+      ],
+      "canonicalMappingNote": "/treatments/3d-digital-dentistry is the primary route for same-day crowns and veneers workflow; /treatments/veneers remains the broader veneers treatment route."
+    },
+    {
+      "id": "spark-aligners",
+      "name": "Spark Aligners",
+      "routePath": "/treatments/clear-aligners-spark",
+      "sources": [
+        {
+          "type": "user_prompt",
+          "url": "mission_prompt"
+        }
+      ],
+      "canonicalIntent": "Spark Aligners",
+      "targetQueries": [
+        "Spark Aligners Shoreham-by-Sea",
+        "clear aligners Shoreham-by-Sea",
+        "Spark Aligners West Sussex"
+      ],
+      "aiCitationSummary": "Spark Aligners are an approved priority service mapped to the existing /treatments/clear-aligners-spark route."
+    },
+    {
+      "id": "orthodontics",
+      "name": "Orthodontics",
+      "routePath": "/treatments/orthodontics",
+      "sources": [
+        {
+          "type": "user_prompt",
+          "url": "mission_prompt"
+        }
+      ],
+      "canonicalIntent": "Orthodontics",
+      "targetQueries": [
+        "orthodontics Shoreham-by-Sea",
+        "orthodontist Shoreham-by-Sea",
+        "clear aligners or braces Shoreham-by-Sea"
+      ],
+      "aiCitationSummary": "Orthodontics is an approved priority service mapped to the existing /treatments/orthodontics route."
+    },
+    {
+      "id": "sedation-anxiety-dentistry",
+      "name": "Sedation/anxiety dentistry",
+      "routePath": "/treatments/sedation-dentistry",
+      "sources": [
+        {
+          "type": "user_prompt",
+          "url": "mission_prompt"
+        }
+      ]
+    },
+    {
+      "id": "cosmetic-dentistry",
+      "name": "Cosmetic dentistry",
+      "routePath": "/treatments/cosmetic-dentistry",
+      "sources": [
+        {
+          "type": "user_prompt",
+          "url": "mission_prompt"
+        },
+        {
+          "type": "live_site",
+          "url": "https://www.smhdental.co.uk/"
+        }
+      ]
+    },
+    {
+      "id": "hygiene-recall",
+      "name": "Hygiene/recall",
+      "routePath": "/treatments/preventative-and-general-dentistry",
+      "sources": [
+        {
+          "type": "user_prompt",
+          "url": "mission_prompt"
+        },
+        {
+          "type": "live_site",
+          "url": "https://www.smhdental.co.uk/dental-hygienist/"
+        }
+      ],
+      "canonicalIntent": "Preventative and general dentistry",
+      "targetQueries": [
+        "general dentistry Shoreham-by-Sea",
+        "dental hygiene Shoreham-by-Sea",
+        "private dental check-up Shoreham-by-Sea"
+      ],
+      "aiCitationSummary": "Preventative and general dentistry is supported by the existing /treatments/preventative-and-general-dentistry route."
+    },
+    {
+      "id": "examinations",
+      "name": "Examinations",
+      "routePath": "/treatments/dental-checkups-oral-cancer-screening",
+      "sources": [
+        {
+          "type": "user_prompt",
+          "url": "mission_prompt"
+        },
+        {
+          "type": "live_site",
+          "url": "https://www.smhdental.co.uk/examination/"
+        }
+      ]
+    }
+  ],
+  "localEntityProof": {
+    "sourceLabel": "Approved local identity fact set",
+    "summary": "St Mary's House Dental Care is a private dental practice on St Mary's Road in Shoreham-by-Sea, West Sussex, BN43 5ZA. The approved public NAP is 01273 453109 and info@smhdental.co.uk.",
+    "primaryLocality": "Shoreham-by-Sea",
+    "countyRelevance": [
+      "West Sussex",
+      "Sussex"
+    ],
+    "approvedNap": {
+      "name": "St Mary's House Dental Care",
+      "address": "St Mary's Road, Shoreham-by-Sea, West Sussex, BN43 5ZA",
+      "telephone": "01273 453109",
+      "email": "info@smhdental.co.uk"
+    },
+    "serviceEntityLinks": [
+      {
+        "serviceId": "private-dentist",
+        "routePath": "/contact",
+        "localIntent": "private dentist Shoreham-by-Sea"
+      },
+      {
+        "serviceId": "dental-implants",
+        "routePath": "/treatments/implants",
+        "localIntent": "dental implants Shoreham-by-Sea"
+      },
+      {
+        "serviceId": "emergency-dentist",
+        "routePath": "/treatments/emergency-dentistry",
+        "localIntent": "emergency dentist Shoreham-by-Sea"
+      },
+      {
+        "serviceId": "spark-aligners",
+        "routePath": "/treatments/clear-aligners-spark",
+        "localIntent": "Spark Aligners Shoreham-by-Sea"
+      },
+      {
+        "serviceId": "orthodontics",
+        "routePath": "/treatments/orthodontics",
+        "localIntent": "orthodontics Shoreham-by-Sea"
+      }
+    ],
+    "sourceRefs": [
+      "local-identity.smh.json:publicBrand",
+      "local-identity.smh.json:address",
+      "local-identity.smh.json:contact",
+      "local-identity.smh.json:priorityServices"
+    ]
+  }
 }

--- a/tools/audits/seo-bounded-implementation/CHAMPAGNE_SEO_BOUNDED_IMPLEMENTATION_V1.json
+++ b/tools/audits/seo-bounded-implementation/CHAMPAGNE_SEO_BOUNDED_IMPLEMENTATION_V1.json
@@ -1,0 +1,167 @@
+{
+  "version": "CHAMPAGNE_SEO_BOUNDED_IMPLEMENTATION_V1",
+  "role": "CHAMPAGNE_SEO_BOUNDED_IMPLEMENTATION_PATCH_V1",
+  "repo": "drnickmaxwell-wq/champagne",
+  "implementationDate": "2026-06-05",
+  "scope": [
+    "LOCAL_ENTITY_PROOF_BUILD",
+    "AI_CITATION_READINESS",
+    "TREATMENT_AUTHORITY_PAGE_BUILD"
+  ],
+  "filesChanged": [
+    {
+      "path": "packages/champagne-manifests/data/seo/local-identity.smh.json",
+      "reason": "Added approved local entity proof, service-to-route query support, and canonical intent labels using existing NAP, locality, support-market, and priority-service data."
+    },
+    {
+      "path": "packages/champagne-manifests/data/seo/approved-facts.smh.json",
+      "reason": "Added concise local entity summary, county/Sussex relevance, NAP source label, and canonical intent mapping decisions for 3D dentistry versus same-day veneers."
+    },
+    {
+      "path": "packages/champagne-manifests/data/seo-ai-answer-foundation/ai-answer-registry.v1.smh.json",
+      "reason": "Added source-labelled local entity and authority summaries to approved answer packets where existing answer structures already supported evidence-source attribution."
+    },
+    {
+      "path": "packages/champagne-manifests/data/seo-ai-answer-foundation/treatment-fact-registry.v1.smh.json",
+      "reason": "Added source-labelled local/entity summaries, authority summaries, supported target queries, and canonical intent fields for priority service treatment facts."
+    },
+    {
+      "path": "tools/audits/seo-bounded-implementation/CHAMPAGNE_SEO_BOUNDED_IMPLEMENTATION_V1.md",
+      "reason": "Required human-readable implementation report."
+    },
+    {
+      "path": "tools/audits/seo-bounded-implementation/CHAMPAGNE_SEO_BOUNDED_IMPLEMENTATION_V1.json",
+      "reason": "Required machine-readable implementation report."
+    }
+  ],
+  "targetQueriesSupported": [
+    "St Mary\u2019s House Dental Care",
+    "private dentist Shoreham-by-Sea",
+    "private dentist West Sussex",
+    "general dentistry Shoreham-by-Sea",
+    "dental implants Shoreham-by-Sea",
+    "dental implants West Sussex",
+    "implant dentist Sussex",
+    "emergency dentist Shoreham-by-Sea",
+    "urgent dentist Shoreham-by-Sea",
+    "emergency dentist West Sussex",
+    "Spark Aligners Shoreham-by-Sea",
+    "clear aligners Shoreham-by-Sea",
+    "Spark Aligners West Sussex",
+    "orthodontics Shoreham-by-Sea",
+    "orthodontist Shoreham-by-Sea",
+    "3D dentistry Shoreham-by-Sea",
+    "3D dental scans Shoreham-by-Sea",
+    "digital dentistry Shoreham-by-Sea",
+    "same-day veneers Shoreham-by-Sea",
+    "same-day crowns Shoreham-by-Sea",
+    "digital veneers Shoreham-by-Sea"
+  ],
+  "localEntityImprovementsMade": [
+    "Added an explicit localEntityProof block with approved public brand, address, phone, email, primary locality, West Sussex/Sussex relevance, and service-route links.",
+    "Added local target-query labels to priority service entries without creating new routes or changing UI.",
+    "Added approved-facts local entity summary and NAP source label."
+  ],
+  "aiCitationReadinessImprovementsMade": [
+    "Added source_label fields to relevant answer packets.",
+    "Added local_entity_summary fields to relevant answer packets.",
+    "Added authority_summary fields to relevant answer packets.",
+    "Preserved evidence_source arrays and approval flags; no answer was promoted beyond its existing approval state."
+  ],
+  "treatmentAuthorityImprovementsMade": [
+    "Dental implants: strengthened treatment fact authority around planning-led care, CBCT/digital scans, suitability boundaries, alternatives, aftercare, and maintenance.",
+    "Emergency dentistry: strengthened treatment fact authority around triage, pain/swelling/trauma/infection assessment, stabilisation, and safety boundaries.",
+    "Spark Aligners/orthodontics: strengthened treatment fact authority around scans, aligner trays, braces/retainers, progress checks, retention, and assessment-led suitability boundaries.",
+    "Private/general dentistry: anchored private dentistry to approved NAP and general dentistry to the preventative/general dentistry route without adding a new route."
+  ],
+  "canonicalIntentMappingDecision": {
+    "3dDentistryShoreham": {
+      "primaryRoute": "/treatments/3d-dentistry-and-technology",
+      "supportingRoute": "/treatments/3d-digital-dentistry",
+      "decision": "Primary route for technology-capability intent such as CBCT, 3D scanning, guided planning, digital scans, and 3D printing where appropriate."
+    },
+    "sameDayVeneersShoreham": {
+      "primaryRoute": "/treatments/3d-digital-dentistry",
+      "supportingRoute": "/treatments/veneers",
+      "decision": "Primary route for same-day crown/veneer workflow intent; /treatments/veneers remains the broader veneer treatment route."
+    }
+  },
+  "filesExplicitlyNotTouched": [
+    "packages/champagne-hero/src/HeroAssetRegistry.ts",
+    "packages/champagne-hero/src/hero-engine/HeroConfig.ts",
+    "packages/champagne-hero/src/hero-engine/HeroManifestAdapter.ts",
+    "packages/champagne-hero/src/hero-engine/HeroRuntime.ts",
+    "packages/champagne-hero/src/hero-engine/HeroSurfaceMap.ts",
+    "packages/champagne-manifests/data/hero/sacred_*",
+    "apps/web/app/components/hero/HeroRenderer.tsx",
+    "apps/web/app/layout.tsx",
+    "apps/web/app/treatments/[slug]/page.tsx",
+    "apps/web/app/globals.css",
+    "apps/web/app/components/layout/Header.tsx",
+    "apps/web/app/components/layout/Footer.tsx",
+    "apps/web/app/components/layout/FooterLuxe.module.css",
+    "apps/web/app/api/**",
+    "apps/web/app/components/concierge/**"
+  ],
+  "risks": [
+    "SEO registries now include additional non-rendered fields; downstream consumers should continue to ignore unknown JSON properties unless intentionally wired later.",
+    "No live search, GBP, reviews, awards, ratings, or external citation claims were added.",
+    "Clinical details remain assessment-gated and do not replace clinician advice."
+  ],
+  "validationResults": [
+    {
+      "command": "npm run lint",
+      "status": "pass",
+      "notes": "Exited 0; existing Next.js lint deprecation/plugin warnings observed."
+    },
+    {
+      "command": "npm run build",
+      "status": "pass",
+      "notes": "Exited 0; existing Browserslist/Tailwind/Next ESLint configuration warnings observed."
+    },
+    {
+      "command": "git diff --check",
+      "status": "pass",
+      "notes": "No whitespace errors."
+    },
+    {
+      "command": "npm run seo:schema-qa",
+      "status": "pass",
+      "notes": "SEO schema graph QA passed with no errors or warnings."
+    },
+    {
+      "command": "npm run seo:answer-foundation-qa",
+      "status": "pass",
+      "notes": "AI answer foundation QA passed; existing word-count and veneers priority-service warnings remained."
+    },
+    {
+      "command": "npm run seo:answer-packet-qa",
+      "status": "pass",
+      "notes": "Priority service answer packet QA passed."
+    },
+    {
+      "command": "npm run seo:answer-rendering-qa",
+      "status": "pass",
+      "notes": "Visible answer surface rendering QA passed 11/11."
+    },
+    {
+      "command": "npm run guard:hero",
+      "status": "pass",
+      "notes": "Hero Guard and sacred hero lock passed."
+    },
+    {
+      "command": "npm run guard:canon",
+      "status": "pass",
+      "notes": "Canon Guard passed; existing Browserslist/Tailwind warnings observed during SSR smoke test."
+    },
+    {
+      "command": "npm run verify",
+      "status": "pass",
+      "notes": "Full verify exited 0; existing workspace dependency, SEO launch-safety, chatbot QA report, Browserslist, Tailwind, and Next ESLint plugin warnings observed."
+    }
+  ],
+  "rollbackNotes": [
+    "Revert this commit to remove the bounded SEO registry additions and implementation report.",
+    "No route, layout, hero, schema-emission, API, analytics, GBP, or deployment state was changed."
+  ]
+}

--- a/tools/audits/seo-bounded-implementation/CHAMPAGNE_SEO_BOUNDED_IMPLEMENTATION_V1.md
+++ b/tools/audits/seo-bounded-implementation/CHAMPAGNE_SEO_BOUNDED_IMPLEMENTATION_V1.md
@@ -1,0 +1,113 @@
+# CHAMPAGNE SEO Bounded Implementation V1
+
+**Role:** `CHAMPAGNE_SEO_BOUNDED_IMPLEMENTATION_PATCH_V1`  
+**Repo:** `drnickmaxwell-wq/champagne`  
+**Implementation date:** 2026-06-05  
+**Action groups:** `LOCAL_ENTITY_PROOF_BUILD`, `AI_CITATION_READINESS`, `TREATMENT_AUTHORITY_PAGE_BUILD`
+
+## Files Changed
+
+| File | Exact reason |
+| --- | --- |
+| `packages/champagne-manifests/data/seo/local-identity.smh.json` | Added approved local entity proof, NAP/entity summary, service-route query support, and canonical intent labels using existing locality, address, contact, support-market, and priority-service data. |
+| `packages/champagne-manifests/data/seo/approved-facts.smh.json` | Added a concise local entity summary, county/Sussex relevance, NAP source label, and canonical intent mapping decisions for 3D dentistry vs same-day veneers. |
+| `packages/champagne-manifests/data/seo-ai-answer-foundation/ai-answer-registry.v1.smh.json` | Added source-labelled local entity and authority summaries to relevant answer packets without changing approval flags or inventing clinical claims. |
+| `packages/champagne-manifests/data/seo-ai-answer-foundation/treatment-fact-registry.v1.smh.json` | Added source-labelled local/entity summaries, treatment authority summaries, target query support, and canonical intent fields for priority service treatment facts. |
+| `tools/audits/seo-bounded-implementation/CHAMPAGNE_SEO_BOUNDED_IMPLEMENTATION_V1.md` | Required human-readable implementation report. |
+| `tools/audits/seo-bounded-implementation/CHAMPAGNE_SEO_BOUNDED_IMPLEMENTATION_V1.json` | Required machine-readable implementation report. |
+
+## Target Queries Supported
+
+- St Mary’s House Dental Care
+- private dentist Shoreham-by-Sea
+- private dentist West Sussex
+- general dentistry Shoreham-by-Sea
+- dental implants Shoreham-by-Sea
+- dental implants West Sussex
+- implant dentist Sussex
+- emergency dentist Shoreham-by-Sea
+- urgent dentist Shoreham-by-Sea
+- emergency dentist West Sussex
+- Spark Aligners Shoreham-by-Sea
+- clear aligners Shoreham-by-Sea
+- Spark Aligners West Sussex
+- orthodontics Shoreham-by-Sea
+- orthodontist Shoreham-by-Sea
+- 3D dentistry Shoreham-by-Sea
+- 3D dental scans Shoreham-by-Sea
+- digital dentistry Shoreham-by-Sea
+- same-day veneers Shoreham-by-Sea
+- same-day crowns Shoreham-by-Sea
+- digital veneers Shoreham-by-Sea
+
+## Local Entity Improvements Made
+
+- Added an explicit `localEntityProof` block for St Mary's House Dental Care using approved public NAP: St Mary's Road, Shoreham-by-Sea, West Sussex, BN43 5ZA; 01273 453109; info@smhdental.co.uk.
+- Added primary locality and county/Sussex relevance labels: Shoreham-by-Sea, West Sussex, Sussex.
+- Added service-to-route links for private dentistry, dental implants, emergency dentistry, Spark Aligners, and orthodontics.
+- Added approved local target-query labels to priority service entries without route creation or UI changes.
+
+## AI Citation Readiness Improvements Made
+
+- Added `source_label` values to relevant answer packets.
+- Added `local_entity_summary` values so AI extraction can identify the practice, locality, and route owner.
+- Added `authority_summary` values that summarise existing page-truth/approved-fact evidence without promoting unsupported claims.
+- Preserved all existing `evidence_source` arrays and approval flags.
+
+## Treatment Authority Improvements Made
+
+- **Dental implants:** strengthened treatment fact summaries around planning-led care, CBCT/digital scans, suitability boundaries, alternatives, aftercare, and maintenance.
+- **Emergency dentistry:** strengthened treatment fact summaries around triage, pain/swelling/trauma/infection assessment, stabilisation, and safety boundaries.
+- **Spark Aligners / orthodontics:** strengthened treatment fact summaries around digital scans, staged aligner trays, fixed braces, retainers, progress checks, retention, and suitability boundaries.
+- **Private/general dentistry:** anchored private dentist intent to approved NAP and general dentistry to the existing preventative/general dentistry route.
+
+## Canonical Intent Mapping Decision
+
+| Intent | Primary route | Supporting route | Decision |
+| --- | --- | --- | --- |
+| 3D dentistry Shoreham | `/treatments/3d-dentistry-and-technology` | `/treatments/3d-digital-dentistry` | The 3D dentistry route owns technology-capability intent such as CBCT, 3D scanning, guided planning, digital scans, and 3D printing where appropriate. |
+| Same-day veneers Shoreham | `/treatments/3d-digital-dentistry` | `/treatments/veneers` | The 3D digital dentistry route owns same-day crown/veneer workflow intent; the veneers route remains the broader veneer treatment route. |
+
+## Files Explicitly Not Touched
+
+- `packages/champagne-hero/src/HeroAssetRegistry.ts`
+- `packages/champagne-hero/src/hero-engine/HeroConfig.ts`
+- `packages/champagne-hero/src/hero-engine/HeroManifestAdapter.ts`
+- `packages/champagne-hero/src/hero-engine/HeroRuntime.ts`
+- `packages/champagne-hero/src/hero-engine/HeroSurfaceMap.ts`
+- `packages/champagne-manifests/data/hero/sacred_*`
+- `apps/web/app/components/hero/HeroRenderer.tsx`
+- `apps/web/app/layout.tsx`
+- `apps/web/app/treatments/[slug]/page.tsx`
+- `apps/web/app/globals.css`
+- `apps/web/app/components/layout/Header.tsx`
+- `apps/web/app/components/layout/Footer.tsx`
+- `apps/web/app/components/layout/FooterLuxe.module.css`
+- `apps/web/app/api/**`
+- `apps/web/app/components/concierge/**`
+
+## Risks
+
+- Added registry-only fields are non-visual and should be ignored by consumers that do not yet read them.
+- No live search, Google Business Profile, review, award, rating, or external citation claims were added.
+- Clinical statements remain bounded to approved facts/page-truth evidence and retain assessment-gated language.
+
+## Validation Results
+
+| Command | Status | Notes |
+| --- | --- | --- |
+| `npm run lint` | PASS | Exited 0; existing Next.js lint deprecation/plugin warnings observed. |
+| `npm run build` | PASS | Exited 0; existing Browserslist/Tailwind/Next ESLint configuration warnings observed. |
+| `git diff --check` | PASS | No whitespace errors. |
+| `npm run seo:schema-qa` | PASS | SEO schema graph QA passed with no errors or warnings. |
+| `npm run seo:answer-foundation-qa` | PASS | AI answer foundation QA passed; existing word-count and veneers priority-service warnings remained. |
+| `npm run seo:answer-packet-qa` | PASS | Priority service answer packet QA passed. |
+| `npm run seo:answer-rendering-qa` | PASS | Visible answer surface rendering QA passed 11/11. |
+| `npm run guard:hero` | PASS | Hero Guard and sacred hero lock passed. |
+| `npm run guard:canon` | PASS | Canon Guard passed; existing Browserslist/Tailwind warnings observed during SSR smoke test. |
+| `npm run verify` | PASS | Full verify exited 0; existing workspace dependency, SEO launch-safety, chatbot QA report, Browserslist, Tailwind, and Next ESLint plugin warnings observed. |
+
+## Rollback Notes
+
+- Revert this commit to remove the SEO registry additions and implementation report.
+- No route, layout, hero, schema-emission, API, analytics, GBP, deployment, or visual state was changed.


### PR DESCRIPTION
### Motivation

- Provide a minimal, data-only SEO strengthening patch that anchors local NAP/entity facts and service authority for St Mary’s House Dental Care and Shoreham-by-Sea to improve local intent mapping and AI citation readiness. 
- Improve machine-readable answer/treatment registries so AI/voice/chatbot consumers can cite exact local evidence and bounded authority for priority services (implants, emergency care, Spark Aligners/orthodontics, private/general dentistry). 
- Resolve canonical intent ambiguity for overlapping technology/workflow pages by selecting primary routes for 3D dentistry vs same-day crowns/veneers without touching routes, layouts, or hero systems. 

### Description

- Added registry fields and structured summaries by editing `packages/champagne-manifests/data/seo/local-identity.smh.json`, `packages/champagne-manifests/data/seo/approved-facts.smh.json`, `packages/champagne-manifests/data/seo-ai-answer-foundation/ai-answer-registry.v1.smh.json`, and `packages/champagne-manifests/data/seo-ai-answer-foundation/treatment-fact-registry.v1.smh.json` to include `localEntityProof`, `source_label`, `local_entity_summary`, `authority_summary`, `target_queries_supported`, and canonical intent metadata. 
- Added a `canonicalIntentMap` entry in approved facts and canonical_intent entries in treatment facts to make the decision that `/treatments/3d-dentistry-and-technology` owns 3D/technology capability and `/treatments/3d-digital-dentistry` owns same-day crown/veneer workflow while keeping `/treatments/veneers` as the broader veneers route. 
- Preserved all existing `evidence_source` arrays, approval flags, route paths and page content, and did not change any UI/layout/hero/route files; added human- and machine-readable implementation reports under `tools/audits/seo-bounded-implementation`. 

### Testing

- Ran `npm run lint` and the workspace linting passed (Next.js plugin deprecation warnings observed) which is recorded as PASS. 
- Ran `npm run build` and the Next build completed successfully (warnings for Browserslist/Tailwind/Next ESLint configuration observed) and is recorded as PASS. 
- Executed `git diff --check` which passed with no whitespace errors and is recorded as PASS. 
- Ran SEO QA suite: `npm run seo:schema-qa` (PASS), `npm run seo:answer-foundation-qa` (PASS with word-count and veneers mapping warnings), `npm run seo:answer-packet-qa` (PASS), and `npm run seo:answer-rendering-qa` (PASS; visible answer surfaces 11/11). 
- Ran guards and full verify: `npm run guard:hero` (PASS), `npm run guard:canon` (PASS), and `npm run verify` (PASS) with the previously noted non-fatal warnings recorded in the validation artifacts.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a22d872b7e08332aef98e8595b615ca)