### PR TITLE
Add treatment source-truth hash exporter and reports

### DIFF
--- a/page-truth/treatment-source-hashes/treatments-clear-aligners.txt
+++ b/page-truth/treatment-source-hashes/treatments-clear-aligners.txt
@@ -1,0 +1,191 @@
+Clear aligners straighten teeth using a series of custom trays that move teeth in small, planned steps. The key is diagnosis and planning: we assess your bite, gum health, tooth wear and any jaw symptoms, then use digital scans to model movement and discuss what’s realistic. Aligners can help with crowding, spacing and some bite corrections, but not every case is suitable — and retention is essential to keep results stable. We’ll also discuss where aligners fit alongside whitening, bonding or restorative work, especially if you’re planning a broader smile refresh. If aligners are recommended, you’ll receive a clear timeline, check-in plan and aftercare guidance.
+
+Discreet, removable aligners
+
+Digital planning and progress checks
+
+Comfort-first fit
+
+Clear timelines and costs explained
+
+Clear Aligners
+
+clear-aligners-hero-intro
+
+Clear aligners in Shoreham-by-Sea
+
+Why patients trust us
+
+clear-aligners-trust-signals
+
+Digital planning with scans so stages stay predictable
+
+Regular monitoring to check fit, hygiene, and progress
+
+Hygiene-first approach to protect gums during treatment
+
+Conservative guidance that keeps movement realistic
+
+Straightforward advice on attachments, refinements, and retainers
+
+Calm, transparent aligner plans
+
+In our clinic we usually stage this after routine check-ups and hygiene (/treatments/preventative-and-general-dentistry) so the plan stays safe and measured.
+
+Appropriate when you want to explore clear aligner options available at the practice.
+
+Often follows Routine check-ups and hygiene (/treatments/preventative-and-general-dentistry); Orthodontic overview (/treatments/orthodontics); Digital smile planning (/treatments/digital-smile-design).
+
+Alternatives we balance: Managing jaw comfort (/treatments/tmj-jaw-comfort); Care for nervous patients (/treatments/nervous-patients).
+
+Next steps we plan for: Retainer fitting after alignment (/treatments/dental-retainers); Mouthguards to protect new alignment (/treatments/mouthguards-and-retainers); Finishing with teeth whitening (/treatments/teeth-whitening).
+
+Decision clarity
+
+clear-aligners-decision-clarity
+
+When this fits and what else to consider
+
+Clear aligners use a series of custom trays to guide teeth into position. Each stage is planned digitally, so you know the expected movements, check-in cadence, and how to care for trays day to day, with options to align shade through whitening (/treatments/teeth-whitening) or plan veneers (/treatments/veneers) once alignment is stable.
+
+Assessment and digital scan or impressions
+
+Treatment plan preview with expected movements
+
+Custom aligners produced in stages
+
+Regular reviews to confirm fit and progress
+
+Refinements if needed to reach the goal
+
+Retention plan and retainers to hold the result
+
+How clear aligners work
+
+clear-aligners-explainer
+
+Clear aligner staging and review
+
+Gentle, staged movements mapped in advance
+
+Who it helps
+
+clear-aligners-who-for
+
+Mild or moderate crowding
+
+Small gaps or spacing
+
+Relapse after previous braces
+
+Bite refinement when appropriate
+
+Not suitable for everyone — an assessment confirms what’s safe
+
+Support for mild to moderate alignment needs
+
+Your aligner pathway
+
+clear-aligners-process
+
+Consultation and goal-setting
+
+Digital scan or impressions
+
+Plan preview showing expected movements
+
+Aligner series produced and issued
+
+Review cadence to check fit and hygiene
+
+Refinement stage if needed
+
+Retention with retainers to protect your result
+
+Timelines vary by complexity; we outline a typical range before you commit.
+
+Steady steps with clear expectations
+
+We use digital scans and planning software to map movements, preview attachment placement, and share expected progress before trays are ordered.
+
+Technology
+
+clear-aligners-technology
+
+Digital scan and movement preview
+
+Digital planning you can see
+
+Aftercare & risks
+
+clear-aligners-aftercare
+
+22-hour daily wear for predictable progress
+
+Attachments may be placed to guide movement
+
+Expect short-term pressure or soreness as trays change
+
+Remove aligners for meals; water only when wearing
+
+Diligent cleaning to protect gums and enamel
+
+Retainers needed after treatment to avoid relapse
+
+Comfort-first guidance with clear responsibilities
+
+Aligner FAQs
+
+Fees depend on complexity and length of treatment; we outline a range after assessing your teeth and the expected number of stages.
+
+How much do clear aligners cost?
+
+Most mild to moderate cases run for several months to over a year; we share a projected timeline and review it at each check-in.
+
+How long will I wear aligners?
+
+You may feel pressure or mild soreness for a few days when switching trays; it typically eases with consistent wear.
+
+Will aligners hurt?
+
+Remove aligners for meals and anything other than still water to avoid staining or warping the trays.
+
+Can I eat and drink with aligners in?
+
+Small tooth-coloured bumps that help guide movement. We explain placement, visibility, and care before adding them.
+
+What are attachments?
+
+Some patients notice a slight lisp for a few days. Speech usually settles as you adapt to the trays.
+
+Will I speak differently?
+
+Contact the clinic quickly. We’ll advise whether to move to the next tray, use a previous one, or order a replacement.
+
+What if I lose an aligner?
+
+Yes. Retainers hold your new tooth positions and reduce relapse risk. We’ll agree a wear schedule and maintenance plan.
+
+Do I need retainers after treatment?
+
+clear-aligners-faq
+
+Answers before you decide
+
+Related treatments
+
+clear-aligners-related
+
+Teeth whitening to set a balanced shade before refinements (/treatments/teeth-whitening)
+
+Composite bonding for finishing edges after movement (/treatments/composite-bonding)
+
+Veneers when porcelain coverage suits the goal (/treatments/veneers)
+
+3D printed veneers as a reversible preview step (/treatments/3d-printed-veneers)
+
+Digital Smile Design to map changes in advance (/treatments/digital-smile-design)
+
+Full Smile Makeover pathways for complex aims (/treatments/full-smile-makeover)
+
+Plan the full smile sequence

