### PR TITLE
Harden concierge /api/converse responses and audit forbidden runtime surfaces

### DIFF
--- a/apps/web/app/api/converse/route.test.ts
+++ b/apps/web/app/api/converse/route.test.ts
@@ -3,6 +3,7 @@ import { POST } from "./route";
 
 afterEach(() => {
   vi.restoreAllMocks();
+  delete process.env.CHATBOT_ENGINE_URL;
   delete process.env.NEXT_PUBLIC_CHATBOT_ENGINE_URL;
 });
 
@@ -22,7 +23,7 @@ describe("POST /api/converse", () => {
   it("forwards to engine with pageContext and optional debug header", async () => {
     process.env.NEXT_PUBLIC_CHATBOT_ENGINE_URL = "https://engine.test";
     const fetchMock = vi.fn().mockResolvedValue(
-      new Response(JSON.stringify({ content: "ok" }), {
+      new Response(JSON.stringify({ content: "ok", certification: "internal" }), {
         status: 201,
         headers: { "Content-Type": "application/json" },
       }),
@@ -84,5 +85,94 @@ describe("POST /api/converse", () => {
       },
       body: JSON.stringify({ text: "hello", pageContext: undefined }),
     });
+  });
+
+  it("filters forbidden public/runtime metadata and unsafe actions from successful responses", async () => {
+    process.env.CHATBOT_ENGINE_URL = "https://engine.test";
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          conversationId: " conversation-1 ",
+          content: "Captain certification readiness metadata should not render.",
+          certification: "DO_NOT_SHOW",
+          personality: { mode: "internal" },
+          ui: {
+            kind: "cards",
+            cards: [
+              {
+                title: "Safe options",
+                description: "Use contact or governed handoff routes only.",
+                actions: [
+                  { type: "link", label: "Contact", href: "/contact" },
+                  { type: "link", label: "Codex deploy bridge", href: "/api/dev/codex/deploy" },
+                  { type: "postback", label: "Booking request", payload: { kind: "handoff", form: "booking" } },
+                  { type: "postback", label: "Recall receptionist", payload: "RECALL" },
+                ],
+              },
+              {
+                title: "Dentally certification metadata",
+                description: "PMS agent runtime bridge",
+              },
+            ],
+          },
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const request = new Request("http://localhost/api/converse", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ text: "hello" }),
+    });
+
+    const response = await POST(request);
+    const payload = await response.json();
+    const publicText = JSON.stringify(payload);
+
+    expect(response.status).toBe(200);
+    expect(payload).toEqual({
+      conversationId: "conversation-1",
+      content: "I can guide you to safe contact options, but the practice team must advise on personal or urgent concerns.",
+      ui: {
+        kind: "cards",
+        cards: [
+          {
+            title: "Safe options",
+            description: "Use contact or governed handoff routes only.",
+            actions: [
+              { type: "link", label: "Contact", href: "/contact" },
+              { type: "postback", label: "Booking request", payload: JSON.stringify({ kind: "handoff", form: "booking" }) },
+            ],
+          },
+        ],
+      },
+    });
+    expect(publicText).not.toMatch(/certification|personality|codex|deploy|dentally|pms|agent runtime|receptionist|recall|DO_NOT_SHOW/i);
+  });
+
+  it("normalizes blocked upstream responses to safe public wording only", async () => {
+    process.env.CHATBOT_ENGINE_URL = "https://engine.test";
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ error: "Captain readiness certification blocked by internal policy" }), {
+        status: 403,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const request = new Request("http://localhost/api/converse", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ text: "hello" }),
+    });
+
+    const response = await POST(request);
+    const payload = await response.json();
+
+    expect(response.status).toBe(403);
+    expect(payload).toEqual({ error: "I could not complete that request just now. Please try again." });
+    expect(JSON.stringify(payload)).not.toMatch(/readiness|certification|internal/i);
   });
 });

--- a/apps/web/app/api/converse/route.ts
+++ b/apps/web/app/api/converse/route.ts
@@ -5,6 +5,182 @@ type ConverseRequest = {
   pageContext?: unknown;
 };
 
