### PR TITLE
Add SEO post-patch validation report

### DIFF
--- a/tools/audits/seo-post-patch-validation/CHAMPAGNE_SEO_POST_PATCH_VALIDATION_V1.json
+++ b/tools/audits/seo-post-patch-validation/CHAMPAGNE_SEO_POST_PATCH_VALIDATION_V1.json
@@ -1,0 +1,200 @@
+{
+  "version": "CHAMPAGNE_SEO_POST_PATCH_VALIDATION_V1",
+  "role": "CHAMPAGNE_SEO_PATCH_VALIDATOR_V1",
+  "repo": "drnickmaxwell-wq/champagne",
+  "validation_date": "2026-06-05",
+  "validated_patch": {
+    "commit": "75d90c7",
+    "subject": "Strengthen bounded SEO entity registries (#830)",
+    "range": "HEAD~1..HEAD"
+  },
+  "authority_status": "VALIDATED_PASS_WITH_WARNINGS",
+  "files_inspected": [
+    "tools/audits/seo-bounded-implementation/CHAMPAGNE_SEO_BOUNDED_IMPLEMENTATION_V1.md",
+    "tools/audits/seo-bounded-implementation/CHAMPAGNE_SEO_BOUNDED_IMPLEMENTATION_V1.json",
+    "packages/champagne-manifests/data/seo/local-identity.smh.json",
+    "packages/champagne-manifests/data/seo/approved-facts.smh.json",
+    "packages/champagne-manifests/data/seo-ai-answer-foundation/ai-answer-registry.v1.smh.json",
+    "packages/champagne-manifests/data/seo-ai-answer-foundation/treatment-fact-registry.v1.smh.json",
+    "package.json",
+    "AGENTS.md"
+  ],
+  "changed_files_validated": [
+    "packages/champagne-manifests/data/seo-ai-answer-foundation/ai-answer-registry.v1.smh.json",
+    "packages/champagne-manifests/data/seo-ai-answer-foundation/treatment-fact-registry.v1.smh.json",
+    "packages/champagne-manifests/data/seo/approved-facts.smh.json",
+    "packages/champagne-manifests/data/seo/local-identity.smh.json",
+    "tools/audits/seo-bounded-implementation/CHAMPAGNE_SEO_BOUNDED_IMPLEMENTATION_V1.json",
+    "tools/audits/seo-bounded-implementation/CHAMPAGNE_SEO_BOUNDED_IMPLEMENTATION_V1.md"
+  ],
+  "files_created": [
+    "tools/audits/seo-post-patch-validation/CHAMPAGNE_SEO_POST_PATCH_VALIDATION_V1.md",
+    "tools/audits/seo-post-patch-validation/CHAMPAGNE_SEO_POST_PATCH_VALIDATION_V1.json"
+  ],
+  "json_validity": {
+    "status": "pass",
+    "files": [
+      "tools/audits/seo-bounded-implementation/CHAMPAGNE_SEO_BOUNDED_IMPLEMENTATION_V1.json",
+      "packages/champagne-manifests/data/seo/local-identity.smh.json",
+      "packages/champagne-manifests/data/seo/approved-facts.smh.json",
+      "packages/champagne-manifests/data/seo-ai-answer-foundation/ai-answer-registry.v1.smh.json",
+      "packages/champagne-manifests/data/seo-ai-answer-foundation/treatment-fact-registry.v1.smh.json"
+    ]
+  },
+  "claim_safety": {
+    "status": "pass",
+    "unsupported_clinical_claims_introduced": false,
+    "invented_credentials_reviews_awards_ratings_or_external_citations_introduced": false,
+    "notes": [
+      "Clinical content remains assessment-gated and bounded to approved facts, local identity, and page-truth references.",
+      "No invented pricing, outcomes, ratings, awards, reviews, credentials, or external citations were identified."
+    ]
+  },
+  "local_identity_nap_consistency": {
+    "status": "pass",
+    "public_brand": "St Mary's House Dental Care",
+    "address": "St Mary's Road, Shoreham-by-Sea, West Sussex, BN43 5ZA",
+    "telephone": "01273 453109",
+    "email": "info@smhdental.co.uk",
+    "primary_locality": "Shoreham-by-Sea",
+    "county_relevance": [
+      "West Sussex",
+      "Sussex"
+    ]
+  },
+  "canonical_mapping_validation": {
+    "status": "pass",
+    "mappings": [
+      {
+        "intent": "3D dentistry Shoreham",
+        "primary_route": "/treatments/3d-dentistry-and-technology",
+        "supporting_route": "/treatments/3d-digital-dentistry",
+        "status": "pass"
+      },
+      {
+        "intent": "same-day veneers Shoreham",
+        "primary_route": "/treatments/3d-digital-dentistry",
+        "supporting_route": "/treatments/veneers",
+        "status": "pass"
+      }
+    ]
+  },
+  "ai_citation_readiness_validation": {
+    "status": "pass_with_existing_warnings",
+    "source_labelled_and_bounded": true,
+    "evidence_sources_preserved": true,
+    "warnings": [
+      "seo:answer-foundation-qa reports answer packet length warnings.",
+      "seo:answer-foundation-qa reports smh-treatment-fact-veneers-v1 maps to a service outside approved priorityServices."
+    ]
+  },
+  "treatment_authority_validation": {
+    "status": "pass_with_existing_warnings",
+    "source_labelled_and_bounded": true,
+    "clinical_review_required_preserved": true,
+    "unknown_fact_boundaries_preserved": true,
+    "canonical_split_preserved": true
+  },
+  "forbidden_file_check": {
+    "status": "pass",
+    "forbidden_files_touched": false,
+    "violations": []
+  },
+  "route_design_deploy_exclusion_check": {
+    "status": "pass",
+    "route_creation": false,
+    "route_deletion": false,
+    "redesign": false,
+    "deployment": false,
+    "gbp": false,
+    "analytics": false,
+    "chatbot_or_portal": false,
+    "api": false,
+    "phi_or_pms": false,
+    "scraping": false,
+    "browser_automation": false,
+    "live_verification": false
+  },
+  "validation_commands": [
+    {
+      "command": "node -e \"...JSON.parse...\"",
+      "status": "pass",
+      "note": "Parsed all changed JSON registry/report files."
+    },
+    {
+      "command": "git diff --name-only HEAD~1..HEAD",
+      "status": "pass",
+      "note": "Confirmed bounded changed-file set."
+    },
+    {
+      "command": "git diff --check",
+      "status": "pass",
+      "note": "No whitespace/conflict marker errors."
+    },
+    {
+      "command": "npm run lint",
+      "status": "pass",
+      "note": "Completed with existing Next lint deprecation/plugin notices; no ESLint errors."
+    },
+    {
+      "command": "npm run build",
+      "status": "pass",
+      "note": "Completed production build with existing Browserslist/Tailwind/Next plugin warnings."
+    },
+    {
+      "command": "npm run seo:schema-qa",
+      "status": "pass",
+      "note": "No unsafe/unsupported/invented schema findings."
+    },
+    {
+      "command": "npm run seo:answer-foundation-qa",
+      "status": "pass_with_warnings",
+      "note": "Passed with answer length warnings and one veneers priority-service mapping warning."
+    },
+    {
+      "command": "npm run seo:answer-packet-qa",
+      "status": "pass",
+      "note": "Priority-service packet QA passed."
+    },
+    {
+      "command": "npm run guard:seo-launch-safety",
+      "status": "pass_with_warnings",
+      "note": "Passed with launch-readiness warnings about missing section layouts and cannibalisation clusters."
+    },
+    {
+      "command": "npm run guard:hero",
+      "status": "pass",
+      "note": "Hero guard and sacred hero lock passed."
+    },
+    {
+      "command": "npm run guard:canon",
+      "status": "pass",
+      "note": "Canon guard passed."
+    },
+    {
+      "command": "npm run verify",
+      "status": "pass_with_warnings",
+      "note": "Full verification passed with existing warning output."
+    }
+  ],
+  "remaining_risks": [
+    "seo:answer-foundation-qa answer packet length warnings remain.",
+    "smh-treatment-fact-veneers-v1 is outside approvedFacts.priorityServices and should receive governance review.",
+    "guard:seo-launch-safety reports existing treatment section-layout and cannibalisation-cluster launch-readiness warnings.",
+    "Existing tooling warnings remain: Next lint deprecation, missing Next ESLint plugin, stale Browserslist data, and Tailwind content glob performance warning.",
+    "No live verification, scraping, browser automation, GBP, deployment, analytics, or external citation verification was performed by design."
+  ],
+  "rollback_notes": {
+    "command": "git revert 75d90c7",
+    "post_rollback_validation": [
+      "git diff --check",
+      "npm run lint",
+      "npm run build",
+      "npm run seo:schema-qa",
+      "npm run seo:answer-foundation-qa",
+      "npm run seo:answer-packet-qa"
+    ]
+  },
+  "next_recommended_mission": "CHAMPAGNE_SEO_ANSWER_PACKET_COMPRESSION_AND_VENEERS_PRIORITY_REVIEW_V1",
+  "overall_result": "PASS_WITH_WARNINGS"
+}