--- a/page-truth/treatment-source-hashes/treatments-composite-bonding.txt
+++ b/page-truth/treatment-source-hashes/treatments-composite-bonding.txt
@@ -1,0 +1,121 @@
+Composite bonding, sometimes called dental bonding, uses tooth-coloured resin in layers to rebuild edges and refine shape with minimal drilling. We aim to preserve enamel wherever possible, plan conservatively, and explain how wear and staining are managed over time.
+
+Tooth-preserving contouring with light surface preparation
+
+Resins layered to match shade, translucency, and texture
+
+Calm appointment pacing with time for review before final polishing
+
+composite_intro
+
+Composite bonding for measured smile refinement
+
+Composite bonding is a conservative cosmetic treatment that improves the appearance of teeth by adding tooth-coloured resin in controlled layers.
+
+It is commonly used to refine shape, close small gaps, or repair minor chips. Because it usually involves little or no removal of natural tooth structure, it is a lower-intervention option than treatments that require more preparation.
+
+Suitability depends on the condition of your teeth, your bite, and what you want to achieve. We assess these carefully before recommending treatment.
+
+composite_bonding_intro_prose
+
+Introduction
+
+Conservative improvements, well planned
+
+composite_candidates
+
+Patients wanting cosmetic improvement without irreversible drilling
+
+Those planning staged care such as whitening or orthodontic alignment before final bonding
+
+People exploring a cost-effective step before considering porcelain veneers
+
+Patients who value reversible changes and measured maintenance
+
+Who composite bonding suits best
+
+composite_indications
+
+Composite bonding uses a resin material that is shaped directly onto the tooth and then hardened using a curing light.
+
+The material is colour-matched to your natural teeth and blended carefully so the result looks subtle rather than artificial. The process relies on careful shaping and finishing rather than laboratory fabrication.
+
+Bonding is typically completed in a single visit for each area treated.
+
+What composite bonding can and can’t do
+
+We begin with 3D scans and clinical photographs, then design the proposed changes digitally. We share mock-ups so you can preview the direction. Guided placement and finishing maps help keep the resin precise and consistent, and support injection moulding when it offers the safest level of control.
+
+composite_digital_planning
+
+Digital planning
+
+Digital smile planning and mock-up visuals
+
+Digitally planned and guided bonding
+
+Injection moulded composite uses a digital design and silicone or printed guides to place resin accurately. This helps keep edge lengths, embrasures, and tooth widths consistent, improves symmetry across multiple teeth, and reduces variation during placement.
+
+Digital scans and wax-ups map planned tooth shapes before treatment
+
+Silicone keys or printed guides control resin volume for repeatable placement
+
+Predictable edge lengths and contact points with fewer mid-appointment adjustments
+
+Efficient when treating several teeth together or refining symmetry after orthodontics
+
+composite_injection_moulding
+
+Injection moulding technique
+
+composite_comparisons
+
+When colour is the main concern, dentist-led whitening is usually recommended before bonding so shades align
+
+If teeth are rotated or crowded, aligners or other orthodontic treatment can set the foundation before cosmetic bonding
+
+For larger shape changes or durability, porcelain veneers or digitally designed 3D veneers may be more appropriate
+
+Composite bonding often forms part of an Align → Bleach → Composite pathway, with veneers reserved for specific needs
+
+How composite bonding fits with other options
+
+composite_lifespan
+
+Composite bonding is not permanent. Over time, the material can wear, stain, or chip, particularly at the edges.
+
+Longevity varies between individuals and depends on factors such as bite forces, habits, and oral hygiene. Maintenance or repair may be required in the future.
+
+We discuss realistic expectations and ongoing care before treatment begins.
+
+Longevity & maintenance
+
+composite_not_suited
+
+Composite bonding is best suited to patients with healthy teeth and gums who want small to moderate cosmetic changes.
+
+It may not be suitable where there is heavy tooth wear, active grinding, or where larger structural changes are required. In these cases, alternative treatments may provide more predictable long-term results.
+
+We will discuss suitability openly so you can make an informed decision.
+
+When bonding isn’t the best choice
+
+Composite bonding can last for several years, but it is not permanent. Over time the material can wear, stain, or chip, and maintenance may be needed.
+
+How long does composite bonding last?
+
+Yes. Chips or edge wear can usually be repaired by smoothing and adding new resin, without removing the rest of the bonding.
+
+Can composite bonding be repaired?
+
+It depends on your teeth, your bite, and your goals. Bonding is more conservative, while veneers can offer greater durability or larger shape changes. We explain which option is most appropriate for your situation.
+
+Is composite bonding better than veneers?
+
+Bonding is usually carried out with minimal or no removal of tooth structure. We assess your enamel and bite beforehand to ensure it is suitable.
+
+Does composite bonding damage teeth?
+
+composite_faq
+
+Composite bonding FAQs

--- a/page-truth/treatment-source-hashes/treatments-dental-crowns.txt
+++ b/page-truth/treatment-source-hashes/treatments-dental-crowns.txt
@@ -1,0 +1,187 @@
+A dental crown is used when a tooth needs more protection than a filling can provide.
+
+Crowns are most often recommended for teeth that are heavily worn, cracked, weakened, or have already had extensive treatment. The aim is to protect what remains of the tooth and help it function comfortably for the long term.
+
+At St Mary’s House Dental Care, crowns are planned carefully, not routinely.
+
+Protection for heavily worn or weakened teeth
+
+Planned carefully, not routinely
+
+Designed to preserve healthy tooth where possible
+
+Comfort and function are prioritised
+
+Dental crowns
+
+dental-crowns-hero
+
+Dental crowns
+
+When a crown is needed
+
+dental-crowns-trust
+
+A tooth is badly broken or worn
+
+A large filling has failed or is likely to fail
+
+A tooth has been root-treated
+
+Cracks affect strength or comfort
+
+Long-term protection is needed
+
+When a crown may be recommended
+
+Dental crown FAQs
+
+Crowns are recommended when a tooth is cracked, heavily filled, or needs reinforcement after root canal treatment. If a more conservative option is viable, we will explain that first.
+
+Who is a suitable candidate for a crown?
+
+Depending on remaining tooth structure, options may include an onlay, bonded repair, or monitoring. We map crack risk and bite forces to advise when full coverage is the safer route.
+
+Are there alternatives to a crown?
+
+Durability depends on bite forces, hygiene, and material. We choose ceramics or metal-ceramic options to suit your case and schedule reviews to check margins and contacts over time.
+
+How long will my crown last?
+
+Clean carefully around the margins and attend regular hygiene appointments. Bite checks help us refine contacts and spot early signs of wear or gum inflammation.
+
+What maintenance does a crown need?
+
+Crowns can chip, loosen, or develop decay at the margins if hygiene or bite balance is poor. We plan coverage height and consider splints if grinding is present to reduce these risks.
+
+What are the risks or limitations?
+
+Fees vary by material, laboratory input, and any additional planning such as scan-guided design. We provide a written estimate and outline phased treatment if needed.
+
+How are crowns priced?
+
+We shade-map your neighbouring teeth and use digital scans to guide shape and translucency. The aim is a natural blend that suits your smile and gumline.
+
+Will the crown match my other teeth?
+
+dental-crowns-faq
+
+What to expect from crown treatment
+
+In our clinic we usually stage this after root canal therapy (/treatments/endodontics-root-canal) so the plan stays safe and measured.
+
+Appropriate when you want to learn when crowns are recommended and what the process involves.
+
+Often follows Root canal therapy (/treatments/endodontics-root-canal); Tooth wear repairs (/treatments/inlays-onlays).
+
+Alternatives we balance: Gum stability (/treatments/periodontal-gum-care); Smile design planning (/treatments/digital-smile-design); Managing clenching and grinding (/treatments/bruxism-and-jaw-clenching).
+
+Next steps we plan for: Routine maintenance (/treatments/preventative-and-general-dentistry); Whitening after restoration (/treatments/teeth-whitening); Night guards for protection (/treatments/night-guards-occlusal-splints).
+
+Decision clarity
+
+dental-crowns-decision-clarity
+
+When this fits and what else to consider
+
+Crowns aren’t just about covering a tooth.
+
+We focus on preserving as much natural tooth as possible, choosing designs that support the tooth rather than over-cutting it, planning the bite carefully to reduce stress, and aiming for longevity rather than quick cosmetic fixes.
+
+Preserve as much natural tooth as possible
+
+Designs that support the tooth rather than over-cutting
+
+Careful bite planning to reduce stress
+
+Longevity-focused decision-making
+
+Our approach
+
+dental-crowns-overview
+
+Our approach to crowns
+
+Materials
+
+dental-crowns-comparison
+
+Different materials suit different teeth and loads
+
+We discuss strength and durability
+
+We discuss appearance and translucency
+
+We consider front versus back teeth
+
+We explain alternatives where relevant
+
+Materials and appearance
+
+Treatment process
+
+dental-crowns-process
+
+Preparing the tooth
+
+Taking accurate records or digital scans
+
+Placing a temporary crown where needed
+
+Fitting and adjusting the final crown
+
+What to expect during treatment
+
+Intraoral scans capture your bite and neighbouring teeth so the lab can produce a crown with clean margins, comfortable contacts, and a shade that blends. This reduces chairside adjustments and helps the crown feel natural from the first fit.
+
+dental-crowns-technology
+
+Digital planning
+
+Digital scan and crown design
+
+Scans that guide fit, bite, and appearance
+
+Comfort & reassurance
+
+dental-crowns-comfort
+
+Local anaesthetic options explained before any preparation
+
+Gentle isolation and support for patients with gag reflex or anxiety
+
+Temporary coverage smoothed for comfort while the final crown is made
+
+Regular bite checks during fitting to avoid high spots
+
+Clear aftercare guidance and easy contact if anything feels unfamiliar
+
+Appointments designed for calm, clear communication
+
+Aftercare
+
+dental-crowns-aftercare
+
+Crowns should feel comfortable and secure once fitted
+
+Temporary sensitivity can occur during the process
+
+We explain what’s normal and how to care for the tooth
+
+Let us know if something doesn’t feel right
+
+Comfort and aftercare
+
+Crowns aren’t always the answer.
+
+In some situations, alternatives such as fillings, onlays, or monitoring may be more appropriate. If we think a crown isn’t the best long-term solution, we’ll explain our reasoning clearly.
+
+We explain when alternatives may be more appropriate
+
+We outline the reasons so you can decide confidently
+
+Alternatives
+
+dental-crowns-authority
+
+When a crown isn’t the best option