+type ConverseCardAction = {
+  type?: unknown;
+  label?: unknown;
+  href?: unknown;
+  payload?: unknown;
+};
+
+type ConverseCard = {
+  title?: unknown;
+  description?: unknown;
+  body?: unknown;
+  actions?: unknown;
+};
+
+type ConversePayload = {
+  conversationId?: unknown;
+  content?: unknown;
+  ui?: {
+    kind?: unknown;
+    cards?: unknown;
+  };
+};
+
+type SafeConverseAction =
+  | { type: "link"; label: string; href: string }
+  | { type: "postback"; label: string; payload: string };
+
+type SafeConverseCard = {
+  title?: string;
+  description?: string;
+  actions?: SafeConverseAction[];
+};
+
+type SafeConversePayload = {
+  conversationId?: string;
+  content: string;
+  ui?: {
+    kind: "cards";
+    cards: SafeConverseCard[];
+  };
+};
+
+const SAFE_PUBLIC_LINK_HREFS = new Set(["/contact"]);
+
+const SAFE_FALLBACK_CONTENT =
+  "I can guide you to safe contact options, but the practice team must advise on personal or urgent concerns.";
+
+const FORBIDDEN_PUBLIC_RESPONSE_PATTERN =
+  /(?:certification|readiness|personality|codex|agent\s+(?:execution|runtime|bridge)|dev\s+(?:execution|bridge|console)|dentally|pms|receptionist|recall|treatment coordinator|model\s+(?:call|activation)|memory|personalisation|personalization|phi|personal health information)/i;
+
+function isSafeUserFacingText(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0 && !FORBIDDEN_PUBLIC_RESPONSE_PATTERN.test(value);
+}
+
+function stringifySafeHandoffPayload(payload: unknown): string | null {
+  if (typeof payload === "string") {
+    return isSafeHandoffPayload(payload) ? payload : null;
+  }
+
+  if (!payload || typeof payload !== "object") {
+    return null;
+  }
+
+  const parsed = payload as { kind?: unknown; form?: unknown; type?: unknown };
+  if (parsed.kind === "handoff" && parsed.form === "booking") {
+    return JSON.stringify({ kind: "handoff", form: "booking" });
+  }
+
+  if (parsed.kind === "handoff" && parsed.form === "emergency_callback") {
+    return JSON.stringify({ kind: "handoff", form: "emergency_callback" });
+  }
+
+  if (parsed.kind === "handoff" && parsed.form === "new_patient") {
+    return JSON.stringify({ kind: "handoff", form: "new_patient" });
+  }
+
+  if (parsed.type === "BOOKING") {
+    return "BOOKING";
+  }
+
+  if (parsed.type === "EMERGENCY_CALLBACK") {
+    return "EMERGENCY_CALLBACK";
+  }
+
+  if (parsed.type === "NEW_PATIENT") {
+    return "NEW_PATIENT";
+  }
+
+  return null;
+}
+
+function isSafeHandoffPayload(payload: string): boolean {
+  const normalized = payload.trim();
+  return normalized === "BOOKING_REQUEST"
+    || normalized === "BOOKING"
+    || normalized === "EMERGENCY_CALLBACK"
+    || normalized === "NEW_PATIENT";
+}
+
+function isSafePublicLink(href: unknown): href is string {
+  if (typeof href !== "string") return false;
+  return SAFE_PUBLIC_LINK_HREFS.has(href) || href.startsWith("/contact?") || href.startsWith("/contact#");
+}
+
+function sanitizeConverseAction(action: ConverseCardAction): SafeConverseAction | null {
+  if (!isSafeUserFacingText(action.label)) {
+    return null;
+  }
+
+  if (action.type === "link" && isSafePublicLink(action.href)) {
+    return { type: "link", label: action.label, href: action.href };
+  }
+
+  if (action.type === "postback") {
+    const safePayload = stringifySafeHandoffPayload(action.payload);
+    if (safePayload) {
+      return { type: "postback", label: action.label, payload: safePayload };
+    }
+  }
+
+  return null;
+}
+
+function sanitizeConverseCard(card: ConverseCard): SafeConverseCard | null {
+  const title = isSafeUserFacingText(card.title) ? card.title : undefined;
+  const descriptionSource = card.description ?? card.body;
+  const description = isSafeUserFacingText(descriptionSource) ? descriptionSource : undefined;
+  const actions = Array.isArray(card.actions)
+    ? card.actions
+      .filter((action): action is ConverseCardAction => Boolean(action) && typeof action === "object")
+      .map(sanitizeConverseAction)
+      .filter((action): action is SafeConverseAction => Boolean(action))
+    : undefined;
+
+  if (!title && !description && !actions?.length) {
+    return null;
+  }
+
+  return {
+    ...(title ? { title } : {}),
+    ...(description ? { description } : {}),
+    ...(actions?.length ? { actions } : {}),
+  };
+}
+
+function sanitizeConversePayload(payload: unknown): SafeConversePayload {
+  const parsed = payload && typeof payload === "object" ? payload as ConversePayload : {};
+  const content = isSafeUserFacingText(parsed.content) ? parsed.content : SAFE_FALLBACK_CONTENT;
+  const cards = parsed.ui?.kind === "cards" && Array.isArray(parsed.ui.cards)
+    ? parsed.ui.cards
+      .filter((card): card is ConverseCard => Boolean(card) && typeof card === "object")
+      .map(sanitizeConverseCard)
+      .filter((card): card is SafeConverseCard => Boolean(card))
+    : [];
+
+  return {
+    ...(typeof parsed.conversationId === "string" && parsed.conversationId.trim().length > 0
+      ? { conversationId: parsed.conversationId.trim() }
+      : {}),
+    content,
+    ...(cards.length ? { ui: { kind: "cards" as const, cards } } : {}),
+  };
+}
+
+function safePublicErrorMessage(status: number): string {
+  if (status === 429) {
+    return "Concierge is a little busy right now. Please try again in a moment.";
+  }
+
+  if (status >= 500) {
+    return "Concierge is briefly unavailable. Please try again shortly.";
+  }
+
+  return "I could not complete that request just now. Please try again.";
+}
+
 function getEngineBaseUrl(): string {
   return process.env.CHATBOT_ENGINE_URL ?? process.env.NEXT_PUBLIC_CHATBOT_ENGINE_URL ?? "";
 }
