### PR TITLE
Harden treatment static SEO generation

### DIFF
--- a/apps/web/app/treatments/[slug]/page.static-seo.test.ts
+++ b/apps/web/app/treatments/[slug]/page.static-seo.test.ts
@@ -1,0 +1,53 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import {
+  getTreatmentManifest,
+  getTreatmentPages,
+  resolveTreatmentPathAlias,
+} from "../../../../../packages/champagne-manifests/src/helpers";
+
+const currentDir = dirname(fileURLToPath(import.meta.url));
+const pageSource = readFileSync(join(currentDir, "page.tsx"), "utf8");
+
+const manifestTreatmentPages = getTreatmentPages();
+const manifestTreatmentSlugs = manifestTreatmentPages.map((page) => page.slug);
+
+describe("treatment static SEO hardening", () => {
+  it("resolves every public treatment manifest page by slug", () => {
+    expect(manifestTreatmentPages.length).toBeGreaterThan(0);
+
+    for (const page of manifestTreatmentPages) {
+      expect(page.slug, page.path).toBeTruthy();
+      expect(getTreatmentManifest(page.slug)?.path).toBe(page.path);
+    }
+  });
+
+  it("keeps treatment aliases redirecting to canonical treatment URLs", () => {
+    expect(resolveTreatmentPathAlias("dental-implants")).toEqual({
+      resolvedPath: "/treatments/implants",
+      wasAlias: true,
+    });
+    expect(getTreatmentManifest("dental-implants")?.path).toBe("/treatments/implants");
+
+    expect(resolveTreatmentPathAlias("retainers")).toEqual({
+      resolvedPath: "/treatments/dental-retainers",
+      wasAlias: true,
+    });
+    expect(getTreatmentManifest("retainers")?.path).toBe("/treatments/dental-retainers");
+  });
+
+  it("declares treatment pages as statically generatable from manifest slugs", () => {
+    expect(pageSource).toContain("export function generateStaticParams()");
+    expect(pageSource).toContain("getTreatmentPages()");
+    expect(pageSource).toContain(".map((slug) => ({ slug }))");
+    expect(manifestTreatmentSlugs).toContain("implants");
+    expect(manifestTreatmentSlugs).toContain("dental-retainers");
+  });
+
+  it("does not leave public treatment pages dependent on request-time or generic fallback routing", () => {
+    expect(pageSource).not.toContain('export const dynamic = "force-dynamic"');
+    expect(pageSource).toContain("export const dynamicParams = false");
+  });
+});

--- a/apps/web/app/treatments/[slug]/page.tsx
+++ b/apps/web/app/treatments/[slug]/page.tsx
@@ -3,14 +3,22 @@ import { notFound, permanentRedirect } from "next/navigation";
 import {
   buildTreatmentSchemaGraph,
   getTreatmentManifest,
+  getTreatmentPages,
   resolveTreatmentPathAlias,
 } from "@champagne/manifests";
 
 import ChampagnePageBuilder from "../../(champagne)/_builder/ChampagnePageBuilder";
 
-export const dynamic = "force-dynamic";
+export const dynamicParams = false;
 
 type PageParams = { slug: string };
+
+export function generateStaticParams(): PageParams[] {
+  return getTreatmentPages()
+    .map((page) => page.slug)
+    .filter((slug): slug is string => Boolean(slug))
+    .map((slug) => ({ slug }));
+}
 
 async function resolveTreatment(params: Promise<PageParams>) {
   const resolved = await params;

--- a/tools/audits/seo-hardening/CHAMPAGNE_TREATMENT_STATIC_SEO_HARDENING_V1.md
+++ b/tools/audits/seo-hardening/CHAMPAGNE_TREATMENT_STATIC_SEO_HARDENING_V1.md
@@ -1,0 +1,32 @@
+# CHAMPAGNE_TREATMENT_STATIC_SEO_HARDENING_V1 Proof Report
+
+## Scope
+
+- Inspected `apps/web/app/treatments/[slug]/page.tsx`.
+- Confirmed treatment slugs are loaded from `@champagne/manifests` through `getTreatmentPages()`, `getTreatmentManifest()`, and `resolveTreatmentPathAlias()`.
+- Preserved alias redirect behavior and canonical treatment paths.
+- No clinical copy, fake reviews, fake awards, unsupported superiority claims, deployment settings, hero files, manifests, globals, or theme files were changed.
+
+## Implementation Proof
+
+- `generateStaticParams()` is now declared on the treatment slug route.
+- Static params are derived from `getTreatmentPages()` and map each manifest treatment page to `{ slug }`.
+- `force-dynamic` was removed because the route resolves from local manifests and has no request-time data dependency.
+- `dynamicParams = false` was added so public treatment pages are limited to manifest-backed static params rather than generic fallback routing.
+- Existing alias redirect flow remains intact: aliases resolve through `resolveTreatmentPathAlias()`, then `permanentRedirect()` sends alias requests to the canonical manifest path.
+
+## Test Proof
+
+Added `apps/web/app/treatments/[slug]/page.static-seo.test.ts` to prove:
+
+1. Every manifest treatment page resolves by slug through `getTreatmentManifest()`.
+2. Known aliases, including `dental-implants` and `retainers`, resolve to canonical treatment URLs.
+3. The treatment route declares `generateStaticParams()` from manifest slugs.
+4. The treatment route no longer exports `dynamic = "force-dynamic"` and explicitly disables dynamic fallback params.
+
+## Commands Run
+
+- `pnpm exec vitest run 'apps/web/app/treatments/[slug]/page.static-seo.test.ts'`
+- `npm run guard:hero`
+- `npm run guard:canon`
+- `npm run verify`


### PR DESCRIPTION
### Motivation

- Ensure treatment detail pages are statically generatable from the canonical manifests to reduce request-time routing and improve SEO predictability.
- Remove request-time `force-dynamic` behaviour so public treatment pages rely on manifest-backed params rather than generic fallback routing.
- Preserve alias → canonical redirects and metadata (canonical alternates and JSON-LD) while preventing any runtime-only pages from being publicly discoverable.

### Description

- Added `generateStaticParams()` to `apps/web/app/treatments/[slug]/page.tsx` that returns `{ slug }` entries derived from `getTreatmentPages()` from `@champagne/manifests`.
- Removed `export const dynamic = "force-dynamic"` and set `export const dynamicParams = false` so routes only use the manifest-provided static params.
- Added a test file `apps/web/app/treatments/[slug]/page.static-seo.test.ts` that asserts manifest slugs resolve, aliases map to canonical paths, `generateStaticParams()` is declared, and `force-dynamic` is absent.
- Added the proof report at `tools/audits/seo-hardening/CHAMPAGNE_TREATMENT_STATIC_SEO_HARDENING_V1.md` summarising scope and steps taken.

### Testing

- Ran the new unit test with `pnpm exec vitest run 'apps/web/app/treatments/[slug]/page.static-seo.test.ts'` and observed `4 tests` passing successfully.
- Ran `npm run guard:hero` and `npm run guard:canon` and both guard suites passed.
- Ran full `npm run verify` which executed token/guard/lint/typecheck and `next build`; the build completed and Next generated static pages for the treatment route (SSG entries produced) with no guard failures.
- All automated checks referenced above completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a34dda95f6c8332bb777c38d797983a)