--- a/page-truth/treatment-source-hashes/treatments-full-arch-dental-implants.txt
+++ b/page-truth/treatment-source-hashes/treatments-full-arch-dental-implants.txt
@@ -1,0 +1,157 @@
+Full-arch implant treatment is designed for people with failing teeth or missing teeth who want a stable fixed option across an entire jaw. It is not one single procedure — it’s a staged plan that may involve extractions, managing infection or gum disease, careful bite planning, and deciding whether immediate fixed teeth are appropriate. We use CBCT scans and digital planning to map bone and anatomy, then design implant positions to support a predictable final bridge. We’ll explain timelines, temporary options, maintenance requirements, and what factors affect suitability such as smoking, diabetes control, tooth grinding and bone volume. If full-arch implants aren’t right for you, we’ll outline other stable alternatives.
+
+Consult-led planning to confirm if same-day or staged delivery is safest
+
+Provisional fixed teeth so you can smile during healing
+
+Transparent conversations about timelines, maintenance, and investment
+
+Full arch implants
+
+full-arch-hero-intro
+
+Full arch implant rehabilitation in Shoreham-by-Sea
+
+Why patients trust us
+
+full-arch-trust-signals
+
+Detailed planning with scans, mock-ups, and a phased approach when needed
+
+Sedation available for appropriate cases, with measured monitoring and recovery
+
+Hygiene support to keep implants and bridges healthy from day one
+
+Upfront discussions about fees, finance options, and maintenance visits
+
+Calm, staged care for fixed full-arch bridges
+
+A full-arch solution secures a custom bridge to a small number of implants (often four to six), giving a fixed alternative to loose dentures. It restores bite stability, supports clearer speech, and feels more comfortable when cleaned and maintained correctly over the long term.
+
+What is a full-arch implant bridge?
+
+full-arch-what-are
+
+Full-arch bridge fitted onto implants
+
+Fixed teeth supported by carefully placed implants
+
+Who it helps
+
+full-arch-who-for
+
+Patients with many failing or missing teeth wanting a fixed option
+
+Denture wearers seeking more bite strength and speech confidence
+
+Cases with sufficient bone or a plan to improve bone and gum support
+
+Those happy to follow strict hygiene and review schedules
+
+Not suitable for everyone; bone quality, general health, and habits like smoking are assessed
+
+Alternative options include implant-retained dentures or a staged bridge approach if full-arch is not right now
+
+For full smiles that need stable, fixed support
+
+Your pathway
+
+full-arch-process
+
+Consultation (week 0-2): medical review, smile goals, and suitability checks
+
+Scans & records (week 1-3): CBCT, digital impressions, and bite analysis
+
+Planning (week 2-4): prosthetic design, guided positioning, and fee confirmation
+
+Surgery day (as planned): implant placement with immediate or next-day provisional bridge when appropriate
+
+Provisional phase (6-12 weeks, varies by case): healing with check-ins and occlusion reviews
+
+Final bridge design (8-20 weeks, varies by healing): precision impressions and try-ins
+
+Fit & settle (after final fit): final bridge secured with comfort checks
+
+Ongoing reviews: hygiene support and long-term maintenance visits
+
+Structured timeline from consult to fixed bridge
+
+CBCT imaging, digital impressions, and guided positioning help place implants accurately for the planned bridge. Occlusion reviews and torque-controlled placement support a balanced, comfortable bite.
+
+Technology
+
+full-arch-technology
+
+Guided full-arch implant planning
+
+Guided, data-led implant placement
+
+Aftercare & risks
+
+full-arch-aftercare
+
+Expected short-term effects like swelling, bruising, or soreness with advice to manage them
+
+Infection or implant failure risks discussed openly with signs to watch for
+
+Daily cleaning guidance to access under the bridge and around implant posts
+
+Regular reviews to check bite balance, hygiene scores, and bridge stability
+
+Responsibility to maintain home care and attend hygiene visits for lasting results
+
+Protecting healing and long-term success
+
+Full-arch implant FAQs
+
+Some cases allow a provisional bridge on the day of surgery, but this depends on bone quality, bite, and stability; we confirm timing during planning.
+
+Is it the same day?
+
+We aim to provide immediate or next-day provisional teeth so you are not left without a smile; if staging is safer, we discuss temporary alternatives.
+
+Will I be without teeth?
+
+Both use strategically placed implants to support a full bridge. The number of implants is planned around your bone volume, bite forces, and long-term maintenance needs.
+
+All-on-4 vs All-on-6?
+
+Treatment is carried out with local anaesthetic and gentle techniques, with sedation available for suitable cases. Expect pressure and post-surgery soreness that we manage with clear aftercare.
+
+Is it painful?
+
+We demonstrate brushes, floss aids, and water flossers to clean under the bridge and around implants, and we review your routine at hygiene visits.
+
+How do I clean under the bridge?
+
+Implants and bridges are designed for long-term function, but longevity relies on healthy gums, controlled bite forces, and consistent maintenance.
+
+How long does it last?
+
+We assess your bite and may recommend night protection or design adjustments to safeguard the bridge if you clench or grind.
+
+What if I grind my teeth?
+
+Costs are confirmed after a full assessment and tailored plan, with finance options discussed so you understand the investment before starting.
+
+How much does it cost?
+
+full-arch-faq
+
+Your questions about fixed full-arch treatment
+
+In our clinic we usually stage this after implant consultation (/treatments/implants-consultation) so the plan stays safe and measured.
+
+Appropriate when you want to explore full-arch implant approaches and whether they fit your situation.
+
+Often follows Implant consultation (/treatments/implants-consultation); CBCT 3D scanning (/treatments/cbct-3d-scanning).
+
+Alternatives we balance: Bone grafting (/treatments/implants-bone-grafting); Sedation support (/treatments/implants-sedation).
+
+Next steps we plan for: Implant restorations (/treatments/3d-implant-restorations); Hygiene and aftercare (/treatments/implants-aftercare); Retained denture options (/treatments/implants-retained-dentures).
+
+Decision clarity
+
+implants-full-arch-decision-clarity
+
+When this fits and what else to consider

