### PR TITLE
Harden SEO launch-safety guard and refresh treatment inventory

### DIFF
--- a/REPORTS/TREATMENT_INVENTORY.md
+++ b/REPORTS/TREATMENT_INVENTORY.md
@@ -1,91 +1,112 @@
 # Treatment Inventory
 
-## A. Canonical registry sources
-- Machine manifest: `packages/champagne-manifests/data/champagne_machine_manifest_full.json`
-- Section layout registry: `packages/champagne-manifests/src/core.ts` (imports + `champagneSectionLayouts`)
+Generated from live `packages/champagne-manifests/data/champagne_machine_manifest_full.json` treatment routes and registered `champagneSectionLayouts` entries in `packages/champagne-manifests/src/core.ts`.
 
-## B. Full treatment list
-| treatmentTitle | slug | route | machineManifestId | category/group | sectionLayoutFile | existsOnDisk | notes |
-| --- | --- | --- | --- | --- | --- | --- | --- |
-| 3D dentistry & technology | 3d-dentistry-and-technology | /treatments/3d-dentistry-and-technology | 3d_dentistry_and_technology | technology | packages/champagne-manifests/data/sections/smh/treatments.3d-dentistry-and-technology.json | YES | — |
-| 3D & digital dentistry | 3d-digital-dentistry | /treatments/3d-digital-dentistry | technology_digital_dentistry | treatment | packages/champagne-manifests/data/sections/smh/treatments.3d-digital-dentistry.json | YES | — |
-| 3D implant restorations | 3d-implant-restorations | /treatments/3d-implant-restorations | 3d_implant_restorations | treatment | packages/champagne-manifests/data/sections/smh/treatments.3d-implant-restorations.json | YES | — |
-| 3D printed dentures | 3d-printed-dentures | /treatments/3d-printed-dentures | printed_dentures_3d | treatment | packages/champagne-manifests/data/sections/smh/treatments.3d-printed-dentures.json | YES | — |
-| 3D printed veneers | 3d-printed-veneers | /treatments/3d-printed-veneers | 3d_printed_veneers | treatment | packages/champagne-manifests/data/sections/smh/treatments.3d-printed-veneers.json | YES | — |
-| 3D printing lab | 3d-printing-lab | /treatments/3d-printing-lab | 3d_printing_lab | treatment | packages/champagne-manifests/data/sections/smh/treatments.3d-printing-lab.json | YES | — |
-| Acrylic dentures | acrylic-dentures | /treatments/acrylic-dentures | acrylic_dentures | treatment | packages/champagne-manifests/data/sections/smh/treatments.acrylic-dentures.json | YES | — |
-| Prescription anti-wrinkle treatments | anti-wrinkle-treatments | /treatments/anti-wrinkle-treatments | anti_wrinkle_treatments | treatment | packages/champagne-manifests/data/sections/smh/treatments.anti-wrinkle-treatments.json | YES | — |
-| Broken, chipped or cracked teeth | broken-chipped-cracked-teeth | /treatments/broken-chipped-cracked-teeth | emergency_broken_chipped_teeth | treatment | — | NO | — |
-| Bruxism and jaw clenching treatment | bruxism-and-jaw-clenching | /treatments/bruxism-and-jaw-clenching | bruxism_jaw_clenching | treatment | packages/champagne-manifests/data/sections/smh/treatments.bruxism-and-jaw-clenching.json | YES | — |
-| CBCT / 3D scanning | cbct-3d-scanning | /treatments/cbct-3d-scanning | cbct_3d_scanning | treatment | packages/champagne-manifests/data/sections/smh/treatments.cbct-3d-scanning.json | YES | — |
-| Children’s dentistry | childrens-dentistry | /treatments/childrens-dentistry | childrens_dentistry | treatment | packages/champagne-manifests/data/sections/smh/treatments.childrens-dentistry.json | YES | — |
-| Chrome dentures | chrome-dentures | /treatments/chrome-dentures | chrome_dentures | treatment | packages/champagne-manifests/data/sections/smh/treatments.chrome-dentures.json | YES | — |
-| Clear Aligners in Shoreham-by-Sea | clear-aligners | /treatments/clear-aligners | clear_aligners | — | packages/champagne-manifests/data/sections/smh/treatments.clear-aligners.json | YES | — |
-| Spark clear aligners in Shoreham-by-Sea | clear-aligners-spark | /treatments/clear-aligners-spark | clear_aligners_spark | treatment | packages/champagne-manifests/data/sections/smh/treatments.clear-aligners-spark.json | YES | — |
-| Composite bonding | composite-bonding | /treatments/composite-bonding | composite_bonding | treatment | — | NO | — |
-| Dental abscess & infection | dental-abscess-infection | /treatments/dental-abscess-infection | emergency_dental_abscess | treatment | — | NO | — |
-| Dental bridges | dental-bridges | /treatments/dental-bridges | dental_bridges | treatment | packages/champagne-manifests/data/sections/smh/treatments.dental-bridges.json | YES | — |
-| Dental crowns | dental-crowns | /treatments/dental-crowns | dental_crowns | treatment | packages/champagne-manifests/data/sections/smh/treatments.dental-crowns.json | YES | — |
-| Dental retainers | dental-retainers | /treatments/dental-retainers | dental_retainers | treatment | packages/champagne-manifests/data/sections/smh/treatments.dental-retainers.json | YES | — |
-| Dental trauma & accidents | dental-trauma-accidents | /treatments/dental-trauma-accidents | emergency_dental_trauma | treatment | — | NO | — |
-| Dentures & tooth replacement | dentures | /treatments/dentures | dentures | treatment | packages/champagne-manifests/data/sections/smh/treatments.dentures.json | YES | — |
-| Dermal fillers with medical oversight | dermal-fillers | /treatments/dermal-fillers | dermal_fillers | treatment | packages/champagne-manifests/data/sections/smh/treatments.dermal-fillers.json | YES | — |
-| Digital smile design | digital-smile-design | /treatments/digital-smile-design | digital_smile_design | treatment | packages/champagne-manifests/data/sections/smh/treatments.digital-smile-design.json | YES | — |
-| Emergency dental appointments | emergency-dental-appointments | /treatments/emergency-dental-appointments | emergency_dental_appointments | treatment | — | NO | — |
-| Emergency dentistry | emergency-dentistry | /treatments/emergency-dentistry | emergency_dentistry | treatment | — | NO | — |
-| Endodontics & root canal care | endodontics-root-canal | /treatments/endodontics-root-canal | endodontics_root_canal | treatment | packages/champagne-manifests/data/sections/smh/treatments.endodontics-root-canal.json | YES | — |
-| Extractions & oral surgery | extractions-and-oral-surgery | /treatments/extractions-and-oral-surgery | extractions_and_oral_surgery | treatment | packages/champagne-manifests/data/sections/smh/treatments.extractions-and-oral-surgery.json | YES | — |
-| Facial aesthetics hub | facial-aesthetics | /treatments/facial-aesthetics | facial_aesthetics | hub | packages/champagne-manifests/data/sections/smh/treatments.facial-aesthetics.json | YES | — |
-| Facial pain and headache pathways | facial-pain-and-headache | /treatments/facial-pain-and-headache | facial_pain_headache | treatment | packages/champagne-manifests/data/sections/smh/treatments.facial-pain-and-headache.json | YES | — |
-| Facial therapeutics in Shoreham-by-Sea | facial-therapeutics | /treatments/facial-therapeutics | facial_therapeutics | hub | packages/champagne-manifests/data/sections/smh/treatments.facial-therapeutics.json | YES | — |
-| Failed implant replacement in Shoreham-by-Sea | failed-implant-replacement | /treatments/failed-implant-replacement | implants_failed_replacement | treatment | packages/champagne-manifests/data/sections/smh/treatments.implants-failed-replacement.json | YES | — |
-| Fixed braces | fixed-braces | /treatments/fixed-braces | fixed_braces | treatment | packages/champagne-manifests/data/sections/smh/treatments.fixed-braces.json | YES | — |
-| Full smile makeover | full-smile-makeover | /treatments/full-smile-makeover | full_smile_makeover | treatment | — | NO | — |
-| Home teeth whitening | home-teeth-whitening | /treatments/home-teeth-whitening | home_teeth_whitening | treatment | packages/champagne-manifests/data/sections/smh/treatments.home-teeth-whitening.json | YES | — |
-| Implant aftercare & recovery in Shoreham-by-Sea | implant-aftercare | /treatments/implant-aftercare | implants_aftercare | treatment | packages/champagne-manifests/data/sections/smh/treatments.implants-aftercare.json | YES | — |
-| Implant consultation & planning in Shoreham-by-Sea | implant-consultation | /treatments/implant-consultation | implants_consultation | treatment | packages/champagne-manifests/data/sections/smh/treatments.implants-consultation.json | YES | — |
-| Implant-retained dentures | implant-retained-dentures | /treatments/implant-retained-dentures | implant_retained_dentures | treatment | packages/champagne-manifests/data/sections/smh/treatments.implants-retained-dentures.json | YES | — |
-| Dental Implants in Shoreham-by-Sea | implants | /treatments/implants | implants | — | packages/champagne-manifests/data/sections/smh/treatments.implants.json | YES | — |
-| Bone grafting for dental implants | implants-bone-grafting | /treatments/implants-bone-grafting | implants_bone_grafting | treatment | packages/champagne-manifests/data/sections/smh/treatments.implants-bone-grafting.json | YES | — |
-| Full arch implant rehabilitation | implants-full-arch | /treatments/implants-full-arch | implants_full_arch | treatment | packages/champagne-manifests/data/sections/smh/treatments.implants-full-arch.json | YES | — |
-| Multiple teeth implant options | implants-multiple-teeth | /treatments/implants-multiple-teeth | implants_multiple_teeth | treatment | packages/champagne-manifests/data/sections/smh/treatments.implants-multiple-teeth.json | YES | — |
-| Single-tooth dental implants in Shoreham-by-Sea | implants-single-tooth | /treatments/implants-single-tooth | implants_single_tooth | treatment | packages/champagne-manifests/data/sections/smh/treatments.implants-single-tooth.json | YES | — |
-| Injection-moulded composite | injection-moulded-composite | /treatments/injection-moulded-composite | injection_moulded_composite | treatment | — | NO | — |
-| Inlays & onlays | inlays-onlays | /treatments/inlays-onlays | inlays_onlays | treatment | packages/champagne-manifests/data/sections/smh/treatments.inlays-onlays.json | YES | — |
-| Knocked-out (avulsed) tooth | knocked-out-tooth | /treatments/knocked-out-tooth | emergency_knocked_out_tooth | treatment | — | NO | — |
-| Lost crowns, veneers & fillings | lost-crowns-veneers-fillings | /treatments/lost-crowns-veneers-fillings | emergency_lost_crowns | treatment | — | NO | — |
-| Mouthguards & retainers | mouthguards-and-retainers | /treatments/mouthguards-and-retainers | mouthguards_and_retainers | treatment | packages/champagne-manifests/data/sections/smh/treatments.mouthguards-and-retainers.json | YES | — |
-| Nervous patients | nervous-patients | /treatments/nervous-patients | nervous_patients | treatment | packages/champagne-manifests/data/sections/smh/treatments.nervous-patients.json | YES | — |
-| Night guards (occlusal splints) | night-guards-occlusal-splints | /treatments/night-guards-occlusal-splints | night_guards_occlusal_splints | treatment | packages/champagne-manifests/data/sections/smh/treatments.night-guards-occlusal-splints.json | YES | — |
-| Orthodontics | orthodontics | /treatments/orthodontics | orthodontics | treatment | packages/champagne-manifests/data/sections/smh/treatments.orthodontics.json | YES | — |
-| Painless numbing with The Wand | painless-numbing-the-wand | /treatments/painless-numbing-the-wand | painless_numbing_the_wand | treatment | packages/champagne-manifests/data/sections/smh/treatments.painless-numbing-the-wand.json | YES | — |
-| PEEK partial dentures | peek-partial-dentures | /treatments/peek-partial-dentures | peek_partial_dentures | treatment | packages/champagne-manifests/data/sections/smh/treatments.peek-partial-dentures.json | YES | — |
-| Periodontal & gum care | periodontal-gum-care | /treatments/periodontal-gum-care | periodontal_gum_care | treatment | packages/champagne-manifests/data/sections/smh/treatments.periodontal-gum-care.json | YES | — |
-| Polynucleotide treatments to support skin quality | polynucleotides | /treatments/polynucleotides | polynucleotides | treatment | packages/champagne-manifests/data/sections/smh/treatments.polynucleotides.json | YES | — |
-| Preventative & general dentistry | preventative-and-general-dentistry | /treatments/preventative-and-general-dentistry | preventative_and_general_dentistry | treatment | packages/champagne-manifests/data/sections/smh/treatments.preventative-and-general-dentistry.json | YES | — |
-| Sedation dentistry | sedation-dentistry | /treatments/sedation-dentistry | sedation_dentistry | treatment | packages/champagne-manifests/data/sections/smh/treatments.sedation-dentistry.json | YES | — |
-| Sedation for dental implant treatment in Shoreham-by-Sea | sedation-for-implants | /treatments/sedation-for-implants | implants_sedation | treatment | packages/champagne-manifests/data/sections/smh/treatments.implants-sedation.json | YES | — |
-| Senior & mature smile care | senior-mature-smile-care | /treatments/senior-mature-smile-care | senior_mature_smile_care | treatment | packages/champagne-manifests/data/sections/smh/treatments.senior-mature-smile-care.json | YES | — |
-| Severe toothache & dental pain | severe-toothache-dental-pain | /treatments/severe-toothache-dental-pain | emergency_severe_toothache | treatment | — | NO | — |
-| Sinus lift for dental implants in Shoreham-by-Sea | sinus-lift | /treatments/sinus-lift | implants_sinus_lift | treatment | packages/champagne-manifests/data/sections/smh/treatments.implants-sinus-lift.json | YES | — |
-| Skin boosters for hydration and elasticity | skin-boosters | /treatments/skin-boosters | skin_boosters | treatment | packages/champagne-manifests/data/sections/smh/treatments.skin-boosters.json | YES | — |
-| Sports mouthguards | sports-mouthguards | /treatments/sports-mouthguards | sports_mouthguards | treatment | packages/champagne-manifests/data/sections/smh/treatments.sports-mouthguards.json | YES | — |
-| Teeth-in-a-Day implants in Shoreham-by-Sea | teeth-in-a-day | /treatments/teeth-in-a-day | implants_teeth_in_a_day | treatment | packages/champagne-manifests/data/sections/smh/treatments.implants-teeth-in-a-day.json | YES | — |
-| Teeth whitening | teeth-whitening | /treatments/teeth-whitening | whitening_hub | treatment | packages/champagne-manifests/data/sections/smh/treatments.teeth-whitening.json | YES | — |
-| Teeth whitening FAQs | teeth-whitening-faqs | /treatments/teeth-whitening-faqs | whitening_faq | treatment | packages/champagne-manifests/data/sections/smh/treatments.teeth-whitening-faqs.json | YES | — |
-| Therapeutic facial injectables | therapeutic-facial-injectables | /treatments/therapeutic-facial-injectables | therapeutic_facial_injectables | treatment | packages/champagne-manifests/data/sections/smh/treatments.therapeutic-facial-injectables.json | YES | — |
-| TMJ disorder treatment | tmj-disorder-treatment | /treatments/tmj-disorder-treatment | tmj_disorder_treatment | treatment | packages/champagne-manifests/data/sections/smh/treatments.tmj-disorder-treatment.json | YES | — |
-| TMJ & jaw comfort | tmj-jaw-comfort | /treatments/tmj-jaw-comfort | tmj_jaw_comfort | treatment | packages/champagne-manifests/data/sections/smh/treatments.tmj-jaw-comfort.json | YES | — |
-| Tooth Wear & Broken Teeth | tooth-wear-broken-teeth | /treatments/tooth-wear-broken-teeth | tooth_wear_broken_teeth | treatment | — | NO | — |
-| — | veneers | /treatments/veneers | veneers | — | packages/champagne-manifests/data/sections/smh/treatments.veneers.json | YES | — |
-| Sensitive teeth & whitening | whitening-sensitive-teeth | /treatments/whitening-sensitive-teeth | whitening_sensitivity | treatment | packages/champagne-manifests/data/sections/smh/treatments.whitening-sensitive-teeth.json | YES | — |
-| Whitening top-ups & maintenance | whitening-top-ups | /treatments/whitening-top-ups | whitening_topups | treatment | packages/champagne-manifests/data/sections/smh/treatments.whitening-top-ups.json | YES | — |
+## A. Registered treatment routes
+
+| Label | Source key | Route | Route ID | Source collection | Registered section layout file | Registered sections | Section layout registered | Notes |
+| --- | --- | --- | --- | --- | --- | ---: | --- | --- |
+| 3D dentistry & technology | 3d_dentistry_and_technology | /treatments/3d-dentistry-and-technology | treatments.3d-dentistry-and-technology | pages | packages/champagne-manifests/data/sections/smh/treatments.3d-dentistry-and-technology.json | 11 | YES | — |
+| 3D & digital dentistry | technology_digital_dentistry | /treatments/3d-digital-dentistry | treatments.3d-digital-dentistry | pages | packages/champagne-manifests/data/sections/smh/treatments.3d-digital-dentistry.json | 11 | YES | — |
+| 3D implant restorations | 3d_implant_restorations | /treatments/3d-implant-restorations | treatments.3d-implant-restorations | pages | packages/champagne-manifests/data/sections/smh/treatments.3d-implant-restorations.json | 11 | YES | — |
+| 3D printed dentures | printed_dentures_3d | /treatments/3d-printed-dentures | treatments.3d-printed-dentures | pages | packages/champagne-manifests/data/sections/smh/treatments.3d-printed-dentures.json | 11 | YES | — |
+| 3D printed veneers | 3d_printed_veneers | /treatments/3d-printed-veneers | treatments.3d-printed-veneers | pages | packages/champagne-manifests/data/sections/smh/treatments.3d-printed-veneers.json | 14 | YES | — |
+| 3D printing lab | 3d_printing_lab | /treatments/3d-printing-lab | treatments.3d-printing-lab | pages | packages/champagne-manifests/data/sections/smh/treatments.3d-printing-lab.json | 11 | YES | — |
+| Acrylic dentures | acrylic_dentures | /treatments/acrylic-dentures | treatments.acrylic-dentures | pages | packages/champagne-manifests/data/sections/smh/treatments.acrylic-dentures.json | 11 | YES | — |
+| Anti-wrinkle treatments | anti_wrinkle_treatments | /treatments/anti-wrinkle-treatments | treatments.anti-wrinkle-treatments | pages | packages/champagne-manifests/data/sections/smh/treatments.anti-wrinkle-treatments.json | 11 | YES | — |
+| Broken, chipped or cracked teeth | emergency_broken_chipped_teeth | /treatments/broken-chipped-cracked-teeth | treatments.broken-chipped-cracked-teeth | pages | packages/champagne-manifests/data/sections/smh/treatments.broken-chipped-cracked-teeth.json | 9 | YES | — |
+| Bruxism (grinding) and jaw clenching | bruxism_jaw_clenching | /treatments/bruxism-and-jaw-clenching | treatments.bruxism-and-jaw-clenching | pages | packages/champagne-manifests/data/sections/smh/treatments.bruxism-and-jaw-clenching.json | 11 | YES | — |
+| CBCT / 3D scanning | cbct_3d_scanning | /treatments/cbct-3d-scanning | treatments.cbct-3d-scanning | pages | packages/champagne-manifests/data/sections/smh/treatments.cbct-3d-scanning.json | 11 | YES | — |
+| Children’s dentistry | childrens_dentistry | /treatments/childrens-dentistry | treatments.childrens-dentistry | pages | packages/champagne-manifests/data/sections/smh/treatments.childrens-dentistry.json | 11 | YES | — |
+| Chrome dentures | chrome_dentures | /treatments/chrome-dentures | treatments.chrome-dentures | pages | packages/champagne-manifests/data/sections/smh/treatments.chrome-dentures.json | 11 | YES | — |
+| Clear Aligners in Shoreham-by-Sea | clear_aligners | /treatments/clear-aligners | treatments.clear-aligners | pages | packages/champagne-manifests/data/sections/smh/treatments.clear-aligners.json | 12 | YES | — |
+| Spark clear aligners in Shoreham-by-Sea | clear_aligners_spark | /treatments/clear-aligners-spark | treatments.clear-aligners-spark | pages | packages/champagne-manifests/data/sections/smh/treatments.clear-aligners-spark.json | 17 | YES | — |
+| Composite bonding | composite_bonding | /treatments/composite-bonding | treatments.composite-bonding | pages | packages/champagne-manifests/data/sections/smh/treatments.composite-bonding.json | 12 | YES | — |
+| Cosmetic dentistry | cosmetic_dentistry | /treatments/cosmetic-dentistry | treatments.cosmetic-dentistry | pages | packages/champagne-manifests/data/sections/smh/treatments.cosmetic-dentistry.json | 9 | YES | — |
+| Dental abscess & infection | emergency_dental_abscess | /treatments/dental-abscess-infection | treatments.dental-abscess-infection | pages | packages/champagne-manifests/data/sections/smh/treatments.dental-abscess-infection.json | 9 | YES | — |
+| Dental bridges | dental_bridges | /treatments/dental-bridges | treatments.dental-bridges | pages | packages/champagne-manifests/data/sections/smh/treatments.dental-bridges.json | 11 | YES | — |
+| Dental Check-Ups & Oral Cancer Screening | dental_checkups_oral_cancer_screening_treatments | /treatments/dental-checkups-oral-cancer-screening | treatments.dental-checkups-oral-cancer-screening | pages | packages/champagne-manifests/data/sections/smh/treatments.dental-checkups-oral-cancer-screening.json | 9 | YES | — |
+| Dental crowns | dental_crowns | /treatments/dental-crowns | treatments.dental-crowns | pages | packages/champagne-manifests/data/sections/smh/treatments.dental-crowns.json | 13 | YES | — |
+| Dental fillings | dental_fillings | /treatments/dental-fillings | treatments.dental-fillings | pages | packages/champagne-manifests/data/sections/smh/treatments.dental-fillings.json | 11 | YES | — |
+| Retainers | dental_retainers | /treatments/dental-retainers | treatments.dental-retainers | pages | packages/champagne-manifests/data/sections/smh/treatments.dental-retainers.json | 9 | YES | — |
+| Dental trauma & accidents | emergency_dental_trauma | /treatments/dental-trauma-accidents | treatments.dental-trauma-accidents | pages | packages/champagne-manifests/data/sections/smh/treatments.dental-trauma-accidents.json | 9 | YES | — |
+| Dentures & tooth replacement | dentures | /treatments/dentures | treatments.dentures | pages | packages/champagne-manifests/data/sections/smh/treatments.dentures.json | 11 | YES | — |
+| Dermal fillers | dermal_fillers | /treatments/dermal-fillers | treatments.dermal-fillers | pages | packages/champagne-manifests/data/sections/smh/treatments.dermal-fillers.json | 11 | YES | — |
+| Digital smile design | digital_smile_design | /treatments/digital-smile-design | treatments.digital-smile-design | pages | packages/champagne-manifests/data/sections/smh/treatments.digital-smile-design.json | 11 | YES | — |
+| Emergency dental appointments | emergency_dental_appointments | /treatments/emergency-dental-appointments | treatments.emergency-dental-appointments | pages | packages/champagne-manifests/data/sections/smh/treatments.emergency-dental-appointments.json | 9 | YES | — |
+| Emergency dentistry | emergency_dentistry | /treatments/emergency-dentistry | treatments.emergency-dentistry | pages | packages/champagne-manifests/data/sections/smh/treatments.emergency-dentistry.json | 11 | YES | — |
+| Endodontics & root canal care | endodontics_root_canal | /treatments/endodontics-root-canal | treatments.endodontics-root-canal | pages | packages/champagne-manifests/data/sections/smh/treatments.endodontics-root-canal.json | 12 | YES | — |
+| Extractions & oral surgery | extractions_and_oral_surgery | /treatments/extractions-and-oral-surgery | treatments.extractions-and-oral-surgery | pages | packages/champagne-manifests/data/sections/smh/treatments.extractions-and-oral-surgery.json | 12 | YES | — |
+| Facial aesthetics | facial_aesthetics | /treatments/facial-aesthetics | treatments.facial-aesthetics | pages | packages/champagne-manifests/data/sections/smh/treatments.facial-aesthetics.json | 10 | YES | — |
+| Facial pain and headache pathways | facial_pain_headache | /treatments/facial-pain-and-headache | treatments.facial-pain-and-headache | pages | packages/champagne-manifests/data/sections/smh/treatments.facial-pain-and-headache.json | 11 | YES | — |
+| Facial therapeutics in Shoreham-by-Sea | facial_therapeutics | /treatments/facial-therapeutics | treatments.facial-therapeutics | pages | packages/champagne-manifests/data/sections/smh/treatments.facial-therapeutics.json | 12 | YES | — |
+| Failed implant replacement in Shoreham-by-Sea | implants_failed_replacement | /treatments/failed-implant-replacement | treatments.failed-implant-replacement | pages | packages/champagne-manifests/data/sections/smh/treatments.failed-implant-replacement.json | 11 | YES | — |
+| Fixed braces | fixed_braces | /treatments/fixed-braces | treatments.fixed-braces | pages | packages/champagne-manifests/data/sections/smh/treatments.fixed-braces.json | 16 | YES | — |
+| Full smile makeover | full_smile_makeover | /treatments/full-smile-makeover | treatments.full-smile-makeover | pages | packages/champagne-manifests/data/sections/smh/treatments.full-smile-makeover.json | 8 | YES | — |
+| Home teeth whitening | home_teeth_whitening | /treatments/home-teeth-whitening | treatments.home-teeth-whitening | pages | packages/champagne-manifests/data/sections/smh/treatments.home-teeth-whitening.json | 10 | YES | — |
+| Implant aftercare & recovery in Shoreham-by-Sea | implants_aftercare | /treatments/implant-aftercare | treatments.implant-aftercare | pages | packages/champagne-manifests/data/sections/smh/treatments.implant-aftercare.json | 11 | YES | — |
+| Implant consultation & planning in Shoreham-by-Sea | implants_consultation | /treatments/implant-consultation | treatments.implant-consultation | pages | packages/champagne-manifests/data/sections/smh/treatments.implant-consultation.json | 11 | YES | — |
+| Implant-retained dentures | implant_retained_dentures | /treatments/implant-retained-dentures | treatments.implant-retained-dentures | pages | packages/champagne-manifests/data/sections/smh/treatments.implant-retained-dentures.json | 11 | YES | — |
+| Dental Implants in Shoreham-by-Sea | implants | /treatments/implants | treatments.implants | pages | packages/champagne-manifests/data/sections/smh/treatments.implants.json | 14 | YES | — |
+| Bone grafting for dental implants | implants_bone_grafting | /treatments/implants-bone-grafting | treatments.implants-bone-grafting | pages | packages/champagne-manifests/data/sections/smh/treatments.implants-bone-grafting.json | 11 | YES | — |
+| Full arch implant rehabilitation | implants_full_arch | /treatments/implants-full-arch | treatments.implants-full-arch | pages | packages/champagne-manifests/data/sections/smh/treatments.implants-full-arch.json | 11 | YES | — |
+| Multiple teeth implant options | implants_multiple_teeth | /treatments/implants-multiple-teeth | treatments.implants-multiple-teeth | pages | packages/champagne-manifests/data/sections/smh/treatments.implants-multiple-teeth.json | 11 | YES | — |
+| Single-tooth dental implants in Shoreham-by-Sea | implants_single_tooth | /treatments/implants-single-tooth | treatments.implants-single-tooth | pages | packages/champagne-manifests/data/sections/smh/treatments.implants-single-tooth.json | 11 | YES | — |
+| Injection-moulded composite | injection_moulded_composite | /treatments/injection-moulded-composite | treatments.injection-moulded-composite | pages | packages/champagne-manifests/data/sections/smh/treatments.injection-moulded-composite.json | 9 | YES | — |
+| Inlays & onlays | inlays_onlays | /treatments/inlays-onlays | treatments.inlays-onlays | pages | packages/champagne-manifests/data/sections/smh/treatments.inlays-onlays.json | 12 | YES | — |
+| Knocked-out (avulsed) tooth | emergency_knocked_out_tooth | /treatments/knocked-out-tooth | treatments.knocked-out-tooth | pages | packages/champagne-manifests/data/sections/smh/treatments.knocked-out-tooth.json | 9 | YES | — |
+| Lost crowns, veneers & fillings | emergency_lost_crowns | /treatments/lost-crowns-veneers-fillings | treatments.lost-crowns-veneers-fillings | pages | packages/champagne-manifests/data/sections/smh/treatments.lost-crowns-veneers-fillings.json | 9 | YES | — |
+| Mouthguards and retainers | mouthguards_and_retainers | /treatments/mouthguards-and-retainers | treatments.mouthguards-and-retainers | pages | packages/champagne-manifests/data/sections/smh/treatments.mouthguards-and-retainers.json | 8 | YES | — |
+| Nervous patients | nervous_patients | /treatments/nervous-patients | treatments.nervous-patients | pages | packages/champagne-manifests/data/sections/smh/treatments.nervous-patients.json | 9 | YES | — |
+| Night guards (occlusal splints) | night_guards_occlusal_splints | /treatments/night-guards-occlusal-splints | treatments.night-guards-occlusal-splints | pages | packages/champagne-manifests/data/sections/smh/treatments.night-guards-occlusal-splints.json | 11 | YES | — |
+| Orthodontics | orthodontics | /treatments/orthodontics | treatments.orthodontics | pages | packages/champagne-manifests/data/sections/smh/treatments.orthodontics.json | 16 | YES | — |
+| The Wand numbing system | painless_numbing_the_wand | /treatments/painless-numbing-the-wand | treatments.painless-numbing-the-wand | pages | packages/champagne-manifests/data/sections/smh/treatments.painless-numbing-the-wand.json | 10 | YES | — |
+| PEEK partial dentures | peek_partial_dentures | /treatments/peek-partial-dentures | treatments.peek-partial-dentures | pages | packages/champagne-manifests/data/sections/smh/treatments.peek-partial-dentures.json | 11 | YES | — |
+| Gum disease | periodontal_gum_care | /treatments/periodontal-gum-care | treatments.periodontal-gum-care | pages | packages/champagne-manifests/data/sections/smh/treatments.periodontal-gum-care.json | 11 | YES | — |
+| Polynucleotides (skin quality support) | polynucleotides | /treatments/polynucleotides | treatments.polynucleotides | pages | packages/champagne-manifests/data/sections/smh/treatments.polynucleotides.json | 11 | YES | — |
+| Preventative & general dentistry | preventative_and_general_dentistry | /treatments/preventative-and-general-dentistry | treatments.preventative-and-general-dentistry | pages | packages/champagne-manifests/data/sections/smh/treatments.preventative-and-general-dentistry.json | 13 | YES | — |
+| Preventive dentistry | preventive_dentistry | /treatments/preventive-dentistry | treatments.preventive-dentistry | pages | packages/champagne-manifests/data/sections/smh/treatments.preventive-dentistry.json | 9 | YES | — |
+| Sedation dentistry | sedation_dentistry | /treatments/sedation-dentistry | treatments.sedation-dentistry | pages | packages/champagne-manifests/data/sections/smh/treatments.sedation-dentistry.json | 10 | YES | — |
+| Sedation for dental implant treatment in Shoreham-by-Sea | implants_sedation | /treatments/sedation-for-implants | treatments.sedation-for-implants | pages | packages/champagne-manifests/data/sections/smh/treatments.sedation-for-implants.json | 11 | YES | — |
+| Senior and mature smile care | senior_mature_smile_care | /treatments/senior-mature-smile-care | treatments.senior-mature-smile-care | pages | packages/champagne-manifests/data/sections/smh/treatments.senior-mature-smile-care.json | 10 | YES | — |
+| Severe toothache & dental pain | emergency_severe_toothache | /treatments/severe-toothache-dental-pain | treatments.severe-toothache-dental-pain | pages | packages/champagne-manifests/data/sections/smh/treatments.severe-toothache-dental-pain.json | 9 | YES | — |
+| Sinus lift for dental implants in Shoreham-by-Sea | implants_sinus_lift | /treatments/sinus-lift | treatments.sinus-lift | pages | packages/champagne-manifests/data/sections/smh/treatments.sinus-lift.json | 11 | YES | — |
+| Skin boosters (hydration and elasticity) | skin_boosters | /treatments/skin-boosters | treatments.skin-boosters | pages | packages/champagne-manifests/data/sections/smh/treatments.skin-boosters.json | 11 | YES | — |
+| Sports mouthguards | sports_mouthguards | /treatments/sports-mouthguards | treatments.sports-mouthguards | pages | packages/champagne-manifests/data/sections/smh/treatments.sports-mouthguards.json | 9 | YES | — |
+| Surgically Guided Implants in Shoreham-by-Sea | surgically_guided_implants | /treatments/surgically-guided-implants | treatments.surgically-guided-implants | pages | packages/champagne-manifests/data/sections/smh/treatments.surgically-guided-implants.json | 11 | YES | — |
+| Teeth-in-a-Day implants in Shoreham-by-Sea | implants_teeth_in_a_day | /treatments/teeth-in-a-day | treatments.teeth-in-a-day | pages | packages/champagne-manifests/data/sections/smh/treatments.teeth-in-a-day.json | 11 | YES | — |
+| Teeth whitening | whitening_hub | /treatments/teeth-whitening | treatments.teeth-whitening | pages | packages/champagne-manifests/data/sections/smh/treatments.teeth-whitening.json | 10 | YES | — |
+| Teeth whitening FAQs | whitening_faq | /treatments/teeth-whitening-faqs | treatments.teeth-whitening-faqs | pages | packages/champagne-manifests/data/sections/smh/treatments.teeth-whitening-faqs.json | 6 | YES | — |
+| Therapeutic facial injectables | therapeutic_facial_injectables | /treatments/therapeutic-facial-injectables | treatments.therapeutic-facial-injectables | pages | packages/champagne-manifests/data/sections/smh/treatments.therapeutic-facial-injectables.json | 12 | YES | — |
+| TMJ disorder treatment | tmj_disorder_treatment | /treatments/tmj-disorder-treatment | treatments.tmj-disorder-treatment | pages | packages/champagne-manifests/data/sections/smh/treatments.tmj-disorder-treatment.json | 11 | YES | — |
+| Jaw joint (TMJ) comfort | tmj_jaw_comfort | /treatments/tmj-jaw-comfort | treatments.tmj-jaw-comfort | pages | packages/champagne-manifests/data/sections/smh/treatments.tmj-jaw-comfort.json | 10 | YES | — |
+| Tooth Wear & Broken Teeth | tooth_wear_broken_teeth | /treatments/tooth-wear-broken-teeth | treatments.tooth-wear-broken-teeth | pages | packages/champagne-manifests/data/sections/smh/treatments.tooth-wear-broken-teeth.json | 10 | YES | — |
+| Dental veneers in Shoreham-by-Sea | veneers | /treatments/veneers | treatments.veneers | pages | packages/champagne-manifests/data/sections/smh/treatments.veneers.json | 15 | YES | — |
+| Sensitive teeth & whitening | whitening_sensitivity | /treatments/whitening-sensitive-teeth | treatments.whitening-sensitive-teeth | pages | packages/champagne-manifests/data/sections/smh/treatments.whitening-sensitive-teeth.json | 8 | YES | — |
+| Whitening top-ups & maintenance | whitening_topups | /treatments/whitening-top-ups | treatments.whitening-top-ups | pages | packages/champagne-manifests/data/sections/smh/treatments.whitening-top-ups.json | 8 | YES | — |
+
+## B. Previously warned routes verified
+
+| Route | Route ID | Registered section layout file | Registered sections | Finding |
+| --- | --- | --- | ---: | --- |
+| /treatments/composite-bonding | treatments.composite-bonding | packages/champagne-manifests/data/sections/smh/treatments.composite-bonding.json | 12 | CONFIRMED_REGISTERED_STALE_WARNING |
+| /treatments/injection-moulded-composite | treatments.injection-moulded-composite | packages/champagne-manifests/data/sections/smh/treatments.injection-moulded-composite.json | 9 | CONFIRMED_REGISTERED_STALE_WARNING |
+| /treatments/full-smile-makeover | treatments.full-smile-makeover | packages/champagne-manifests/data/sections/smh/treatments.full-smile-makeover.json | 8 | CONFIRMED_REGISTERED_STALE_WARNING |
+| /treatments/emergency-dentistry | treatments.emergency-dentistry | packages/champagne-manifests/data/sections/smh/treatments.emergency-dentistry.json | 11 | CONFIRMED_REGISTERED_STALE_WARNING |
+| /treatments/emergency-dental-appointments | treatments.emergency-dental-appointments | packages/champagne-manifests/data/sections/smh/treatments.emergency-dental-appointments.json | 9 | CONFIRMED_REGISTERED_STALE_WARNING |
+| /treatments/severe-toothache-dental-pain | treatments.severe-toothache-dental-pain | packages/champagne-manifests/data/sections/smh/treatments.severe-toothache-dental-pain.json | 9 | CONFIRMED_REGISTERED_STALE_WARNING |
+| /treatments/dental-abscess-infection | treatments.dental-abscess-infection | packages/champagne-manifests/data/sections/smh/treatments.dental-abscess-infection.json | 9 | CONFIRMED_REGISTERED_STALE_WARNING |
+| /treatments/broken-chipped-cracked-teeth | treatments.broken-chipped-cracked-teeth | packages/champagne-manifests/data/sections/smh/treatments.broken-chipped-cracked-teeth.json | 9 | CONFIRMED_REGISTERED_STALE_WARNING |
+| /treatments/knocked-out-tooth | treatments.knocked-out-tooth | packages/champagne-manifests/data/sections/smh/treatments.knocked-out-tooth.json | 9 | CONFIRMED_REGISTERED_STALE_WARNING |
+| /treatments/lost-crowns-veneers-fillings | treatments.lost-crowns-veneers-fillings | packages/champagne-manifests/data/sections/smh/treatments.lost-crowns-veneers-fillings.json | 9 | CONFIRMED_REGISTERED_STALE_WARNING |
+| /treatments/dental-trauma-accidents | treatments.dental-trauma-accidents | packages/champagne-manifests/data/sections/smh/treatments.dental-trauma-accidents.json | 9 | CONFIRMED_REGISTERED_STALE_WARNING |
+| /treatments/tooth-wear-broken-teeth | treatments.tooth-wear-broken-teeth | packages/champagne-manifests/data/sections/smh/treatments.tooth-wear-broken-teeth.json | 10 | CONFIRMED_REGISTERED_STALE_WARNING |
 
 ## C. Orphans / mismatches