--- a/tools/audits/seo-post-patch-validation/CHAMPAGNE_SEO_POST_PATCH_VALIDATION_V1.md
+++ b/tools/audits/seo-post-patch-validation/CHAMPAGNE_SEO_POST_PATCH_VALIDATION_V1.md
@@ -1,0 +1,209 @@
+# CHAMPAGNE SEO Post-Patch Validation V1
+
+**Role:** `CHAMPAGNE_SEO_PATCH_VALIDATOR_V1`
+**Repo:** `drnickmaxwell-wq/champagne`
+**Validation date:** 2026-06-05
+**Validated patch:** `75d90c7 Strengthen bounded SEO entity registries (#830)`
+**Baseline compared:** `HEAD~1..HEAD`
+
+## Authority Status
+
+**Status:** `VALIDATED_PASS_WITH_WARNINGS`
+
+The bounded SEO implementation patch remains within registry/report scope. No implementation changes, content rewrites, route changes, hero/design changes, deployment actions, live verification, browser automation, scraping, analytics, chatbot/portal, API, PHI/PMS, GBP, or external publishing actions were performed during this validation.
+
+## Changed Files Validated
+
+The post-patch validator inspected the files changed in `HEAD~1..HEAD`:
+
+| File | Validation scope |
+| --- | --- |
+| `packages/champagne-manifests/data/seo/local-identity.smh.json` | JSON validity, NAP/local identity consistency, canonical intent mapping, source labels, bounded local entity proof. |
+| `packages/champagne-manifests/data/seo/approved-facts.smh.json` | JSON validity, approved fact safety, local entity summary, canonical intent map. |
+| `packages/champagne-manifests/data/seo-ai-answer-foundation/ai-answer-registry.v1.smh.json` | JSON validity, AI answer citation readiness, source-labelled and bounded summaries, claim safety. |
+| `packages/champagne-manifests/data/seo-ai-answer-foundation/treatment-fact-registry.v1.smh.json` | JSON validity, treatment authority readiness, source-labelled and bounded treatment facts, claim safety. |
+| `tools/audits/seo-bounded-implementation/CHAMPAGNE_SEO_BOUNDED_IMPLEMENTATION_V1.md` | Implementation report consistency and declared exclusions. |
+| `tools/audits/seo-bounded-implementation/CHAMPAGNE_SEO_BOUNDED_IMPLEMENTATION_V1.json` | JSON validity and machine-readable implementation report consistency. |
+
+Additional reference files inspected:
+
+| File | Validation scope |
+| --- | --- |
+| `package.json` | Required guard/script availability and discovery of relevant SEO/schema/manifest QA commands. |
+| `AGENTS.md` | Canon, sacred zone, guard, and forbidden-file authority constraints. |
+
+## JSON Validity Result
+
+**Result:** `PASS`
+
+The following JSON files parse successfully with `JSON.parse`:
+
+- `tools/audits/seo-bounded-implementation/CHAMPAGNE_SEO_BOUNDED_IMPLEMENTATION_V1.json`
+- `packages/champagne-manifests/data/seo/local-identity.smh.json`
+- `packages/champagne-manifests/data/seo/approved-facts.smh.json`
+- `packages/champagne-manifests/data/seo-ai-answer-foundation/ai-answer-registry.v1.smh.json`
+- `packages/champagne-manifests/data/seo-ai-answer-foundation/treatment-fact-registry.v1.smh.json`
+
+## Claim-Safety Result
+
+**Result:** `PASS`
+
+No unsupported clinical claims were identified in the changed registry/data files. The patch keeps treatment statements bounded to existing approved facts, local identity records, and page-truth sources. The registries continue to preserve assessment-gated language for suitability, risks, alternatives, diagnosis, urgent escalation, personal treatment advice, finance, duration, recovery, and outcomes.
+
+No invented credentials, reviews, awards, ratings, pricing, outcomes, external citations, or live-verification claims were identified.
+
+Automated SEO schema QA also reported:
+
+- `unsafeClinicalClaimsDetected: false`
+- `unsupportedFactsDetected: false`
+- `inventedPricingDetected: false`
+- `inventedOutcomesDetected: false`
+
+## Local Identity / NAP Consistency Result
+
+**Result:** `PASS`
+
+The NAP/local identity remains internally consistent across the inspected local identity registry:
+
+- **Public brand:** `St Mary's House Dental Care`
+- **Address:** `St Mary's Road, Shoreham-by-Sea, West Sussex, BN43 5ZA`
+- **Telephone:** `01273 453109`
+- **Email:** `info@smhdental.co.uk`
+- **Primary locality:** `Shoreham-by-Sea`
+- **County/Sussex relevance:** `West Sussex`, `Sussex`
+
+The `localEntityProof.approvedNap` values match the registry `publicBrand`, `address`, and `contact` values.
+
+## Canonical Mapping Validation
+
+**Result:** `PASS`
+
+Canonical intent mapping is present and internally aligned for the requested intents:
+
+| Intent | Primary mapping found | Supporting mapping found | Result |
+| --- | --- | --- | --- |
+| `3D dentistry Shoreham` | `/treatments/3d-dentistry-and-technology` | `/treatments/3d-digital-dentistry` | `PASS` |
+| `same-day veneers Shoreham` | `/treatments/3d-digital-dentistry` | `/treatments/veneers` | `PASS` |
+
+The local identity registry also maps:
+
+- `3D dentistry Shoreham-by-Sea` to `/treatments/3d-dentistry-and-technology`
+- `same-day veneers Shoreham-by-Sea` to `/treatments/3d-digital-dentistry`
+
+The treatment fact registry mirrors those route ownership decisions and keeps `/treatments/veneers` as supporting broader veneers intent rather than same-day workflow primary ownership.
+
+## AI Citation Readiness Validation
+
+**Result:** `PASS_WITH_EXISTING_WARNINGS`
+
+AI answer registry references remain source-labelled and bounded:
+
+- Relevant answer packets include `source_label`, `local_entity_summary`, and `authority_summary` fields.
+- Existing `evidence_source` arrays remain present on the inspected packets.
+- Source labels are local registry/page-truth/approved-fact labels, not invented third-party citations.
+- Approval flags were not broadened beyond the bounded registry pattern.
+
+Relevant SEO QA command passed, but emitted pre-existing/content-length style warnings for several answer packets exceeding target word counts and one treatment fact mapping warning for veneers outside `approvedFacts.priorityServices`. These warnings do not indicate invalid JSON, unsupported clinical claims, or forbidden file changes.
+
+## Treatment Authority Validation
+
+**Result:** `PASS_WITH_EXISTING_WARNINGS`
+
+Treatment fact registry references remain source-labelled and bounded:
+
+- Treatment fact entries added or strengthened in the patch preserve `evidence_source` arrays.
+- `clinical_review_required` remains true for treatment facts that carry clinical-treatment content.
+- Unknown/high-risk fields remain null/unknown unless evidence is present.
+- `source_note` continues to state that duration, recovery, finance, suitability, alternatives, and outcome promises remain null unless approved evidence is present.
+- `3D dentistry`, `same-day crowns/veneers`, and `veneers` entries preserve the intended route ownership split.
+
+## Forbidden-File Check
+
+**Result:** `PASS`
+
+No forbidden files were changed in `HEAD~1..HEAD`.
+
+Specifically, the changed-file set does **not** include:
+
+- Sacred hero engine files
+- Sacred hero manifests
+- `apps/web/app/components/hero/HeroRenderer.tsx`
+- `apps/web/app/layout.tsx`
+- `apps/web/app/treatments/[slug]/page.tsx`
+- `apps/web/app/globals.css`
+- Header/footer files
+- API paths
+- Concierge paths
+- Portal paths
+- PHI/PMS areas
+
+## Route / Design / Deploy Exclusion Check
+
+**Result:** `PASS`
+
+No route creation, route deletion, redesign, deployment, GBP update, analytics change, chatbot/portal change, API change, PHI/PMS change, scraping, browser automation, or live verification occurred during this validation.
+
+The build output lists existing routes as part of normal `next build`; this is not route creation or deletion.
+
+## Validation Command Results
+
+| Command | Result | Notes |
+| --- | --- | --- |
+| `node -e "...JSON.parse..."` | `PASS` | Parsed all changed JSON registry/report files. |
+| `git diff --name-only HEAD~1..HEAD` | `PASS` | Confirmed changed file list remained bounded to SEO registries and audit reports. |
+| `git diff --check` | `PASS` | No whitespace/conflict marker errors. |
+| `npm run lint` | `PASS` | Completed with existing Next lint deprecation/plugin notices; no ESLint errors. |
+| `npm run build` | `PASS` | Completed production build; emitted existing Browserslist/Tailwind/Next plugin warnings. |
+| `npm run seo:schema-qa` | `PASS` | Schema QA passed; no unsafe/unsupported/invented clinical or pricing/outcome findings. |
+| `npm run seo:answer-foundation-qa` | `PASS_WITH_WARNINGS` | Passed with answer length warnings and one veneers priority-service mapping warning. |
+| `npm run seo:answer-packet-qa` | `PASS` | Priority-service packet QA passed. |
+| `npm run guard:seo-launch-safety` | `PASS_WITH_WARNINGS` | Passed with launch-readiness warnings about missing section layouts and cannibalisation clusters to audit. |
+| `npm run guard:hero` | `PASS` | Hero guard and sacred hero lock passed. |
+| `npm run guard:canon` | `PASS` | Canon guard passed with existing environment/tooling notices. |
+| `npm run verify` | `PASS_WITH_WARNINGS` | Full verification passed; warnings were existing guard/tooling/SEO launch-readiness warnings, not patch blockers. |
+
+## Remaining Risks
+
+1. `seo:answer-foundation-qa` reports answer packet length warnings. These are not validation blockers, but should be handled in a future copy/answer-packet compression mission if desired.
+2. `seo:answer-foundation-qa` reports that `smh-treatment-fact-veneers-v1` maps to a service outside `approvedFacts.priorityServices`. This appears intentional as supporting broader veneer treatment intent, but should be reviewed in the next SEO registry governance pass.
+3. `guard:seo-launch-safety` reports existing launch-readiness warnings for treatment routes missing section layouts and high-risk cannibalisation clusters. These are outside the bounded patch but remain SEO launch risks.
+4. `npm run build`, `npm run lint`, and guard commands emit existing tooling warnings: Next lint deprecation, missing Next ESLint plugin, stale Browserslist data, and a Tailwind content glob performance warning.
+5. This validation did not perform live verification, scraping, browser automation, GBP checks, deployment checks, analytics checks, or external citation verification, per mission restrictions.
+
+## Rollback Notes
+
+If rollback is required, revert the bounded implementation commit:
+
+```bash
+git revert 75d90c7
+```
+
+Expected rollback scope is limited to:
+
+- `packages/champagne-manifests/data/seo/local-identity.smh.json`
+- `packages/champagne-manifests/data/seo/approved-facts.smh.json`
+- `packages/champagne-manifests/data/seo-ai-answer-foundation/ai-answer-registry.v1.smh.json`
+- `packages/champagne-manifests/data/seo-ai-answer-foundation/treatment-fact-registry.v1.smh.json`
+- `tools/audits/seo-bounded-implementation/CHAMPAGNE_SEO_BOUNDED_IMPLEMENTATION_V1.md`
+- `tools/audits/seo-bounded-implementation/CHAMPAGNE_SEO_BOUNDED_IMPLEMENTATION_V1.json`
+
+Post-rollback, rerun `git diff --check`, `npm run lint`, `npm run build`, and the SEO QA commands listed above.
+
+## Next Recommended Mission
+
+`CHAMPAGNE_SEO_ANSWER_PACKET_COMPRESSION_AND_VENEERS_PRIORITY_REVIEW_V1`
+
+Recommended scope:
+
+- Resolve `seo:answer-foundation-qa` answer-length warnings without changing clinical meaning.
+- Decide whether `veneers` should be explicitly represented in `approvedFacts.priorityServices`, remain a supporting non-priority treatment fact, or be excluded from the priority service fact registry.
+- Preserve the current canonical split:
+  - 3D dentistry capability intent -> `/treatments/3d-dentistry-and-technology`
+  - same-day veneer/crown workflow intent -> `/treatments/3d-digital-dentistry`
+  - broader veneers treatment intent -> `/treatments/veneers`
+
+## Final Validation Result
+
+**Overall:** `PASS_WITH_WARNINGS`
+
+The bounded Champagne SEO implementation patch is valid JSON, remains claim-safe, preserves local identity/NAP consistency, includes the required canonical mappings, maintains source-labelled bounded AI/treatment facts, avoids forbidden files, and passes required validation/build/guard commands. Remaining warnings are non-blocking governance/launch-readiness risks for future missions.