--- a/page-truth/treatment-source-hashes/treatments-implant-aftercare.txt
+++ b/page-truth/treatment-source-hashes/treatments-implant-aftercare.txt
@@ -1,0 +1,167 @@
+After implant treatment, most healing is straightforward — especially when you know what’s normal, what to avoid, and when we’ll review you. We’ll guide you at every stage.
+
+Clear guidance for each stage of healing
+
+Comfort-focused advice and review schedule
+
+Support for nervous patients
+
+Long-term maintenance for implant health
+
+IMPLANTS
+
+implants-aftercare-hero-intro
+
+Implant aftercare & recovery in Shoreham-by-Sea
+
+implants-aftercare-trust-signals
+
+Written aftercare instructions tailored to your treatment
+
+Planned follow-ups and reviews
+
+Hygiene guidance that protects healing tissues
+
+Clear expectations and timelines
+
+Calm access to advice if you’re worried
+
+Long-term maintenance planning
+
+Healing support you can rely on
+
+Most people notice expected swelling or soreness for a few days, move to gentle cleaning and a soft diet, and ease back into normal routines as tissues heal. Healing varies by individual and treatment type, and timelines for fitting final teeth can differ — we set clear steps so you know what’s coming.
+
+RECOVERY
+
+implants-aftercare-what-are
+
+Implant healing and maintenance guidance
+
+What to expect after implant treatment
+
+If something doesn’t feel right, contact us — we’d always rather check.
+
+implants-aftercare-who-for
+
+After implant placement (single, multiple, full-arch)
+
+After fitting temporary teeth
+
+After implant-retained dentures
+
+Anyone unsure what’s normal during healing
+
+Who is this aftercare guide for?
+
+implants-aftercare-process
+
+Day of treatment: rest, initial care, bite precautions
+
+First 48–72 hours: swelling/soreness management and gentle cleaning
+
+Week 1: settling period and guidance check
+
+Weeks 2–6: soft tissue healing and routine hygiene
+
+Integration phase (varies by case)
+
+Temporary teeth review/adjustments if present
+
+Final restoration planning and fitting (case-dependent)
+
+Maintenance cleans and long-term checks
+
+Ongoing home-care routine
+
+Recovery timeline: the stages of healing
+
+We keep aftercare grounded in structured reviews, monitoring, and straightforward advice so healing feels predictable.
+
+implants-aftercare-technology
+
+Planned review schedule
+
+Monitoring healing progress and bite forces
+
+Maintenance advice for long-term stability
+
+Follow-up and monitoring that protects results
+
+implants-aftercare-risks
+
+Expected: mild bleeding, swelling, soreness
+
+How to protect healing (soft diet guidance, avoid disturbing the area)
+
+Cleaning guidance (gentle, consistent)
+
+Bite-force precautions with temporary teeth
+
+Factors affecting healing (smoking, health conditions, hygiene)
+
+When to contact us: persistent bleeding, worsening swelling, fever, severe pain, unusual taste/discharge
+
+Reassurance: reviews and small adjustments are normal parts of care
+
+Comfort, safety, and when to contact us
+
+Early settling often takes a couple of weeks, with deeper integration varying by case. We’ll outline your expected checkpoints and review dates.
+
+How long does implant healing take?
+
+Start with soft, cool foods and avoid chewing directly on the implant site until we confirm it’s appropriate to progress.
+
+What can I eat after implant surgery?
+
+Use gentle brushing and any recommended brushes or rinses, keeping the area clean without disturbing the site. We’ll show you the technique.
+
+How do I clean around the implant?
+
+Mild swelling and soreness are common in the first few days. We’ll explain how to manage them and when to check in.
+
+Is swelling normal?
+
+Light activity is usually fine after a few days, but avoid strenuous exercise until we’ve confirmed healing is on track.
+
+When can I exercise again?
+
+Temporary teeth can feel different at first. If your bite feels off or high, let us know so we can adjust it.
+
+What if my bite feels high?
+
+Contact us if you notice persistent bleeding, increasing swelling, fever, severe pain, or an unusual taste or discharge.
+
+What are signs I should call the clinic?
+
+Attend routine reviews and cleans, follow tailored hygiene advice, and avoid habits that overload the area.
+
+How do I look after implants long term?
+
+We may recommend interdental brushes, floss, or water flossers depending on your restoration. We’ll make it clear and simple.
+
+Do implants need special brushes or tools?
+
+If anxiety is a barrier, we can discuss sedation or other calming options before treatment so you feel supported.
+
+Can I have sedation if I’m nervous about treatment?
+
+implants-aftercare-faq
+
+Common questions about implant aftercare
+
+In our clinic we usually stage this after implant placement (/treatments/implants) so the plan stays safe and measured.
+
+Appropriate when you want to restorative.
+
+Often follows Implant placement (/treatments/implants); Teeth in a day care (/treatments/implants-teeth-in-a-day).
+
+Alternatives we balance: Sedation for reviews (/treatments/implants-sedation); Routine check-ups (/treatments/preventative-and-general-dentistry).
+
+Next steps we plan for: Gum maintenance (/treatments/periodontal-gum-care); Night guard protection (/treatments/night-guards-occlusal-splints); Implant restorations (/treatments/3d-implant-restorations).
+
+Decision clarity
+
+implant-aftercare-decision-clarity
+
+When this fits and what else to consider