@@ -45,6 +221,11 @@ export async function POST(request: Request) {
     body: JSON.stringify({ text, pageContext: body?.pageContext }),
   });
 
-  const payload = await upstreamResponse.json();
-  return NextResponse.json(payload, { status: upstreamResponse.status });
+  const payload = await upstreamResponse.json().catch(() => null);
+
+  if (!upstreamResponse.ok) {
+    return NextResponse.json({ error: safePublicErrorMessage(upstreamResponse.status) }, { status: upstreamResponse.status });
+  }
+
+  return NextResponse.json(sanitizeConversePayload(payload), { status: upstreamResponse.status });
 }

--- a/apps/web/app/components/concierge/_helpers/converseDisplay.test.ts
+++ b/apps/web/app/components/concierge/_helpers/converseDisplay.test.ts
@@ -72,4 +72,29 @@ describe("normalizeConverseDisplayMessage", () => {
     ]);
     expect(visibleMessageText(message)).not.toMatch(/dev bridge|dentally|recall|receptionist/i);
   });
+
+  it("falls back before rendering memory, model, PHI, readiness, or internal metadata claims", () => {
+    const message = normalizeConverseDisplayMessage(
+      {
+        content: "Captain memory and model activation readiness metadata should not render PHI claims.",
+        ui: {
+          kind: "cards",
+          cards: [
+            {
+              title: "Model call activation",
+              description: "Personalisation memory readiness and PHI routing",
+              actions: [{ type: "link", label: "Contact", href: "/contact" }],
+            },
+          ],
+        },
+      },
+      "forbidden-runtime-claims",
+    );
+
+    const visibleText = visibleMessageText(message);
+
+    expect(visibleText).toContain("I can guide you to safe contact options");
+    expect(visibleText).toContain("Contact");
+    expect(visibleText).not.toMatch(/memory|model activation|PHI|readiness|personalisation/i);
+  });
 });