-- Treatments missing section layout: /treatments/composite-bonding, /treatments/injection-moulded-composite, /treatments/full-smile-makeover, /treatments/emergency-dentistry, /treatments/emergency-dental-appointments, /treatments/severe-toothache-dental-pain, /treatments/dental-abscess-infection, /treatments/broken-chipped-cracked-teeth, /treatments/knocked-out-tooth, /treatments/lost-crowns-veneers-fillings, /treatments/dental-trauma-accidents, /treatments/tooth-wear-broken-teeth
-- Orphan section layout files: packages/champagne-manifests/data/sections/smh/treatments.hub-directory.json, packages/champagne-manifests/data/sections/smh/treatments.aligners.json
-- Duplicate slugs: None
+- Treatments missing registered section layout: None
+- Orphan registered treatment section layout files: packages/champagne-manifests/data/sections/smh/treatments.aligners.json
+- Duplicate routes: None
 
-Total treatments: 73
-Total missing layouts: 12
-Total orphan layouts: 2
+Total treatments: 78
+Total missing registered layouts: 0
+Total orphan registered layouts: 1

--- a/scripts/seo-launch-safety-check.mjs
+++ b/scripts/seo-launch-safety-check.mjs
@@ -6,6 +6,8 @@ const CANONICAL_ORIGIN = "https://www.smhdental.co.uk";
 const ROBOTS_PATH = path.join(ROOT, "apps/web/app/robots.ts");
 const SITEMAP_PATH = path.join(ROOT, "apps/web/app/sitemap.ts");
 const TREATMENT_INVENTORY_PATH = path.join(ROOT, "REPORTS/TREATMENT_INVENTORY.md");