--- a/reports/WEBSITE_OS_TREATMENT_SOURCE_TRUTH_HASH_EXPORT_V1.json
+++ b/reports/WEBSITE_OS_TREATMENT_SOURCE_TRUTH_HASH_EXPORT_V1.json
@@ -1,0 +1,155 @@
+{
+  "version": "WEBSITE_OS_TREATMENT_SOURCE_TRUTH_HASH_EXPORT_V1",
+  "repository": "drnickmaxwell-wq/champagne",
+  "exportTimestamp": "2026-06-19T09:08:49.613Z",
+  "mission": "Source-truth and current-text hash export only; no treatment content mutation or rewrite authority granted.",
+  "hashAlgorithm": "sha256 over UTF-8 text with CRLF converted to LF only",
+  "inputs": {
+    "pageIndexTruth": "_truth_output/page_index_truth.json",
+    "pageContentTruth": "_truth_output/page_content_truth.json",
+    "pageTruthDirectory": "page-truth/",
+    "websiteTruthReport": "reports/WEBSITE_TRUTH_EXPORT_REPORT_V1.json",
+    "schemaQaReportAvailable": false,
+    "answerFoundationQaReportAvailable": false,
+    "answerPacketQaReportAvailable": false
+  },
+  "pages": [
+    {
+      "route": "/treatments/composite-bonding",
+      "canonicalRoute": "/treatments/composite-bonding",
+      "treatmentFamily": "treatment",
+      "sourceFilePath": "packages/champagne-manifests/data/sections/smh/treatments.composite-bonding.json",
+      "sourceTextAvailable": true,
+      "currentSourceTextHash": "c399770917c9d284f6599e2f09c0c138520b669234f0ac7cee53aca2401ee536",
+      "currentRenderedTextHash": "d8aa711118340b859f232ecd0444ab9529bf71a96dab6e4d2cbf72a2af9fc3d3",
+      "answerSurfaceStatus": "PASS",
+      "schemaStatus": "PASS_INFERRED_OR_EMITTED",
+      "canonicalStatus": "PASS",
+      "localSeoStatus": "PARTIAL",
+      "conversionStatus": "PASS_SOURCE_CTA_TEXT_PRESENT",
+      "sourceExcerptOrTextLocation": {
+        "textExport": "page-truth/treatment-source-hashes/treatments-composite-bonding.txt",
+        "sourceEntryCount": 59,
+        "firstJsonPointer": "/sections/0/body"
+      },
+      "exportTimestamp": "2026-06-19T09:08:49.613Z",
+      "blockerReasons": [],
+      "implementationReadiness": "READY_FOR_AGENT_STAGING"
+    },
+    {
+      "route": "/treatments/dental-crowns",
+      "canonicalRoute": "/treatments/dental-crowns",
+      "treatmentFamily": "treatment",
+      "sourceFilePath": "packages/champagne-manifests/data/sections/smh/treatments.dental-crowns.json",
+      "sourceTextAvailable": true,
+      "currentSourceTextHash": "be2eec7d847718e8a98906f47bb2567da02fbbbf76dd4937a1104b6be3b0d9ff",
+      "currentRenderedTextHash": "b6ab98b42a501cb25e65ba28b04ecb44b45e35242f0b58a85eeaed4727964cf2",
+      "answerSurfaceStatus": "PASS",
+      "schemaStatus": "PASS_INFERRED_OR_EMITTED",
+      "canonicalStatus": "PASS",
+      "localSeoStatus": "PASS",
+      "conversionStatus": "PASS_SOURCE_CTA_TEXT_PRESENT",
+      "sourceExcerptOrTextLocation": {
+        "textExport": "page-truth/treatment-source-hashes/treatments-dental-crowns.txt",
+        "sourceEntryCount": 90,
+        "firstJsonPointer": "/sections/0/body"
+      },
+      "exportTimestamp": "2026-06-19T09:08:49.613Z",
+      "blockerReasons": [],
+      "implementationReadiness": "READY_FOR_AGENT_STAGING"
+    },
+    {
+      "route": "/treatments/clear-aligners",
+      "canonicalRoute": "/treatments/clear-aligners",
+      "treatmentFamily": "treatment",
+      "sourceFilePath": "packages/champagne-manifests/data/sections/smh/treatments.clear-aligners.json",
+      "sourceTextAvailable": true,
+      "currentSourceTextHash": "a6a3ef1fd049926735f33aa761a095fa3cddfb65b67b7c06505fd33f3b3357ad",
+      "currentRenderedTextHash": "0297df927c2f976f2df650ffab095a6408532f51790b924b720849a66d305306",
+      "answerSurfaceStatus": "PASS",
+      "schemaStatus": "PASS_INFERRED_OR_EMITTED",
+      "canonicalStatus": "PASS",
+      "localSeoStatus": "PARTIAL",
+      "conversionStatus": "PASS_SOURCE_CTA_TEXT_PRESENT",
+      "sourceExcerptOrTextLocation": {
+        "textExport": "page-truth/treatment-source-hashes/treatments-clear-aligners.txt",
+        "sourceEntryCount": 96,
+        "firstJsonPointer": "/sections/0/body"
+      },
+      "exportTimestamp": "2026-06-19T09:08:49.613Z",
+      "blockerReasons": [],
+      "implementationReadiness": "READY_FOR_AGENT_STAGING"
+    },
+    {
+      "route": "/treatments/full-arch-dental-implants",
+      "canonicalRoute": "/treatments/implants-full-arch",
+      "treatmentFamily": "treatment",
+      "sourceFilePath": "packages/champagne-manifests/data/sections/smh/treatments.implants-full-arch.json",
+      "sourceTextAvailable": true,
+      "currentSourceTextHash": "b4d9f87855a002f643f7d99d53410e00b723f673c12bfa1a87d2b0ca3cce9df4",
+      "currentRenderedTextHash": "1d2355796b8b4eb80b8fb8ca32b973aebe7c770ed4e7852fb679b2de5227474b",
+      "answerSurfaceStatus": "MISSING",
+      "schemaStatus": "PASS_INFERRED_OR_EMITTED",
+      "canonicalStatus": "PASS",
+      "localSeoStatus": "PARTIAL",
+      "conversionStatus": "PASS_SOURCE_CTA_TEXT_PRESENT",
+      "sourceExcerptOrTextLocation": {
+        "textExport": "page-truth/treatment-source-hashes/treatments-full-arch-dental-implants.txt",
+        "sourceEntryCount": 79,
+        "firstJsonPointer": "/sections/0/body"
+      },
+      "exportTimestamp": "2026-06-19T09:08:49.613Z",
+      "blockerReasons": [
+        "Answer surface incomplete: answerSurface is missing"
+      ],
+      "implementationReadiness": "PARTIAL"
+    },
+    {
+      "route": "/treatments/implant-aftercare",
+      "canonicalRoute": "/treatments/implant-aftercare",
+      "treatmentFamily": "treatment",
+      "sourceFilePath": "packages/champagne-manifests/data/sections/smh/treatments.implants-aftercare.json",
+      "sourceTextAvailable": true,
+      "currentSourceTextHash": "ff08c0cda0606625b730273f9ee3d150072f6880024ca9255f9b9d12ae9400a5",
+      "currentRenderedTextHash": "6691c11dff7ef149fc261115ec6b3d0ee95999aaca38ac7067b580107a8edc10",
+      "answerSurfaceStatus": "PASS",
+      "schemaStatus": "PASS_INFERRED_OR_EMITTED",
+      "canonicalStatus": "PASS",
+      "localSeoStatus": "PARTIAL",
+      "conversionStatus": "PASS_SOURCE_CTA_TEXT_PRESENT",
+      "sourceExcerptOrTextLocation": {
+        "textExport": "page-truth/treatment-source-hashes/treatments-implant-aftercare.txt",
+        "sourceEntryCount": 84,
+        "firstJsonPointer": "/sections/0/body"
+      },
+      "exportTimestamp": "2026-06-19T09:08:49.613Z",
+      "blockerReasons": [],
+      "implementationReadiness": "READY_FOR_AGENT_STAGING"
+    }
+  ],
+  "summary": {
+    "targetCount": 5,
+    "readyForAgentStaging": [
+      "/treatments/composite-bonding",
+      "/treatments/dental-crowns",
+      "/treatments/clear-aligners",
+      "/treatments/implant-aftercare"
+    ],
+    "partial": [
+      {
+        "route": "/treatments/full-arch-dental-implants",
+        "blockerReasons": [
+          "Answer surface incomplete: answerSurface is missing"
+        ]
+      }
+    ],
+    "blocked": []
+  },
+  "nonAuthority": {
+    "contentRewritten": false,
+    "publicPublicationAuthorityGranted": false,
+    "clinicalReviewBypassed": false,
+    "humanApprovalBypassed": false,
+    "phiOrPmsFieldsAdded": false
+  }
+}