--- a/apps/web/app/components/concierge/_helpers/converseDisplay.ts
+++ b/apps/web/app/components/concierge/_helpers/converseDisplay.ts
@@ -20,7 +20,7 @@ export type ConverseResponse = {
 const SAFE_PUBLIC_LINK_HREFS = new Set(["/contact"]);
 
 const FORBIDDEN_USER_FACING_METADATA_PATTERN =
-  /certification|personality|codex|agent\s+(?:execution|runtime|bridge)|dev\s+(?:execution|bridge|console)|dentally|pms|receptionist|recall|treatment coordinator/i;
+  /certification|readiness|personality|codex|agent\s+(?:execution|runtime|bridge)|dev\s+(?:execution|bridge|console)|dentally|pms|receptionist|recall|treatment coordinator|model\s+(?:call|activation)|memory|personalisation|personalization|phi|personal health information/i;
 
 function isSafeUserFacingText(value: string | undefined): value is string {
   return typeof value === "string" && !FORBIDDEN_USER_FACING_METADATA_PATTERN.test(value);

--- a/reports/M28B_CHAMPAGNE_005_FORBIDDEN_RUNTIME_SURFACE_AUDIT_REPORT_V1.md
+++ b/reports/M28B_CHAMPAGNE_005_FORBIDDEN_RUNTIME_SURFACE_AUDIT_REPORT_V1.md
@@ -1,0 +1,136 @@
+# M28B_CHAMPAGNE_005_FORBIDDEN_RUNTIME_SURFACE_AUDIT_REPORT_V1
+
+Generated: 2026-06-05
+
+## Scope
+
+Split packet: `M28B-CHAMPAGNE-005-FORBIDDEN-RUNTIME-SURFACE-AUDIT`.
+
+This audit checked the champagne website repo only. It did not start M29, approve launch, approve production certification, modify any agent repo, or modify `champagne-chatbot-engine`.
+
+## Files searched
+
+Targeted public/runtime surfaces searched:
+
+- `apps/web/app/api/converse/route.ts`
+- `apps/web/app/api/converse/route.test.ts`
+- `apps/web/app/api/handoff/_shared.ts`
+- `apps/web/app/api/handoff/booking/route.ts`
+- `apps/web/app/api/handoff/booking/route.test.ts`
+- `apps/web/app/api/handoff/emergency-callback/route.ts`
+- `apps/web/app/api/handoff/emergency-callback/route.test.ts`
+- `apps/web/app/api/handoff/new-patient/route.ts`
+- `apps/web/app/api/handoff/new-patient/route.test.ts`
+- `apps/web/app/components/concierge/ConciergeLayer.tsx`
+- `apps/web/app/components/concierge/ConciergeShell.tsx`
+- `apps/web/app/components/concierge/ConciergeRoute.runtime-proof.test.ts`
+- `apps/web/app/components/concierge/ConciergeShell.boundary-copy.test.ts`
+- `apps/web/app/components/concierge/_helpers/converseDisplay.ts`
+- `apps/web/app/components/concierge/_helpers/converseDisplay.test.ts`
+- `apps/web/app/components/concierge/_helpers/sessionMemory.ts`
+- `apps/web/app/components/concierge/_helpers/sessionMemory.test.ts`
+- `apps/web/app/components/concierge/_handoff/HandoffModal.tsx`
+- `apps/web/app/components/concierge/_handoff/HandoffModal.fallback-copy.test.ts`
+- `apps/web/app/components/concierge/_handoff/postbackRouter.ts`
+- `apps/web/app/components/concierge/_handoff/postbackRouter.test.ts`
+- `apps/web/app/contact/page.tsx`
+- `apps/web/app/champagne/hero-lab/concierge/page.tsx`
+- `apps/web/app/_components/concierge/ConciergePreview.tsx`
+- `apps/web/app/_components/concierge/ConciergePreview.module.css`
+
+Broader repo scan roots searched: `apps/web/app`, `packages`, `scripts`, and `reports`.
+
+## Search patterns used
+
+- File locator: `rg --files apps/web/app | rg 'api/(converse|handoff)|components/concierge|contact|booking|hero-lab/concierge'`
+- Forbidden runtime/public terms: `PHI|personal health information|memory|personalisation|personalization|model call|model activation|agent runtime|agent execution|PMS|Dentally|receptionist|recall|treatment coordinator|Codex|apply|dispatch|deploy|Captain.*readiness|readiness|personality|certification`
+- Public concierge link/API/storage inspection: `href=|/api/|fetch\(|window\.sessionStorage|localStorage|CHATBOT_ENGINE_URL|HANDOFF_.*WEBHOOK`
+- Dev bridge exposure scan: `codex|agent\s+(runtime|execution|bridge)|dev\s+(bridge|console|execution)|apply|dispatch|deploy`
+- Handoff/contact safety scan: `href=|/contact|/api/handoff|resolveHandoffEndpoint|HANDOFF_.*WEBHOOK|confirmed|confirm`
+
+## Findings
+
+### Public concierge UI
+
+PASS after remediation.
+
+- Boundary copy states Captain is a public concierge, not a clinician; prohibits diagnosis, triage, treatment-specific clinical advice, and personal health information; and states handoffs do not confirm appointments.
+- The UI stores only bounded session-local navigation state, intent stage, topic hints, and conversation id in `window.sessionStorage`. This is session-local UI state, not a public promise of memory/personalisation, and no PHI storage claim is rendered.
+- Debug state is gated out of production (`process.env.NODE_ENV !== "production"`) and is not shown publicly in production.
+- Response rendering filters forbidden user-facing text and unsafe actions before display.
+
+### `/api/converse`
+
+BLOCKED before remediation; PASS after remediation.
+
+- Finding: the public API previously proxied the upstream engine JSON payload directly to the browser. That meant forbidden upstream fields or unsafe action links could become public/runtime-facing at the network response layer even if the client UI filtered visible rendering.
+- Remediation: the route now normalizes successful upstream responses to safe `content`, optional `conversationId`, and safe card UI only. It drops forbidden internal metadata, forbidden text, unsafe links, unsafe postbacks, dev/Codex/deploy bridge actions, PMS/Dentally references, receptionist/recall/treatment-coordinator actions, memory/personalisation claims, PHI claims, model activation wording, and internal readiness/personality/certification wording.
+- Remediation: blocked/non-OK upstream responses now return safe public wording only and do not echo internal upstream errors.
+- The route still forwards to the configured chatbot engine endpoint when configured; this audit did not introduce model calls and found no direct model SDK/model-call implementation in the champagne website repo public runtime. Engine behavior remains outside this repo/packet.
+
+### `/api/handoff/*`
+
+PASS.
+
+- Handoff endpoints validate narrow request schemas, use honeypot/timing/rate-limit controls, and forward to configured webhook URLs only.
+- Runtime responses are canonical safe JSON such as `ok`, invalid request, rate limit, missing configuration, or failed send. They do not expose webhook bodies, Dentally/PMS internals, receptionist/recall/treatment-coordinator activation, or confirmed-booking language.
+- The audit found no PMS/Dentally mutation code in these website endpoints.
+
+### Contact/booking handoff surfaces
+
+PASS.
+
+- Public links remain constrained to `/contact` or governed handoff routes: `/api/handoff/booking`, `/api/handoff/emergency-callback`, and `/api/handoff/new-patient`.
+- Handoff modal copy states requests are handoffs only and not confirmed appointments.
+- Form labels ask for non-sensitive summaries only and warn not to include personal health information or sensitive details.
+
+### Route/runtime proof tests
+
+PASS.
+
+- Existing runtime proof tests cover public concierge mounting, visible boundary copy, safe handoff routing, and absence of forbidden route/runtime strings.
+- New targeted tests cover `/api/converse` response filtering and blocked upstream safe wording, plus client display fallback filtering for memory/model/PHI/readiness/internal claims.
+
+### Broad scan false positives / future-planning only evidence
+
+- `scripts/**` and `reports/**` contain audit/reporting/build terms such as readiness, launch disclaimers, PHI guard names, and route QA. These are not public runtime UI/API surfaces.
+- `packages/champagne-manifests/data/seo-ai-answer-foundation/**` and SEO/local identity data include public content terms such as hygiene/recall as service content. This is public informational content/future planning data, not receptionist/recall activation or PMS mutation.
+- Hero/debug and canon files include generic `apply` function names or canon references. These are not dev/Codex/apply/dispatch/deploy execution bridges exposed by the concierge or handoff runtime.
+
+## Verdict
+
+PASS after narrow remediation.
+
+## Forbidden public/runtime surface status
+
+- PHI collection/storage in public concierge: no forbidden PHI collection/storage found. Public copy warns users not to submit PHI/sensitive details.
+- Memory/personalisation claims: no public claim after remediation; response filters block memory/personalisation wording.
+- Model call activation exposed to public route: no direct public model SDK/model-call implementation found in the champagne website repo; `/api/converse` remains a configured engine proxy but now filters public responses.
+- Agent runtime execution: not found in public concierge, `/api/converse`, `/api/handoff`, contact, or booking handoff runtime surfaces.
+- PMS/Dentally mutation: not found in website runtime surfaces.
+- Receptionist activation: not found.
+- Recall activation: not found; broad references are public SEO/service content or blocked test fixtures only.
+- Treatment coordinator activation: not found.
+- Dev/Codex/apply/dispatch/deploy bridge exposure: not found in public concierge/handoff runtime; unsafe action links are filtered by `/api/converse` and client display normalization.
+- Internal Captain readiness/personality/certification metadata rendered publicly: blocked at `/api/converse` and client display normalization after remediation.
+
+## Public/runtime-facing vs future/planning evidence
+
+- Public/runtime-facing evidence before remediation: `/api/converse` could echo arbitrary upstream JSON to the browser.
+- Public/runtime-facing evidence after remediation: successful responses render only safe user-facing content/actions; blocked responses return safe wording only; unsafe actions/metadata are filtered or absent.
+- Future/planning-only evidence: broad scan matches in `reports/**`, `scripts/**`, and SEO/canon packages are audit/build/SEO content and not public concierge/handoff runtime activation.
+
+## Tests run
+
+- `pnpm exec vitest run apps/web/app/api/converse/route.test.ts apps/web/app/api/handoff/booking/route.test.ts apps/web/app/api/handoff/new-patient/route.test.ts apps/web/app/api/handoff/emergency-callback/route.test.ts apps/web/app/components/concierge/_helpers/converseDisplay.test.ts apps/web/app/components/concierge/_handoff/postbackRouter.test.ts apps/web/app/components/concierge/_handoff/HandoffModal.fallback-copy.test.ts apps/web/app/components/concierge/ConciergeShell.boundary-copy.test.ts apps/web/app/components/concierge/ConciergeRoute.runtime-proof.test.ts`
+- `pnpm run lint`
+- `pnpm run build`
+- `npm run guard:hero`
+- `npm run guard:canon`
+- `npm run verify`
+
+## Explicit packet constraints statement
+
+No M29 was started. No launch approval was made. No production certification was made.
+
+This packet introduced no PHI, no memory, no model calls, no agent runtime calls, no PMS/Dentally mutation, no receptionist logic, no recall logic, no treatment coordinator logic, no dev/Codex/apply/dispatch/deploy bridge, and no public internal Captain readiness/personality/certification metadata.


### PR DESCRIPTION
### Motivation

- Audit the public website for forbidden runtime/public surfaces (PHI, memory/personalisation, model/agent activation, PMS/Dentally mutation, receptionist/recall/treatment-coordinator activation, dev/Codex bridges) and ensure user-facing surfaces only expose safe text/actions.
- Prevent upstream engine internals or internal metadata from being echoed to public clients by normalizing/proxying behavior at the site boundary.

### Description

- Hardened `/api/converse` to sanitize upstream engine payloads and return a narrow, safe shape (`content`, optional `conversationId`, and safe `cards` with only `/contact` links or governed handoff postbacks), and to normalize blocked/non-OK upstream responses to safe public wording only (`apps/web/app/api/converse/route.ts`).
- Added defensive client-side filtering to the concierge display to block readiness, model activation, memory/personalisation, PHI, Dev/Codex, PMS/Dentally, receptionist/recall, and other internal metadata from rendering (`apps/web/app/components/concierge/_helpers/converseDisplay.ts`).
- Added targeted tests that assert `/api/converse` filters forbidden metadata/actions and that the client display falls back for memory/model/PHI/internal claims (`apps/web/app/api/converse/route.test.ts`, `apps/web/app/components/concierge/_helpers/converseDisplay.test.ts`).
- Included the audit report `reports/M28B_CHAMPAGNE_005_FORBIDDEN_RUNTIME_SURFACE_AUDIT_REPORT_V1.md` listing files searched, search patterns, findings, verdict (PASS after narrow remediation), and the explicit no-M29/no-launch/no-production-certification and no-forbidden-runtime statements.

### Testing

- Ran unit/runtime tests: `pnpm exec vitest run .../converse/route.test.ts .../handoff/*.route.test.ts .../converseDisplay.test.ts` and all targeted test files passed (33 tests across concierge/handoff/converse suites).
- Ran repo checks: `pnpm run lint` completed successfully and `pnpm run build` (Next build) completed successfully (tooling warnings were emitted but did not fail the commands).
- Ran guards and verify: `npm run guard:hero`, `npm run guard:canon`, and `npm run verify` completed and reported guard/verify success for the relevant checks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a22dc6f10048332a0214ec04c3ec8c4)