+const MACHINE_MANIFEST_PATH = path.join(ROOT, "packages/champagne-manifests/data/champagne_machine_manifest_full.json");
+const MANIFEST_CORE_PATH = path.join(ROOT, "packages/champagne-manifests/src/core.ts");
 
 const fail = (message, details = undefined) => {
   console.error(`SEO_LAUNCH_SAFETY_FAIL: ${message}`);
@@ -18,6 +20,74 @@ const pass = (message) => console.log(`SEO_LAUNCH_SAFETY_PASS: ${message}`);
 const read = (filePath) => {
   if (!fs.existsSync(filePath)) fail(`Missing required file: ${path.relative(ROOT, filePath)}`);
   return fs.readFileSync(filePath, "utf8");
+};
+
+const readJson = (filePath) => {
+  try {
+    return JSON.parse(read(filePath));
+  } catch (error) {
+    fail(`Could not parse JSON file: ${path.relative(ROOT, filePath)}`, {
+      message: error instanceof Error ? error.message : String(error),
+    });
+  }
+};
+
+const normalizeSlug = (slug) => {
+  if (!slug) return "/";
+  return slug.startsWith("/") ? slug : `/${slug}`;
+};
+
+const getRouteIdFromSlug = (slug) => {
+  const normalized = normalizeSlug(slug).replace(/^\//, "").replace(/\/$/, "");
+  if (!normalized) return "home";
+  return normalized.replace(/\//g, ".");
+};
+
+const getTreatmentRoutesFromMachineManifest = () => {
+  const machineManifest = readJson(MACHINE_MANIFEST_PATH);
+  const byRoute = new Map();
+
+  for (const collection of [machineManifest.pages ?? {}, machineManifest.treatments ?? {}]) {
+    for (const entry of Object.values(collection)) {
+      if (!entry?.path?.startsWith("/treatments/")) continue;
+      if (!byRoute.has(entry.path)) byRoute.set(entry.path, entry);
+    }
+  }
+
+  return [...byRoute.keys()].sort((a, b) => a.localeCompare(b));
+};
+
+const getRegisteredTreatmentSectionLayouts = () => {
+  const manifestCoreSource = read(MANIFEST_CORE_PATH);
+  const importByVariable = new Map();
+  const importRegex = /import\s+(sectionLayout\w+)\s+from\s+"(\.\.\/data\/sections\/smh\/treatments\.[^"]+\.json)";/g;
+  let importMatch;
+
+  while ((importMatch = importRegex.exec(manifestCoreSource)) !== null) {
+    const [, variableName, importPath] = importMatch;
+    importByVariable.set(variableName, path.join(ROOT, "packages/champagne-manifests", importPath.replace(/^\.\.\//, "")));
+  }
+
+  const layoutArrayMatch = manifestCoreSource.match(/export const champagneSectionLayouts:[\s\S]*?= \[([\s\S]*?)\];/);
+  if (!layoutArrayMatch) fail("Could not locate champagneSectionLayouts registry in packages/champagne-manifests/src/core.ts");
+
+  const layouts = new Map();
+  const registeredVariableRegex = /(sectionLayout\w+)\s+as ChampagneSectionLayout/g;
+  let registeredMatch;
+  while ((registeredMatch = registeredVariableRegex.exec(layoutArrayMatch[1])) !== null) {
+    const variableName = registeredMatch[1];
+    const layoutPath = importByVariable.get(variableName);
+    if (!layoutPath) continue;
+
+    const layout = readJson(layoutPath);
+    if (!layout?.routeId?.startsWith("treatments.")) continue;
+    layouts.set(layout.routeId, {
+      file: path.relative(ROOT, layoutPath),
+      sectionCount: Array.isArray(layout.sections) ? layout.sections.length : 0,
+    });
+  }
+
+  return layouts;
 };
 
 const robots = read(ROBOTS_PATH);
@@ -57,27 +127,19 @@ for (const relativePath of legalRouteFiles) {
 }
 pass("legal routes expose metadata, canonical, and JSON-LD schema evidence");
 
-const routeRegex = /\|\s*[^|]+\s*\|\s*[^|]+\s*\|\s*(\/treatments\/[a-z0-9-]+)\s*\|/g;
-const treatmentRoutes = new Set();
-let match;
-while ((match = routeRegex.exec(inventory)) !== null) {
-  treatmentRoutes.add(match[1]);
-}
+const treatmentRoutes = new Set(getTreatmentRoutesFromMachineManifest());
 if (treatmentRoutes.size < 50) {
-  fail("Treatment inventory route extraction found unexpectedly few treatment routes", { count: treatmentRoutes.size });
+  fail("Treatment manifest route extraction found unexpectedly few treatment routes", { count: treatmentRoutes.size });
 }
-pass(`treatment inventory exposes ${treatmentRoutes.size} treatment routes for SEO coverage review`);
+pass(`machine manifest exposes ${treatmentRoutes.size} treatment routes for SEO coverage review`);
 
-const missingLayoutLine = inventory.match(/Treatments missing section layout: (.+)/);
-if (missingLayoutLine) {
-  const missingRoutes = missingLayoutLine[1]
-    .split(",")
-    .map((value) => value.trim())
-    .filter(Boolean);
-  if (missingRoutes.length > 0) {
-    console.log("SEO_LAUNCH_SAFETY_WARN: Treatment routes missing section layouts; review before launch:");
-    for (const route of missingRoutes) console.log(`- ${route}`);
-  }
+const registeredTreatmentLayouts = getRegisteredTreatmentSectionLayouts();
+const missingLayoutRoutes = [...treatmentRoutes].filter((route) => !registeredTreatmentLayouts.has(getRouteIdFromSlug(route)));
+if (missingLayoutRoutes.length > 0) {
+  console.log("SEO_LAUNCH_SAFETY_WARN: Treatment routes missing registered section layouts; review before launch:");
+  for (const route of missingLayoutRoutes) console.log(`- ${route}`);
+} else {
+  pass(`all ${treatmentRoutes.size} treatment routes have registered section layouts`);
 }
 
 const cannibalisationClusters = [
@@ -105,8 +167,12 @@ for (const cluster of cannibalisationClusters) {
   for (const route of cluster.routes.slice(0, 20)) console.log(`  - ${route}`);
 }
 
-if (!inventory.includes("Total treatments: 73")) {
-  console.log("SEO_LAUNCH_SAFETY_WARN: Treatment inventory total has changed from the last audited value of 73. Re-run SEO truth audit.");
+const inventoryTotalMatch = inventory.match(/Total treatments:\s*(\d+)/);
+const inventoryTotal = inventoryTotalMatch ? Number(inventoryTotalMatch[1]) : undefined;
+if (inventoryTotal !== treatmentRoutes.size) {
+  console.log("SEO_LAUNCH_SAFETY_WARN: Treatment inventory total does not match live machine manifest. Refresh REPORTS/TREATMENT_INVENTORY.md.");
+  console.log(`- inventory: ${inventoryTotal ?? "unknown"}`);
+  console.log(`- machine manifest: ${treatmentRoutes.size}`);
 }
 
 console.log("SEO_LAUNCH_SAFETY_COMPLETE");

--- a/tools/audits/seo-inventory-refresh-guard-hardening/CHAMPAGNE_SEO_INVENTORY_REFRESH_GUARD_HARDENING_V1.json
+++ b/tools/audits/seo-inventory-refresh-guard-hardening/CHAMPAGNE_SEO_INVENTORY_REFRESH_GUARD_HARDENING_V1.json
@@ -1,0 +1,86 @@
+{
+  "id": "CHAMPAGNE_SEO_INVENTORY_REFRESH_GUARD_HARDENING_V1",
+  "role": "CHAMPAGNE_SEO_INVENTORY_REFRESH_AND_GUARD_TRUTH_HARDENER_V1",
+  "repo": "drnickmaxwell-wq/champagne",
+  "review_date": "2026-06-05",
+  "authority_status": "DIRECTOR_AUTHORIZED_SEO_INVENTORY_REFRESH_AND_GUARD_TRUTH_HARDENING",
+  "scope_boundary": {
+    "changed": [
+      "treatment inventory report truth",
+      "seo launch safety guard missing-section-layout data source",
+      "audit report outputs"
+    ],
+    "not_changed": [
+      "patient-facing treatment copy",
+      "routes",
+      "canonical metadata",
+      "noindex behaviour",
+      "hero",
+      "design",
+      "visual layout",
+      "header/footer",
+      "deployment"
+    ]
+  },
+  "files_changed": [
+    {
+      "path": "REPORTS/TREATMENT_INVENTORY.md",
+      "reason": "Regenerated stale inventory from live machine-manifest treatment routes and registered champagneSectionLayouts data."
+    },
+    {
+      "path": "scripts/seo-launch-safety-check.mjs",
+      "reason": "Resolved missing-section-layout checks from live manifest and registered layout data rather than stale Markdown warning text."
+    },
+    {
+      "path": "tools/audits/seo-inventory-refresh-guard-hardening/CHAMPAGNE_SEO_INVENTORY_REFRESH_GUARD_HARDENING_V1.md",
+      "reason": "Human-readable audit output."
+    },
+    {
+      "path": "tools/audits/seo-inventory-refresh-guard-hardening/CHAMPAGNE_SEO_INVENTORY_REFRESH_GUARD_HARDENING_V1.json",
+      "reason": "Machine-readable audit output."
+    }
+  ],
+  "missing_section_layout_warning_confirmed_stale": true,
+  "inventory_refresh": {
+    "source_routes": "packages/champagne-manifests/data/champagne_machine_manifest_full.json",
+    "source_registered_layouts": "packages/champagne-manifests/src/core.ts champagneSectionLayouts",
+    "total_treatment_routes": 78,
+    "total_missing_registered_layouts": 0,
+    "total_orphan_registered_layouts": 1,
+    "orphan_registered_layouts": [
+      "packages/champagne-manifests/data/sections/smh/treatments.aligners.json"
+    ]
+  },
+  "previously_warned_routes_verified": [
+    { "route": "/treatments/composite-bonding", "layout_file": "packages/champagne-manifests/data/sections/smh/treatments.composite-bonding.json", "registered_sections": 12, "finding": "CONFIRMED_REGISTERED_STALE_WARNING" },
+    { "route": "/treatments/injection-moulded-composite", "layout_file": "packages/champagne-manifests/data/sections/smh/treatments.injection-moulded-composite.json", "registered_sections": 9, "finding": "CONFIRMED_REGISTERED_STALE_WARNING" },
+    { "route": "/treatments/full-smile-makeover", "layout_file": "packages/champagne-manifests/data/sections/smh/treatments.full-smile-makeover.json", "registered_sections": 8, "finding": "CONFIRMED_REGISTERED_STALE_WARNING" },
+    { "route": "/treatments/emergency-dentistry", "layout_file": "packages/champagne-manifests/data/sections/smh/treatments.emergency-dentistry.json", "registered_sections": 11, "finding": "CONFIRMED_REGISTERED_STALE_WARNING" },
+    { "route": "/treatments/emergency-dental-appointments", "layout_file": "packages/champagne-manifests/data/sections/smh/treatments.emergency-dental-appointments.json", "registered_sections": 9, "finding": "CONFIRMED_REGISTERED_STALE_WARNING" },
+    { "route": "/treatments/severe-toothache-dental-pain", "layout_file": "packages/champagne-manifests/data/sections/smh/treatments.severe-toothache-dental-pain.json", "registered_sections": 9, "finding": "CONFIRMED_REGISTERED_STALE_WARNING" },
+    { "route": "/treatments/dental-abscess-infection", "layout_file": "packages/champagne-manifests/data/sections/smh/treatments.dental-abscess-infection.json", "registered_sections": 9, "finding": "CONFIRMED_REGISTERED_STALE_WARNING" },
+    { "route": "/treatments/broken-chipped-cracked-teeth", "layout_file": "packages/champagne-manifests/data/sections/smh/treatments.broken-chipped-cracked-teeth.json", "registered_sections": 9, "finding": "CONFIRMED_REGISTERED_STALE_WARNING" },
+    { "route": "/treatments/knocked-out-tooth", "layout_file": "packages/champagne-manifests/data/sections/smh/treatments.knocked-out-tooth.json", "registered_sections": 9, "finding": "CONFIRMED_REGISTERED_STALE_WARNING" },
+    { "route": "/treatments/lost-crowns-veneers-fillings", "layout_file": "packages/champagne-manifests/data/sections/smh/treatments.lost-crowns-veneers-fillings.json", "registered_sections": 9, "finding": "CONFIRMED_REGISTERED_STALE_WARNING" },
+    { "route": "/treatments/dental-trauma-accidents", "layout_file": "packages/champagne-manifests/data/sections/smh/treatments.dental-trauma-accidents.json", "registered_sections": 9, "finding": "CONFIRMED_REGISTERED_STALE_WARNING" },
+    { "route": "/treatments/tooth-wear-broken-teeth", "layout_file": "packages/champagne-manifests/data/sections/smh/treatments.tooth-wear-broken-teeth.json", "registered_sections": 10, "finding": "CONFIRMED_REGISTERED_STALE_WARNING" }
+  ],
+  "guard_behaviour": {
+    "before": "Read stale REPORTS/TREATMENT_INVENTORY.md warning text, exposed 73 routes, and printed 12 false missing-section-layout warnings.",
+    "after": "Reads 78 live treatment routes from machine manifest, verifies all 78 against registered section layouts, and emits no missing-section-layout warning."
+  },
+  "cannibalisation_warnings": {
+    "status": "DEFERRED",
+    "reason": "Requires separate human editorial/SEO one-intent-per-page decision mission."
+  },
+  "validation_results": [
+    { "command": "npm run guard:seo-launch-safety", "result": "PASS" },
+    { "command": "npm run seo:answer-foundation-qa", "result": "PASS" },
+    { "command": "npm run seo:answer-packet-qa", "result": "PASS" },
+    { "command": "npm run lint", "result": "PASS" },
+    { "command": "npm run build", "result": "PASS" },
+    { "command": "git diff --check", "result": "PASS" }
+  ],
+  "rollback_notes": "Revert this commit to restore the prior Markdown-derived warning behaviour and previous inventory report contents.",
+  "next_recommended_mission": "CHAMPAGNE_SEO_CANNIBALISATION_CLUSTER_HUMAN_DECISION_V1"
+}

--- a/tools/audits/seo-inventory-refresh-guard-hardening/CHAMPAGNE_SEO_INVENTORY_REFRESH_GUARD_HARDENING_V1.md
+++ b/tools/audits/seo-inventory-refresh-guard-hardening/CHAMPAGNE_SEO_INVENTORY_REFRESH_GUARD_HARDENING_V1.md
@@ -1,0 +1,79 @@
+# CHAMPAGNE SEO Inventory Refresh + Guard Hardening V1
+
+**Role:** `CHAMPAGNE_SEO_INVENTORY_REFRESH_AND_GUARD_TRUTH_HARDENER_V1`  
+**Repo:** `drnickmaxwell-wq/champagne`  
+**Review date:** 2026-06-05  
+**Authority status:** `DIRECTOR_AUTHORIZED_SEO_INVENTORY_REFRESH_AND_GUARD_TRUTH_HARDENING`  
+
+## Scope Boundary
+
+This mission refreshed treatment inventory truth and hardened the SEO launch safety guard's section-layout warning source. No patient-facing treatment copy, route definitions, canonical/noindex behaviour, hero, design, visual layout, header/footer, deployment, analytics, or external publishing surfaces were changed.
+
+Cannibalisation clusters were not remediated. They remain a separate human editorial/SEO decision mission.
+
+## Files Changed
+
+| File | Exact reason for change |
+| --- | --- |
+| `REPORTS/TREATMENT_INVENTORY.md` | Regenerated stale inventory from live machine-manifest treatment routes and registered `champagneSectionLayouts` data so section-layout status reflects actual registered layout JSON files. |
+| `scripts/seo-launch-safety-check.mjs` | Hardened missing-section-layout checks to resolve live treatment routes from `champagne_machine_manifest_full.json` and registered section layouts from `packages/champagne-manifests/src/core.ts`, instead of replaying stale Markdown warning text. |
+| `tools/audits/seo-inventory-refresh-guard-hardening/CHAMPAGNE_SEO_INVENTORY_REFRESH_GUARD_HARDENING_V1.md` | Added human-readable audit record for this mission. |
+| `tools/audits/seo-inventory-refresh-guard-hardening/CHAMPAGNE_SEO_INVENTORY_REFRESH_GUARD_HARDENING_V1.json` | Added machine-readable audit record for this mission. |
+
+## Missing Section Layout Warning Finding
+
+The missing-section-layout warning was confirmed stale.
+
+Before hardening, `npm run guard:seo-launch-safety` read the stale `Treatments missing section layout:` line from `REPORTS/TREATMENT_INVENTORY.md` and warned on 12 routes.
+
+After refreshing inventory truth and hardening the guard, `npm run guard:seo-launch-safety` resolves live manifest data and reports:
+
+- `SEO_LAUNCH_SAFETY_PASS: machine manifest exposes 78 treatment routes for SEO coverage review`
+- `SEO_LAUNCH_SAFETY_PASS: all 78 treatment routes have registered section layouts`
+
+## Routes / Layouts Verified
+
+| Route | Registered section layout file | Registered sections | Finding |
+| --- | --- | ---: | --- |
+| `/treatments/composite-bonding` | `packages/champagne-manifests/data/sections/smh/treatments.composite-bonding.json` | 12 | Confirmed registered; stale warning removed. |
+| `/treatments/injection-moulded-composite` | `packages/champagne-manifests/data/sections/smh/treatments.injection-moulded-composite.json` | 9 | Confirmed registered; stale warning removed. |
+| `/treatments/full-smile-makeover` | `packages/champagne-manifests/data/sections/smh/treatments.full-smile-makeover.json` | 8 | Confirmed registered; stale warning removed. |
+| `/treatments/emergency-dentistry` | `packages/champagne-manifests/data/sections/smh/treatments.emergency-dentistry.json` | 11 | Confirmed registered; stale warning removed. |
+| `/treatments/emergency-dental-appointments` | `packages/champagne-manifests/data/sections/smh/treatments.emergency-dental-appointments.json` | 9 | Confirmed registered; stale warning removed. |
+| `/treatments/severe-toothache-dental-pain` | `packages/champagne-manifests/data/sections/smh/treatments.severe-toothache-dental-pain.json` | 9 | Confirmed registered; stale warning removed. |
+| `/treatments/dental-abscess-infection` | `packages/champagne-manifests/data/sections/smh/treatments.dental-abscess-infection.json` | 9 | Confirmed registered; stale warning removed. |
+| `/treatments/broken-chipped-cracked-teeth` | `packages/champagne-manifests/data/sections/smh/treatments.broken-chipped-cracked-teeth.json` | 9 | Confirmed registered; stale warning removed. |
+| `/treatments/knocked-out-tooth` | `packages/champagne-manifests/data/sections/smh/treatments.knocked-out-tooth.json` | 9 | Confirmed registered; stale warning removed. |
+| `/treatments/lost-crowns-veneers-fillings` | `packages/champagne-manifests/data/sections/smh/treatments.lost-crowns-veneers-fillings.json` | 9 | Confirmed registered; stale warning removed. |
+| `/treatments/dental-trauma-accidents` | `packages/champagne-manifests/data/sections/smh/treatments.dental-trauma-accidents.json` | 9 | Confirmed registered; stale warning removed. |
+| `/treatments/tooth-wear-broken-teeth` | `packages/champagne-manifests/data/sections/smh/treatments.tooth-wear-broken-teeth.json` | 10 | Confirmed registered; stale warning removed. |
+
+## Guard Behaviour Before / After
+
+| State | Behaviour |
+| --- | --- |
+| Before | Guard passed core robots/sitemap/legal checks, extracted 73 routes from stale Markdown, then printed a false missing-section-layout warning for 12 routes. |
+| After | Guard passes core robots/sitemap/legal checks, extracts 78 treatment routes from the live machine manifest, verifies all 78 against registered section-layout JSON data, and emits no missing-section-layout warning. |
+
+## Cannibalisation Warnings Deferred
+
+High-risk cannibalisation clusters are still intentionally printed by the guard as informational launch-review prompts. No cannibalisation remediation was attempted in this mission. Cluster resolution requires a separate human decision mission for one-intent-per-page editorial direction.
+
+## Validation Results
+
+| Command | Result | Notes |
+| --- | --- | --- |
+| `npm run guard:seo-launch-safety` | PASS | Missing-section-layout warning removed; cannibalisation info remains. |
+| `npm run seo:answer-foundation-qa` | PASS | Answer foundation QA passed. |
+| `npm run seo:answer-packet-qa` | PASS | Answer packet QA passed. |
+| `npm run lint` | PASS | Workspace lint passed. |
+| `npm run build` | PASS | Production web build completed. |
+| `git diff --check` | PASS | No whitespace errors. |
+
+## Rollback Notes
+
+To roll back, revert this commit. That restores the prior Markdown-derived warning behaviour and previous `REPORTS/TREATMENT_INVENTORY.md` contents. No route, patient-facing copy, hero, visual design, canonical, noindex, or registry ownership changes need separate rollback.
+
+## Authority Status
+
+`DIRECTOR_AUTHORIZED_SEO_INVENTORY_REFRESH_AND_GUARD_TRUTH_HARDENING` under strict SEO inventory/guard truth scope. Sacred hero/design zones were not touched.


### PR DESCRIPTION
### Motivation
- Remove a stale missing-section-layout source by refreshing treatment inventory truth and making the SEO launch-safety guard resolve live registered section-layout data instead of relying on stale REPORTS/TREATMENT_INVENTORY.md text.
- Preserve all routes, treatment copy, hero/design, and canonical/noindex behaviour; this is a data/guard-truth patch only.

### Description
- Regenerated `REPORTS/TREATMENT_INVENTORY.md` from the live machine manifest (`packages/champagne-manifests/data/champagne_machine_manifest_full.json`) and the registered `champagneSectionLayouts` entries in `packages/champagne-manifests/src/core.ts` so inventory reflects actual registered layout JSON files (now reports 78 routes, 0 missing registered layouts, 1 orphan layout file).
- Hardened `scripts/seo-launch-safety-check.mjs` to: read treatment routes from the machine manifest, parse `packages/champagne-manifests/src/core.ts` imports to enumerate registered section layouts, and only warn when a live route lacks a registered layout (replacing the previous Markdown text parsing approach).
- Added audit outputs documenting the work and findings: `tools/audits/seo-inventory-refresh-guard-hardening/CHAMPAGNE_SEO_INVENTORY_REFRESH_GUARD_HARDENING_V1.md` and `.json` explaining files changed, reasons, stale-warning confirmation, verified routes, guard before/after behaviour, deferred cannibalisation, rollback notes, and authority status.
- Verified the 12 previously warned routes are present and have registered layout JSON files; cannibalisation cluster notices remain informational and explicitly deferred for a separate human SEO decision mission.

### Testing
- `npm run guard:seo-launch-safety` — PASS; guard now reports the machine manifest exposes 78 routes and that all 78 have registered section layouts (no missing-layout false warnings).
- `npm run seo:answer-foundation-qa` — PASS.
- `npm run seo:answer-packet-qa` — PASS.
- `npm run lint` — PASS.
- `npm run build` — PASS (production web build completed).
- `git diff --check` — PASS (no whitespace errors).

Rollback note: revert these files to restore prior Markdown-driven behaviour; no route/content/hero/design edits were made. Authority: change executed under `DIRECTOR_AUTHORIZED_SEO_INVENTORY_REFRESH_AND_GUARD_TRUTH_HARDENING` scope.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a22f1149b388332a11ea9765f8496b7)