--- a/reports/WEBSITE_OS_TREATMENT_SOURCE_TRUTH_HASH_EXPORT_V1.md
+++ b/reports/WEBSITE_OS_TREATMENT_SOURCE_TRUTH_HASH_EXPORT_V1.md
@@ -1,0 +1,31 @@
+# Website OS Treatment Source Truth Hash Export V1
+
+- Repository: `drnickmaxwell-wq/champagne`
+- Export timestamp: `2026-06-19T09:08:49.613Z`
+- Hash algorithm: sha256 over UTF-8 text with CRLF converted to LF only
+- Authority: truth/export only; no rewrite, publication, clinical approval, chatbot, behavioural capture, PHI, PMS, or patient-data authority granted.
+
+## Summary
+
+- Target pages: 5
+- Ready for agent staging: 4
+- Partial: 1
+- Blocked: 0
+
+## Page export matrix
+
+| Route | Canonical route | Source hash | Rendered hash | Answer surface | Schema | Canonical | Local SEO | Conversion | Readiness | Blockers |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| `/treatments/composite-bonding` | `/treatments/composite-bonding` | `c399770917c9d284f6599e2f09c0c138520b669234f0ac7cee53aca2401ee536` | `d8aa711118340b859f232ecd0444ab9529bf71a96dab6e4d2cbf72a2af9fc3d3` | PASS | PASS_INFERRED_OR_EMITTED | PASS | PARTIAL | PASS_SOURCE_CTA_TEXT_PRESENT | READY_FOR_AGENT_STAGING | None |
+| `/treatments/dental-crowns` | `/treatments/dental-crowns` | `be2eec7d847718e8a98906f47bb2567da02fbbbf76dd4937a1104b6be3b0d9ff` | `b6ab98b42a501cb25e65ba28b04ecb44b45e35242f0b58a85eeaed4727964cf2` | PASS | PASS_INFERRED_OR_EMITTED | PASS | PASS | PASS_SOURCE_CTA_TEXT_PRESENT | READY_FOR_AGENT_STAGING | None |
+| `/treatments/clear-aligners` | `/treatments/clear-aligners` | `a6a3ef1fd049926735f33aa761a095fa3cddfb65b67b7c06505fd33f3b3357ad` | `0297df927c2f976f2df650ffab095a6408532f51790b924b720849a66d305306` | PASS | PASS_INFERRED_OR_EMITTED | PASS | PARTIAL | PASS_SOURCE_CTA_TEXT_PRESENT | READY_FOR_AGENT_STAGING | None |
+| `/treatments/full-arch-dental-implants` | `/treatments/implants-full-arch` | `b4d9f87855a002f643f7d99d53410e00b723f673c12bfa1a87d2b0ca3cce9df4` | `1d2355796b8b4eb80b8fb8ca32b973aebe7c770ed4e7852fb679b2de5227474b` | MISSING | PASS_INFERRED_OR_EMITTED | PASS | PARTIAL | PASS_SOURCE_CTA_TEXT_PRESENT | PARTIAL | Answer surface incomplete: answerSurface is missing |
+| `/treatments/implant-aftercare` | `/treatments/implant-aftercare` | `ff08c0cda0606625b730273f9ee3d150072f6880024ca9255f9b9d12ae9400a5` | `6691c11dff7ef149fc261115ec6b3d0ee95999aaca38ac7067b580107a8edc10` | PASS | PASS_INFERRED_OR_EMITTED | PASS | PARTIAL | PASS_SOURCE_CTA_TEXT_PRESENT | READY_FOR_AGENT_STAGING | None |
+
+## Source text locations
+
+- `/treatments/composite-bonding`: page-truth/treatment-source-hashes/treatments-composite-bonding.txt from `packages/champagne-manifests/data/sections/smh/treatments.composite-bonding.json`.
+- `/treatments/dental-crowns`: page-truth/treatment-source-hashes/treatments-dental-crowns.txt from `packages/champagne-manifests/data/sections/smh/treatments.dental-crowns.json`.
+- `/treatments/clear-aligners`: page-truth/treatment-source-hashes/treatments-clear-aligners.txt from `packages/champagne-manifests/data/sections/smh/treatments.clear-aligners.json`.
+- `/treatments/full-arch-dental-implants`: page-truth/treatment-source-hashes/treatments-full-arch-dental-implants.txt from `packages/champagne-manifests/data/sections/smh/treatments.implants-full-arch.json`.
+- `/treatments/implant-aftercare`: page-truth/treatment-source-hashes/treatments-implant-aftercare.txt from `packages/champagne-manifests/data/sections/smh/treatments.implants-aftercare.json`.