### PR DESCRIPTION
### Motivation

- Validate the bounded SEO registry implementation to ensure new registry fields are JSON-valid, claim-safe, and correctly source-labelled without touching forbidden zones. 
- Confirm canonical intent mapping for 3D dentistry and same-day veneers and verify AI/treatment registries remain bounded to approved evidence. 
- Produce an auditable post-patch report documenting checks, risks, rollback notes, and next recommended mission.

### Description

- Added a human-readable report `tools/audits/seo-post-patch-validation/CHAMPAGNE_SEO_POST_PATCH_VALIDATION_V1.md` and a machine-readable companion `tools/audits/seo-post-patch-validation/CHAMPAGNE_SEO_POST_PATCH_VALIDATION_V1.json` summarising the validation. 
- Inspected and validated changed registry/data files: `packages/champagne-manifests/data/seo/local-identity.smh.json`, `packages/champagne-manifests/data/seo/approved-facts.smh.json`, `packages/champagne-manifests/data/seo-ai-answer-foundation/ai-answer-registry.v1.smh.json`, and `packages/champagne-manifests/data/seo-ai-answer-foundation/treatment-fact-registry.v1.smh.json`. 
- Confirmed no forbidden files or sacred hero/manifests/layouts/routes/globals/footer/header/API/concierge/portal/PHI areas were touched and preserved assessment-gated language and evidence-source attribution. 
- Recorded canonical intent decisions preserved in the patch: `/treatments/3d-dentistry-and-technology` owns 3D capability intent and `/treatments/3d-digital-dentistry` owns same-day crowns/veneers workflow intent while `/treatments/veneers` remains supporting.

### Testing

- Ran JSON parse checks (`node -e

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a22dbbe48dc8332b0de4d6506e56c34)