--- a/scripts/export-treatment-source-truth-hashes.mjs
+++ b/scripts/export-treatment-source-truth-hashes.mjs
@@ -1,0 +1,192 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { createHash } from "node:crypto";
+
+const rootDir = process.cwd();
+const exportTimestamp = new Date().toISOString();
+
+const targets = [
+  { requestedRoute: "/treatments/composite-bonding", canonicalRoute: "/treatments/composite-bonding" },
+  { requestedRoute: "/treatments/dental-crowns", canonicalRoute: "/treatments/dental-crowns" },
+  { requestedRoute: "/treatments/clear-aligners", canonicalRoute: "/treatments/clear-aligners" },
+  { requestedRoute: "/treatments/full-arch-dental-implants", canonicalRoute: "/treatments/implants-full-arch" },
+  { requestedRoute: "/treatments/implant-aftercare", canonicalRoute: "/treatments/implant-aftercare" },
+];
+
+const readJson = async (relativePath, fallback = null) => {
+  try {
+    return JSON.parse(await fs.readFile(path.join(rootDir, relativePath), "utf8"));
+  } catch {
+    return fallback;
+  }
+};
+
+const readText = async (relativePath, fallback = null) => {
+  try {
+    return await fs.readFile(path.join(rootDir, relativePath), "utf8");
+  } catch {
+    return fallback;
+  }
+};
+
+const writeText = async (relativePath, text) => {
+  const fullPath = path.join(rootDir, relativePath);
+  await fs.mkdir(path.dirname(fullPath), { recursive: true });
+  await fs.writeFile(fullPath, text, "utf8");
+};
+
+const sha256Text = (text) => createHash("sha256").update(text.replace(/\r\n/g, "\n"), "utf8").digest("hex");
+const routeToTruthFile = (route) => `page-truth/${route.replace(/^\//, "").replace(/\/$/, "").replace(/\//g, "-")}.txt`;
+const routeSlug = (route) => route.split("/").filter(Boolean).join("-");
+const relativePath = (filePath) => !filePath ? null : path.isAbsolute(filePath) ? path.relative(rootDir, filePath).split(path.sep).join("/") : filePath;
+
+const collectSourceText = (pageContentTruth, route) => {
+  const entries = pageContentTruth.filter((entry) => entry?.route === route && typeof entry.currentText === "string");
+  const text = entries.map((entry) => entry.currentText).join("\n\n").trimEnd();
+  return { entries, text: text ? `${text}\n` : "" };
+};
+
+const main = async () => {
+  const manifest = await readJson("packages/champagne-manifests/data/champagne_machine_manifest_full.json", { pages: {} });
+  const pageIndexTruth = await readJson("_truth_output/page_index_truth.json", []);
+  const pageContentTruth = await readJson("_truth_output/page_content_truth.json", []);
+  const websiteTruth = await readJson("reports/WEBSITE_TRUTH_EXPORT_REPORT_V1.json", null);
+  const schemaQa = await readJson("reports/SEO_SCHEMA_GRAPH_QA_REPORT_V1.json", null);
+  const answerFoundationQa = await readJson("reports/SEO_AI_ANSWER_FOUNDATION_QA_REPORT_V1.json", null);
+  const answerPacketQa = await readJson("reports/SEO_AI_ANSWER_PRIORITY_SERVICE_PACKET_QA_REPORT_V1.json", null);
+
+  const pagesByRoute = new Map(Object.entries(manifest.pages ?? {}).filter(([, page]) => page?.path).map(([pageId, page]) => [page.path, { pageId, page }]));
+  const indexByRoute = new Map(pageIndexTruth.map((entry) => [entry.route, entry]));
+  const inventoryByRoute = new Map((websiteTruth?.routeInventory ?? []).map((entry) => [entry.route, entry]));
+  const answerByRoute = new Map((websiteTruth?.answerSurfaceCoverage?.entries ?? []).map((entry) => [entry.route, entry]));
+
+  const pages = [];
+  for (const target of targets) {
+    const { requestedRoute, canonicalRoute } = target;
+    const pageEntry = pagesByRoute.get(canonicalRoute);
+    const indexEntry = indexByRoute.get(canonicalRoute);
+    const inventory = inventoryByRoute.get(canonicalRoute);
+    const answer = answerByRoute.get(canonicalRoute);
+    const source = collectSourceText(pageContentTruth, canonicalRoute);
+    const pageTruthFile = routeToTruthFile(canonicalRoute);
+    const renderedText = await readText(pageTruthFile, null);
+    const sourceFilePath = relativePath(indexEntry?.contentSources?.find((entry) => entry.type === "section_json")?.filePath)
+      ?? relativePath(indexEntry?.contentSources?.[0]?.filePath)
+      ?? "packages/champagne-manifests/data/champagne_machine_manifest_full.json";
+
+    if (source.text) {
+      await writeText(`page-truth/treatment-source-hashes/${routeSlug(requestedRoute)}.txt`, source.text);
+    }
+
+    const blockerReasons = [];
+    if (!pageEntry) blockerReasons.push(`Canonical route ${canonicalRoute} is not present in the treatment manifest.`);
+    if (!source.text) blockerReasons.push("Current source text could not be extracted from _truth_output/page_content_truth.json.");
+    if (!renderedText) blockerReasons.push(`Current rendered/page-truth text export is not available at ${pageTruthFile}.`);
+    if (answer?.validation && !answer.validation.valid) blockerReasons.push(`Answer surface incomplete: ${answer.validation.errors?.join("; ") || "validation failed"}`);
+    if (inventory?.metadata && !inventory.metadata.canonicalUrl) blockerReasons.push("Canonical URL metadata could not be inferred.");
+    if (inventory?.schema && !inventory.schema.discoverable) blockerReasons.push("Schema inventory is not discoverable for this route.");
+
+    const sourceTextAvailable = Boolean(source.text);
+    const answerSurfaceStatus = answer?.validation?.valid ? "PASS" : answer?.validation?.frameworkPresent ? "PARTIAL" : "MISSING";
+    const schemaStatus = inventory?.schema?.discoverable ? "PASS_INFERRED_OR_EMITTED" : "MISSING";
+    const canonicalStatus = inventory?.metadata?.canonicalUrl ? "PASS" : "MISSING";
+    const localSeoStatus = inventory?.metadata?.title && inventory?.metadata?.description ? "PASS" : "PARTIAL";
+    const conversionStatus = source.text && /book|consult|call|appointment|enquiry|contact/i.test(source.text) ? "PASS_SOURCE_CTA_TEXT_PRESENT" : "PARTIAL_NO_CTA_TEXT_MATCH";
+
+    const implementationReadiness = !sourceTextAvailable ? "BLOCKED"
+      : blockerReasons.length > 0 ? "PARTIAL"
+      : "READY_FOR_AGENT_STAGING";
+
+    pages.push({
+      route: requestedRoute,
+      canonicalRoute,
+      treatmentFamily: pageEntry?.page?.category ?? indexEntry?.treatmentGroup ?? "treatment_detail",
+      sourceFilePath,
+      sourceTextAvailable,
+      currentSourceTextHash: sourceTextAvailable ? sha256Text(source.text) : null,
+      currentRenderedTextHash: renderedText ? sha256Text(renderedText) : null,
+      answerSurfaceStatus,
+      schemaStatus,
+      canonicalStatus,
+      localSeoStatus,
+      conversionStatus,
+      sourceExcerptOrTextLocation: sourceTextAvailable
+        ? { textExport: `page-truth/treatment-source-hashes/${routeSlug(requestedRoute)}.txt`, sourceEntryCount: source.entries.length, firstJsonPointer: source.entries[0]?.jsonPointer ?? null }
+        : null,
+      exportTimestamp,
+      blockerReasons,
+      implementationReadiness,
+    });
+  }
+
+  const report = {
+    version: "WEBSITE_OS_TREATMENT_SOURCE_TRUTH_HASH_EXPORT_V1",
+    repository: "drnickmaxwell-wq/champagne",
+    exportTimestamp,
+    mission: "Source-truth and current-text hash export only; no treatment content mutation or rewrite authority granted.",
+    hashAlgorithm: "sha256 over UTF-8 text with CRLF converted to LF only",
+    inputs: {
+      pageIndexTruth: "_truth_output/page_index_truth.json",
+      pageContentTruth: "_truth_output/page_content_truth.json",
+      pageTruthDirectory: "page-truth/",
+      websiteTruthReport: "reports/WEBSITE_TRUTH_EXPORT_REPORT_V1.json",
+      schemaQaReportAvailable: Boolean(schemaQa),
+      answerFoundationQaReportAvailable: Boolean(answerFoundationQa),
+      answerPacketQaReportAvailable: Boolean(answerPacketQa),
+    },
+    pages,
+    summary: {
+      targetCount: pages.length,
+      readyForAgentStaging: pages.filter((page) => page.implementationReadiness === "READY_FOR_AGENT_STAGING").map((page) => page.route),
+      partial: pages.filter((page) => page.implementationReadiness === "PARTIAL").map((page) => ({ route: page.route, blockerReasons: page.blockerReasons })),
+      blocked: pages.filter((page) => page.implementationReadiness === "BLOCKED").map((page) => ({ route: page.route, blockerReasons: page.blockerReasons })),
+    },
+    nonAuthority: {
+      contentRewritten: false,
+      publicPublicationAuthorityGranted: false,
+      clinicalReviewBypassed: false,
+      humanApprovalBypassed: false,
+      phiOrPmsFieldsAdded: false,
+    },
+  };
+
+  await writeText("reports/WEBSITE_OS_TREATMENT_SOURCE_TRUTH_HASH_EXPORT_V1.json", `${JSON.stringify(report, null, 2)}\n`);
+
+  const md = [
+    "# Website OS Treatment Source Truth Hash Export V1",
+    "",
+    `- Repository: \`${report.repository}\``,
+    `- Export timestamp: \`${exportTimestamp}\``,
+    `- Hash algorithm: ${report.hashAlgorithm}`,
+    "- Authority: truth/export only; no rewrite, publication, clinical approval, chatbot, behavioural capture, PHI, PMS, or patient-data authority granted.",
+    "",
+    "## Summary",
+    "",
+    `- Target pages: ${report.summary.targetCount}`,
+    `- Ready for agent staging: ${report.summary.readyForAgentStaging.length}`,
+    `- Partial: ${report.summary.partial.length}`,
+    `- Blocked: ${report.summary.blocked.length}`,
+    "",
+    "## Page export matrix",
+    "",
+    "| Route | Canonical route | Source hash | Rendered hash | Answer surface | Schema | Canonical | Local SEO | Conversion | Readiness | Blockers |",
+    "| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |",
+    ...pages.map((page) => `| \`${page.route}\` | \`${page.canonicalRoute}\` | \`${page.currentSourceTextHash ?? "MISSING"}\` | \`${page.currentRenderedTextHash ?? "MISSING"}\` | ${page.answerSurfaceStatus} | ${page.schemaStatus} | ${page.canonicalStatus} | ${page.localSeoStatus} | ${page.conversionStatus} | ${page.implementationReadiness} | ${page.blockerReasons.length ? page.blockerReasons.join("; ") : "None"} |`),
+    "",
+    "## Source text locations",
+    "",
+    ...pages.map((page) => `- \`${page.route}\`: ${page.sourceExcerptOrTextLocation?.textExport ?? "BLOCKED"} from \`${page.sourceFilePath}\`.`),
+    "",
+  ].join("\n");
+
+  await writeText("reports/WEBSITE_OS_TREATMENT_SOURCE_TRUTH_HASH_EXPORT_V1.md", md);
+
+  console.log(`[export-treatment-source-truth-hashes] wrote reports/WEBSITE_OS_TREATMENT_SOURCE_TRUTH_HASH_EXPORT_V1.json`);
+  console.log(`[export-treatment-source-truth-hashes] wrote reports/WEBSITE_OS_TREATMENT_SOURCE_TRUTH_HASH_EXPORT_V1.md`);
+  console.log(`[export-treatment-source-truth-hashes] ready=${report.summary.readyForAgentStaging.length} partial=${report.summary.partial.length} blocked=${report.summary.blocked.length}`);
+};
+
+main().catch((error) => {
+  console.error("[export-treatment-source-truth-hashes] failed", error);
+  process.exit(1);
+});


### PR DESCRIPTION
### Motivation

- Provide a deterministic, machine-readable export of current source text and rendered text hashes for the first Website OS treatment rewrite batch so downstream agents can stage rewrites without any content mutation authority. 
- Ensure exports adhere to the repository’s truth-only rules (no rewrites, no publication, no clinical bypass) and include readiness/blocker signals for workflow gating. 
- Target the specific first-batch treatment routes to bootstrap the rewrite pipeline: `/treatments/composite-bonding`, `/treatments/dental-crowns`, `/treatments/clear-aligners`, `/treatments/full-arch-dental-implants` (canonicalized), and `/treatments/implant-aftercare`.

### Description

- Added a deterministic exporter script at `scripts/export-treatment-source-truth-hashes.mjs` that collects current source text from `_truth_output/page_content_truth.json`, page-truth rendered text from `page-truth/`, and produces per-page SHA-256 hashes (LF-normalised) and a readiness matrix. 
- The script emits a machine-readable report at `reports/WEBSITE_OS_TREATMENT_SOURCE_TRUTH_HASH_EXPORT_V1.json` and a human-readable markdown summary at `reports/WEBSITE_OS_TREATMENT_SOURCE_TRUTH_HASH_EXPORT_V1.md`, both containing the required fields (route, canonicalRoute, treatmentFamily, sourceFilePath, sourceTextAvailable, currentSourceTextHash, currentRenderedTextHash, answerSurfaceStatus, schemaStatus, canonicalStatus, localSeoStatus, conversionStatus, sourceExcerptOrTextLocation, exportTimestamp, blockerReasons, implementationReadiness).
- Wrote per-page current source-text exports to `page-truth/treatment-source-hashes/*.txt` for the five target routes so the exact source text is discoverable by agents without editing source manifests. 
- Handles canonical route mapping (example: `/treatments/full-arch-dental-implants` → canonical `/treatments/implants-full-arch`), captures blocker reasons when key evidence is missing (e.g., missing answer-surface), and marks `implementationReadiness` as `READY_FOR_AGENT_STAGING` / `PARTIAL` / `BLOCKED` accordingly.

Files added/created:
- `scripts/export-treatment-source-truth-hashes.mjs`
- `reports/WEBSITE_OS_TREATMENT_SOURCE_TRUTH_HASH_EXPORT_V1.json`
- `reports/WEBSITE_OS_TREATMENT_SOURCE_TRUTH_HASH_EXPORT_V1.md`
- `page-truth/treatment-source-hashes/treatments-composite-bonding.txt`
- `page-truth/treatment-source-hashes/treatments-dental-crowns.txt`
- `page-truth/treatment-source-hashes/treatments-clear-aligners.txt`
- `page-truth/treatment-source-hashes/treatments-full-arch-dental-implants.txt`
- `page-truth/treatment-source-hashes/treatments-implant-aftercare.txt`

### Testing

- Ran the export and validation suite: `pnpm run export:website-truth`, `pnpm run export:page-truth`, and `node scripts/export-treatment-source-truth-hashes.mjs`, and the exporter produced the JSON and MD reports successfully (summary: 5 targets processed). 
- Ran guards and QA scripts which returned passing states: `pnpm --filter @champagne/guards guard:route-truth`, `pnpm run guard:treatment-answer-surface`, `pnpm run guard:seo-launch-safety`, `pnpm run seo:schema-qa`, `pnpm run seo:answer-foundation-qa`, `pnpm run seo:answer-packet-qa`, `pnpm run guard:hero`, `pnpm run guard:canon`, and `pnpm run verify` (all passed in this run). 
- Sanity and repo checks: `git diff --check` and `git diff --cached --check` produced no blocking issues. 
- Export results: 4 routes marked `READY_FOR_AGENT_STAGING` (`/treatments/composite-bonding`, `/treatments/dental-crowns`, `/treatments/clear-aligners`, `/treatments/implant-aftercare`), 1 route `PARTIAL` (`/treatments/full-arch-dental-implants` canonicalized to `/treatments/implants-full-arch`) due to a missing answer surface, and 0 `BLOCKED` pages.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a35057db19c8332a071088febb1b324)