### PR TITLE
Complete full-arch treatment answer surface

### DIFF
--- a/ops/contracts/WEBSITE_TRUTH_EXPORT_CONTRACT_V1.json
+++ b/ops/contracts/WEBSITE_TRUTH_EXPORT_CONTRACT_V1.json
@@ -1,6 +1,6 @@
 {
   "version": "CHAMPAGNE_WEBSITE_TRUTH_EXPORT_CONTRACT_V1",
-  "generatedAt": "2026-06-19T08:29:38.332Z",
+  "generatedAt": "2026-06-19T09:17:37.764Z",
   "purpose": "Champagne-side static website truth export contract for the frontier dominance agent repo.",
   "producer": {
     "repo": "drnickmaxwell-wq/champagne",

--- a/packages/champagne-manifests/data/champagne_machine_manifest_full.json
+++ b/packages/champagne-manifests/data/champagne_machine_manifest_full.json
@@ -43,14 +43,14 @@
           "type": "copy-block",
           "title": "Dentistry planned carefully, delivered properly",
           "label": "Overview",
-          "copy": "St Mary’s House Dental Care is a long-established private practice in Shoreham-by-Sea. We focus on careful planning, calm delivery, and dentistry that makes sense for the long term.\n\nWe look after everyday oral health and also support complex cases involving tooth wear, missing teeth, implant-supported restorations, heavily restored mouths, and bite-related problems.\n\nAppointments are structured so you understand what we’ve found, what it means, and what your realistic options are. If you’re anxious, short on time, or simply want things explained properly, we’ll take a measured approach and agree the next step together."
+          "copy": "St Mary\u2019s House Dental Care is a long-established private practice in Shoreham-by-Sea. We focus on careful planning, calm delivery, and dentistry that makes sense for the long term.\n\nWe look after everyday oral health and also support complex cases involving tooth wear, missing teeth, implant-supported restorations, heavily restored mouths, and bite-related problems.\n\nAppointments are structured so you understand what we\u2019ve found, what it means, and what your realistic options are. If you\u2019re anxious, short on time, or simply want things explained properly, we\u2019ll take a measured approach and agree the next step together."
         },
         {
           "id": "home_who_we_are",
           "type": "copy-block",
           "label": "Who we are",
           "title": "Dentistry designed for clarity, comfort, and long-term confidence",
-          "copy": "Care at St Mary’s House is built around time, explanation, and respect for every patient’s circumstances.\n\nWe provide general, restorative, implant, orthodontic, and aesthetic dentistry, but we don’t rush decisions or push treatment. Appointments are unhurried, explanations are clear, and choices are made collaboratively."
+          "copy": "Care at St Mary\u2019s House is built around time, explanation, and respect for every patient\u2019s circumstances.\n\nWe provide general, restorative, implant, orthodontic, and aesthetic dentistry, but we don\u2019t rush decisions or push treatment. Appointments are unhurried, explanations are clear, and choices are made collaboratively."
         },
         {
           "id": "home_authority",
@@ -69,7 +69,7 @@
           "type": "copy-block",
           "label": "Clinical philosophy",
           "title": "Care that values planning as much as precision",
-          "copy": "Good dentistry isn’t just about a single procedure. It’s about understanding bite, function, health, aesthetics, and long-term stability — and planning accordingly.\n\nWe take a conservative, evidence-led approach. When care becomes complex or irreversible — implants, extractions, root canal treatment, veneers, larger restorative plans — we slow things down, map out options clearly, and proceed step by step with your comfort and understanding at the centre."
+          "copy": "Good dentistry isn\u2019t just about a single procedure. It\u2019s about understanding bite, function, health, aesthetics, and long-term stability \u2014 and planning accordingly.\n\nWe take a conservative, evidence-led approach. When care becomes complex or irreversible \u2014 implants, extractions, root canal treatment, veneers, larger restorative plans \u2014 we slow things down, map out options clearly, and proceed step by step with your comfort and understanding at the centre."
         },
         {
           "id": "home_treatment_hub",
@@ -98,7 +98,7 @@
           "type": "copy-block",
           "label": "Complex & multidisciplinary care",
           "title": "Structured care for complex situations",
-          "copy": "Many patients come to us after years of piecemeal dentistry, unresolved problems, or uncertainty about what should happen next. These cases need structure, not speed.\n\nOur approach brings disciplines together — restorative, orthodontic, implant, and digital planning — so treatment is sequenced sensibly and reviewed carefully. For missing teeth, that may include implant-supported restorations or implant-retained dentures, planned with stability, comfort, and ease of maintenance in mind.\n\nThe aim is a clearer path forward before anything irreversible begins."
+          "copy": "Many patients come to us after years of piecemeal dentistry, unresolved problems, or uncertainty about what should happen next. These cases need structure, not speed.\n\nOur approach brings disciplines together \u2014 restorative, orthodontic, implant, and digital planning \u2014 so treatment is sequenced sensibly and reviewed carefully. For missing teeth, that may include implant-supported restorations or implant-retained dentures, planned with stability, comfort, and ease of maintenance in mind.\n\nThe aim is a clearer path forward before anything irreversible begins."
         },
         {
           "id": "home_treatment_routing",
@@ -173,7 +173,7 @@
           "type": "media",
           "label": "Tech & tools",
           "title": "Technology that keeps planning clear",
-          "copy": "Diagnostics, digital planning, and 3D workflows help you see the steps before they happen — particularly for implants and complex restorative work — so decisions feel clearer and more predictable."
+          "copy": "Diagnostics, digital planning, and 3D workflows help you see the steps before they happen \u2014 particularly for implants and complex restorative work \u2014 so decisions feel clearer and more predictable."
         },
         {
           "id": "home_patient_stories",
@@ -219,7 +219,7 @@
           "type": "copy-block",
           "label": "Local trust & continuity",
           "title": "Established care for Shoreham-by-Sea and surrounding communities",
-          "copy": "We’ve cared for patients from Shoreham-by-Sea and surrounding towns for many years. Many stay with us long-term — not because they need ongoing treatment, but because they value consistency and knowing who is looking after them.\n\nDentistry works best when your dentist understands your history, priorities, and concerns. That continuity matters whether you’re visiting for routine care, managing dental wear over time, or planning something more involved."
+          "copy": "We\u2019ve cared for patients from Shoreham-by-Sea and surrounding towns for many years. Many stay with us long-term \u2014 not because they need ongoing treatment, but because they value consistency and knowing who is looking after them.\n\nDentistry works best when your dentist understands your history, priorities, and concerns. That continuity matters whether you\u2019re visiting for routine care, managing dental wear over time, or planning something more involved."
         },
         {
           "id": "home_locality_nap",
@@ -228,7 +228,7 @@
           "title": "Private dental care in Shoreham-by-Sea",
           "copy": "A long-established Shoreham-by-Sea dental practice for patients who value experience, continuity, and well-planned care.",
           "items": [
-            "Practice: St Mary’s House Dental Care, Shoreham-by-Sea",
+            "Practice: St Mary\u2019s House Dental Care, Shoreham-by-Sea",
             "Address area: Central Shoreham-by-Sea near the River Adur",
             "Phone: Reach the team through the contact page for a call-back"
           ],
@@ -279,8 +279,8 @@
           "title": "Questions about the practice",
           "faqs": [
             {
-              "question": "I’m nervous about dental treatment. Is that a problem?",
-              "answer": "Not at all. Many people feel anxious about dental visits, and we’re used to working at a pace that feels comfortable. We explain what’s happening before we do anything, check in as we go, and adjust if you need a pause."
+              "question": "I\u2019m nervous about dental treatment. Is that a problem?",
+              "answer": "Not at all. Many people feel anxious about dental visits, and we\u2019re used to working at a pace that feels comfortable. We explain what\u2019s happening before we do anything, check in as we go, and adjust if you need a pause."
             },
             {
               "question": "Will treatment hurt?",
@@ -288,7 +288,7 @@
             },
             {
               "question": "Do I have to decide on treatment straight away?",
-              "answer": "No. In many cases, the first appointment is about understanding what’s going on and discussing options. You’re never expected to decide on the spot."
+              "answer": "No. In many cases, the first appointment is about understanding what\u2019s going on and discussing options. You\u2019re never expected to decide on the spot."
             },
             {
               "question": "Do you do implants and complex restorative work?",
@@ -296,7 +296,7 @@
             },
             {
               "question": "What if I just want advice or a second opinion?",
-              "answer": "That’s fine. Some patients come to us simply to understand their situation better before deciding what to do next. We’re happy to help with that."
+              "answer": "That\u2019s fine. Some patients come to us simply to understand their situation better before deciding what to do next. We\u2019re happy to help with that."
             },
             {
               "question": "Do you treat older patients?",
@@ -312,7 +312,7 @@
           "faqs": [
             {
               "question": "Do you help with directions or parking?",
-              "answer": "Yes — call or message ahead and we can outline nearby parking options and the easiest way to enter the practice."
+              "answer": "Yes \u2014 call or message ahead and we can outline nearby parking options and the easiest way to enter the practice."
             },
             {
               "question": "Can I start with a phone discussion?",
@@ -324,7 +324,7 @@
             },
             {
               "question": "Is the practice suitable for nervous patients?",
-              "answer": "Yes—gentle pacing, clear numbing options, and calm explanations are part of every visit."
+              "answer": "Yes\u2014gentle pacing, clear numbing options, and calm explanations are part of every visit."
             }
           ]
         },
@@ -333,7 +333,7 @@
           "type": "copy-block",
           "label": "Patient journey",
           "title": "A clear, supportive first step",
-          "copy": "Your first visit is about listening, understanding your concerns, and gathering the information needed to guide you properly. You don’t need to know where to start. We’ll take things step by step.\n\nWhere treatment is required, options are explained clearly, including benefits, limitations, costs, and timescales. From there, you can decide how — or whether — to proceed, with support available at every stage."
+          "copy": "Your first visit is about listening, understanding your concerns, and gathering the information needed to guide you properly. You don\u2019t need to know where to start. We\u2019ll take things step by step.\n\nWhere treatment is required, options are explained clearly, including benefits, limitations, costs, and timescales. From there, you can decide how \u2014 or whether \u2014 to proceed, with support available at every stage."
         },
         {
           "id": "home_closing_cta",
@@ -623,7 +623,7 @@
               "href": "/treatments/periodontal-gum-care"
             },
             {
-              "title": "Children’s dentistry",
+              "title": "Children\u2019s dentistry",
               "description": "",
               "href": "/treatments/childrens-dentistry"
             },
@@ -1006,7 +1006,7 @@
                 "href": "/treatments/periodontal-gum-care"
               },
               {
-                "title": "Children’s dentistry",
+                "title": "Children\u2019s dentistry",
                 "description": "",
                 "href": "/treatments/childrens-dentistry"
               },
@@ -1809,7 +1809,7 @@
           "type": "copy-block",
           "title": "Planning first, surgery second",
           "label": "Introduction",
-          "copy": "Dental implants replace missing teeth using a small titanium post that supports a crown, bridge, or implant-retained denture. Planning matters: before any surgery we assess your mouth, review your medical history, and use CBCT imaging and digital scans to map bone, nerves, bite and the final tooth shape. This allows us to discuss realistic options, timing, and whether additional steps such as bone grafting or sinus lift assessment may be relevant. If implants aren’t the right fit, we’ll explain alternatives such as bridges or removable solutions and help you choose an approach that’s stable, maintainable and comfortable long-term."
+          "copy": "Dental implants replace missing teeth using a small titanium post that supports a crown, bridge, or implant-retained denture. Planning matters: before any surgery we assess your mouth, review your medical history, and use CBCT imaging and digital scans to map bone, nerves, bite and the final tooth shape. This allows us to discuss realistic options, timing, and whether additional steps such as bone grafting or sinus lift assessment may be relevant. If implants aren\u2019t the right fit, we\u2019ll explain alternatives such as bridges or removable solutions and help you choose an approach that\u2019s stable, maintainable and comfortable long-term."
         },
         {
           "id": "treatment.trustSignals"
@@ -1881,7 +1881,7 @@
         {
           "id": "implants_full_inventory",
           "type": "routing_cards",
-          "title": "Dental Implants — full treatment list",
+          "title": "Dental Implants \u2014 full treatment list",
           "label": "Full list",
           "items": [
             {
@@ -2111,7 +2111,7 @@
           {
             "id": "local_shoreham_context",
             "heading": "Local Shoreham-by-Sea context",
-            "body": "Implant planning is provided at St Mary’s House Dental Care in Shoreham-by-Sea, with diagnostics and follow-up arranged locally so the pathway remains practical for ongoing reviews."
+            "body": "Implant planning is provided at St Mary\u2019s House Dental Care in Shoreham-by-Sea, with diagnostics and follow-up arranged locally so the pathway remains practical for ongoing reviews."
           },
           {
             "id": "clinician_expertise",
@@ -2205,7 +2205,7 @@
           "type": "copy-block",
           "title": "A conservative route to refined change",
           "label": "Introduction",
-          "copy": "Veneers are thin restorations placed on the front surface of teeth to refine shape, colour and alignment. They can be an excellent option when the teeth underneath are healthy enough, and when the plan is conservative and carefully staged. We start by understanding what you’d like to change, then assess enamel, bite, gum health and wear patterns so the result is stable and maintainable. In many cases, we can explore minimal-prep or additive approaches, or consider alternatives such as whitening, bonding, or aligners first. If veneers are suitable, we’ll talk through preview options, longevity factors and how to protect the finished work."
+          "copy": "Veneers are thin restorations placed on the front surface of teeth to refine shape, colour and alignment. They can be an excellent option when the teeth underneath are healthy enough, and when the plan is conservative and carefully staged. We start by understanding what you\u2019d like to change, then assess enamel, bite, gum health and wear patterns so the result is stable and maintainable. In many cases, we can explore minimal-prep or additive approaches, or consider alternatives such as whitening, bonding, or aligners first. If veneers are suitable, we\u2019ll talk through preview options, longevity factors and how to protect the finished work."
         },
         {
           "id": "treatment.trustSignals"
@@ -2469,7 +2469,7 @@
             "heading": "Last reviewed",
             "review": {
               "lastReviewed": "2026-05-29",
-              "clinicalReviewer": "St Mary’s House Dental Care clinical team",
+              "clinicalReviewer": "St Mary\u2019s House Dental Care clinical team",
               "nextReviewDue": "2027-05-29"
             }
           },
@@ -2507,7 +2507,7 @@
           "type": "copy-block",
           "title": "Clear aligners with clear diagnosis",
           "label": "Introduction",
-          "copy": "Clear aligners straighten teeth using a series of custom trays that move teeth in small, planned steps. The key is diagnosis and planning: we assess your bite, gum health, tooth wear and any jaw symptoms, then use digital scans to model movement and discuss what’s realistic. Aligners can help with crowding, spacing and some bite corrections, but not every case is suitable — and retention is essential to keep results stable. We’ll also discuss where aligners fit alongside whitening, bonding or restorative work, especially if you’re planning a broader smile refresh. If aligners are recommended, you’ll receive a clear timeline, check-in plan and aftercare guidance."
+          "copy": "Clear aligners straighten teeth using a series of custom trays that move teeth in small, planned steps. The key is diagnosis and planning: we assess your bite, gum health, tooth wear and any jaw symptoms, then use digital scans to model movement and discuss what\u2019s realistic. Aligners can help with crowding, spacing and some bite corrections, but not every case is suitable \u2014 and retention is essential to keep results stable. We\u2019ll also discuss where aligners fit alongside whitening, bonding or restorative work, especially if you\u2019re planning a broader smile refresh. If aligners are recommended, you\u2019ll receive a clear timeline, check-in plan and aftercare guidance."
         },
         {
           "id": "treatment.trustSignals"
@@ -2919,14 +2919,14 @@
           "id": "smile_gallery_intro_copy",
           "type": "copy-block",
           "title": "Smile transformations, simplified",
-          "copy": "Our smile gallery shares examples of treatments carried out at St Mary’s House Dental Care, with the aim of helping you understand what different options can look like in real life. Every smile is unique and results vary, so these cases are here to support informed conversations — not to promise a specific outcome. Where we share before-and-after images, we do so with consent and with context about the type of work involved. If you see a result you like, we can discuss whether a similar approach is clinically suitable for you, and what the planning would involve.",
+          "copy": "Our smile gallery shares examples of treatments carried out at St Mary\u2019s House Dental Care, with the aim of helping you understand what different options can look like in real life. Every smile is unique and results vary, so these cases are here to support informed conversations \u2014 not to promise a specific outcome. Where we share before-and-after images, we do so with consent and with context about the type of work involved. If you see a result you like, we can discuss whether a similar approach is clinically suitable for you, and what the planning would involve.",
           "label": "Overview"
         },
         {
           "id": "smile_gallery_cases_overview",
           "type": "copy-block",
           "title": "Cases overview",
-          "copy": "Each case includes a brief summary of the starting point, the type of treatment provided, and the kind of planning involved.\n\nWhere before-and-after images are shown, they are there to help you understand what may be possible — not to suggest you will get an identical result. Photographs also don’t show everything that matters in dentistry, such as bite, gum health, long-term maintenance, or the stability of the underlying teeth.\n\nIf you see a style of outcome you like, we can talk through whether a similar approach is clinically suitable for you and what would need to be assessed first.",
+          "copy": "Each case includes a brief summary of the starting point, the type of treatment provided, and the kind of planning involved.\n\nWhere before-and-after images are shown, they are there to help you understand what may be possible \u2014 not to suggest you will get an identical result. Photographs also don\u2019t show everything that matters in dentistry, such as bite, gum health, long-term maintenance, or the stability of the underlying teeth.\n\nIf you see a style of outcome you like, we can talk through whether a similar approach is clinically suitable for you and what would need to be assessed first.",
           "label": "Cases"
         },
         {
@@ -2960,26 +2960,26 @@
         {
           "id": "practice_overview_authority_frame",
           "type": "story",
-          "title": "About St Mary’s House Dental Care",
-          "copy": "St Mary’s House Dental Care is a long-established private dental practice in Shoreham-by-Sea.\n\nWe work in a calm, clinician-led way: careful assessment, clear explanation, and treatment planned for long-term stability rather than quick fixes.\n\nIf you’re nervous about dentistry, or you’ve had mixed experiences in the past, we’ll take things at a pace that feels manageable and explain what we’re doing as we go."
+          "title": "About St Mary\u2019s House Dental Care",
+          "copy": "St Mary\u2019s House Dental Care is a long-established private dental practice in Shoreham-by-Sea.\n\nWe work in a calm, clinician-led way: careful assessment, clear explanation, and treatment planned for long-term stability rather than quick fixes.\n\nIf you\u2019re nervous about dentistry, or you\u2019ve had mixed experiences in the past, we\u2019ll take things at a pace that feels manageable and explain what we\u2019re doing as we go."
         },
         {
           "id": "philosophy_and_standards",
           "type": "story",
           "title": "An independent practice by choice",
-          "copy": "How we work is simple, even if the dentistry isn’t.\n\nWe start with understanding the problem properly before talking about solutions. We explain options in plain English, including limits and trade-offs. Where it helps outcomes and costs, we plan treatment in stages. And we focus on comfort, fit, and long-term maintenance — not hype."
+          "copy": "How we work is simple, even if the dentistry isn\u2019t.\n\nWe start with understanding the problem properly before talking about solutions. We explain options in plain English, including limits and trade-offs. Where it helps outcomes and costs, we plan treatment in stages. And we focus on comfort, fit, and long-term maintenance \u2014 not hype."
         },
         {
           "id": "history_and_evolution",
           "type": "story",
           "title": "A practice built on relationships",
-          "copy": "The practice has been part of the Shoreham area for many years, and the building itself reflects that history.\n\nDentistry has changed a lot over time, but the principles haven’t: careful diagnosis, sensible planning, and work you can live with comfortably. We continue to improve how we assess, plan, and deliver care, while keeping the experience calm and straightforward."
+          "copy": "The practice has been part of the Shoreham area for many years, and the building itself reflects that history.\n\nDentistry has changed a lot over time, but the principles haven\u2019t: careful diagnosis, sensible planning, and work you can live with comfortably. We continue to improve how we assess, plan, and deliver care, while keeping the experience calm and straightforward."
         },
         {
           "id": "commitment_to_patients_and_community",
           "type": "story",
           "title": "Part of Shoreham, not just located in it",
-          "copy": "Good dentistry should feel understandable and unrushed.\n\nWhether you need a simple check-up or more involved restorative work, our job is to help you make clear decisions you’ll still feel comfortable with in five and ten years’ time."
+          "copy": "Good dentistry should feel understandable and unrushed.\n\nWhether you need a simple check-up or more involved restorative work, our job is to help you make clear decisions you\u2019ll still feel comfortable with in five and ten years\u2019 time."
         },
         {
           "id": "cta_gold_bar",
@@ -3003,7 +3003,7 @@
           "id": "team_intro_copy",
           "type": "copy-block",
           "title": "Our team",
-          "copy": "Dentistry works best when it’s delivered by people who know each other well.\n\nAt St Mary’s House Dental Care, we’re a small, experienced team who work together every day — not a rotating cast. That continuity matters. It affects communication, planning, and how calmly care is delivered.\n\nPatients often tell us they value recognising familiar faces and feeling understood rather than processed.",
+          "copy": "Dentistry works best when it\u2019s delivered by people who know each other well.\n\nAt St Mary\u2019s House Dental Care, we\u2019re a small, experienced team who work together every day \u2014 not a rotating cast. That continuity matters. It affects communication, planning, and how calmly care is delivered.\n\nPatients often tell us they value recognising familiar faces and feeling understood rather than processed.",
           "label": "Team"
         },
         {
@@ -3060,42 +3060,42 @@
               "role": "Practice Manager",
               "summary": "Joanna Dobson oversees the day-to-day running of the practice, supporting patients with clear communication and a calm, organised approach that helps visits feel smooth and well-coordinated.",
               "imageSrc": "placeholder",
-              "imageAlt": "Joanna Dobson, Practice Manager at St Mary’s House Dental Care, Shoreham-by-Sea"
+              "imageAlt": "Joanna Dobson, Practice Manager at St Mary\u2019s House Dental Care, Shoreham-by-Sea"
             },
             {
               "name": "Riz Deen",
               "role": "Complex Treatment Co-ordinator",
               "summary": "Riz Deen supports patients through complex treatment planning, helping them understand options clearly and feel comfortable making decisions that fit their needs.",
               "imageSrc": "placeholder",
-              "imageAlt": "Riz Deen, Complex Treatment Co-ordinator at St Mary’s House Dental Care, Shoreham-by-Sea"
+              "imageAlt": "Riz Deen, Complex Treatment Co-ordinator at St Mary\u2019s House Dental Care, Shoreham-by-Sea"
             },
             {
               "name": "Gill Bentley",
               "role": "Head Nurse (GDC registered)",
               "summary": "Gill Bentley leads the nursing team with a calm, organised approach, supporting patient care while maintaining consistently high clinical and infection-control standards.",
               "imageSrc": "placeholder",
-              "imageAlt": "Gill Bentley, Head Dental Nurse at St Mary’s House Dental Care, Shoreham-by-Sea"
+              "imageAlt": "Gill Bentley, Head Dental Nurse at St Mary\u2019s House Dental Care, Shoreham-by-Sea"
             },
             {
               "name": "Sophia Ball",
               "role": "Dental Nurse & Receptionist (GDC registered)",
               "summary": "Sophia Ball supports patients both at reception and in surgery, helping visits feel calm, informed and well-coordinated through clear communication and reassurance.",
               "imageSrc": "placeholder",
-              "imageAlt": "Sophia Ball, Dental Nurse and Receptionist at St Mary’s House Dental Care, Shoreham-by-Sea"
+              "imageAlt": "Sophia Ball, Dental Nurse and Receptionist at St Mary\u2019s House Dental Care, Shoreham-by-Sea"
             },
             {
               "name": "Molly Pearce",
               "role": "Dental Nurse (GDC registered)",
               "summary": "Molly Pearce supports patients with a calm, detail-focused approach, helping appointments feel steady and well supported, particularly for nervous patients.",
               "imageSrc": "placeholder",
-              "imageAlt": "Molly Pearce, Dental Nurse at St Mary’s House Dental Care, Shoreham-by-Sea"
+              "imageAlt": "Molly Pearce, Dental Nurse at St Mary\u2019s House Dental Care, Shoreham-by-Sea"
             },
             {
               "name": "Marianne Fawbert",
               "role": "Receptionist",
               "summary": "Marianne Fawbert supports patients at reception, helping appointments run smoothly through careful organisation and clear, helpful communication.",
               "imageSrc": "placeholder",
-              "imageAlt": "Marianne Fawbert, Receptionist at St Mary’s House Dental Care, Shoreham-by-Sea"
+              "imageAlt": "Marianne Fawbert, Receptionist at St Mary\u2019s House Dental Care, Shoreham-by-Sea"
             }
           ]
         },
@@ -3143,25 +3143,25 @@
           "id": "profile_intro",
           "type": "copy-block",
           "label": "Profile intro",
-          "copy": "Dr Nick Maxwell\nPrincipal Dentist · Restorative, Aesthetic & Digital Dentistry\n\nI’m Dr Nick Maxwell, principal dentist at St Mary’s House Dental Care in Shoreham-by-Sea.\nI’ve been practising dentistry since 1998 and have spent much of my career focused on the kind of dentistry that needs calm judgment: complex restorative work, aesthetic planning, bite stability, and carefully selected implant and orthodontic cases.\nMy aim is simple: help patients make decisions they can feel good about years from now — not just next month."
+          "copy": "Dr Nick Maxwell\nPrincipal Dentist \u00b7 Restorative, Aesthetic & Digital Dentistry\n\nI\u2019m Dr Nick Maxwell, principal dentist at St Mary\u2019s House Dental Care in Shoreham-by-Sea.\nI\u2019ve been practising dentistry since 1998 and have spent much of my career focused on the kind of dentistry that needs calm judgment: complex restorative work, aesthetic planning, bite stability, and carefully selected implant and orthodontic cases.\nMy aim is simple: help patients make decisions they can feel good about years from now \u2014 not just next month."
         },
         {
           "id": "profile_credentials",
           "type": "copy-block",
           "label": "Credentials",
-          "copy": "Qualifications and training\n\nI hold:\n• BDS (King’s College London)\n• MSc Restorative & Aesthetic Dentistry\n• PGDip Orthodontics & Facial Orthopaedics\nI’ve also completed implant surgical training and intensive implant placement training (Cairo, 2014).\nQualifications matter, but what matters most is what they change in day-to-day care: the ability to plan, select cases carefully, and avoid unnecessary intervention."
+          "copy": "Qualifications and training\n\nI hold:\n\u2022 BDS (King\u2019s College London)\n\u2022 MSc Restorative & Aesthetic Dentistry\n\u2022 PGDip Orthodontics & Facial Orthopaedics\nI\u2019ve also completed implant surgical training and intensive implant placement training (Cairo, 2014).\nQualifications matter, but what matters most is what they change in day-to-day care: the ability to plan, select cases carefully, and avoid unnecessary intervention."
         },
         {
           "id": "profile_philosophy",
           "type": "copy-block",
           "label": "Care philosophy",
-          "copy": "How I work\n\nDentistry can be rushed. It can also be over-sold. I’m not interested in either.\nMy approach is deliberately planning-first and case-by-case:\n• We start with diagnosis and stability, not “what you’d like done”\n• We talk honestly about trade-offs and limitations\n• I’m happy to recommend the simplest sensible option — and equally happy to advise against treatment that isn’t in your long-term interest\nThat’s what I mean by “sleep-at-night dentistry”."
+          "copy": "How I work\n\nDentistry can be rushed. It can also be over-sold. I\u2019m not interested in either.\nMy approach is deliberately planning-first and case-by-case:\n\u2022 We start with diagnosis and stability, not \u201cwhat you\u2019d like done\u201d\n\u2022 We talk honestly about trade-offs and limitations\n\u2022 I\u2019m happy to recommend the simplest sensible option \u2014 and equally happy to advise against treatment that isn\u2019t in your long-term interest\nThat\u2019s what I mean by \u201csleep-at-night dentistry\u201d."
         },
         {
           "id": "profile_additional_media",
           "type": "copy-block",
           "label": "Additional media",
-          "copy": "Digital dentistry and 3D planning\n\nOver the past several years I’ve developed a strong focus on digital dentistry — not as a gimmick, but as a way to plan more precisely and communicate more clearly.\nThis includes:\n• digital planning workflows for restorative and implant cases\n• CBCT-based assessment where appropriate\n• designing and 3D-printing surgical guides for guided implant placement\n• a strong emphasis on predictability and maintainability\nTechnology doesn’t replace clinical judgment — but used properly, it helps reduce uncertainty and improves decision-making.\n\nPatients often come to see me when they want a calm, honest second opinion, a long-term plan rather than a quick fix, and careful aesthetic work that still respects tooth structure. If you’re looking for rushed dentistry, I won’t be the right fit. If you want careful, clinician-led planning, you probably will."
+          "copy": "Digital dentistry and 3D planning\n\nOver the past several years I\u2019ve developed a strong focus on digital dentistry \u2014 not as a gimmick, but as a way to plan more precisely and communicate more clearly.\nThis includes:\n\u2022 digital planning workflows for restorative and implant cases\n\u2022 CBCT-based assessment where appropriate\n\u2022 designing and 3D-printing surgical guides for guided implant placement\n\u2022 a strong emphasis on predictability and maintainability\nTechnology doesn\u2019t replace clinical judgment \u2014 but used properly, it helps reduce uncertainty and improves decision-making.\n\nPatients often come to see me when they want a calm, honest second opinion, a long-term plan rather than a quick fix, and careful aesthetic work that still respects tooth structure. If you\u2019re looking for rushed dentistry, I won\u2019t be the right fit. If you want careful, clinician-led planning, you probably will."
         },
         {
           "id": "team_connection_cta",
@@ -3207,19 +3207,19 @@
           "id": "profile_intro",
           "type": "copy-block",
           "label": "Profile intro",
-          "copy": "Dr Sylvia Krafft is an Associate Dentist at St Mary’s House Dental Care in Shoreham-by-Sea. She qualified as a Zahnarzt (Dental Surgeon) at the University of Cologne and has over 20 years’ experience working in general dentistry across Germany, the United States and the United Kingdom.\n\nPatients commonly see Dr Krafft for general dental care, prevention-focused treatment and aesthetic dentistry delivered with a conservative, minimally invasive approach. She has a particular interest in improving the appearance of teeth in ways that remain biologically sound and appropriate for long-term oral health.\n\nSince relocating to the UK in 2009, Dr Krafft has worked extensively in both NHS and private practice. Her international background allows her to draw on a broad range of clinical perspectives, supporting thoughtful, individualised care for patients of all ages.\n\nShe is especially valued by patients who want careful explanations, realistic expectations and treatment that enhances confidence without unnecessary intervention."
+          "copy": "Dr Sylvia Krafft is an Associate Dentist at St Mary\u2019s House Dental Care in Shoreham-by-Sea. She qualified as a Zahnarzt (Dental Surgeon) at the University of Cologne and has over 20 years\u2019 experience working in general dentistry across Germany, the United States and the United Kingdom.\n\nPatients commonly see Dr Krafft for general dental care, prevention-focused treatment and aesthetic dentistry delivered with a conservative, minimally invasive approach. She has a particular interest in improving the appearance of teeth in ways that remain biologically sound and appropriate for long-term oral health.\n\nSince relocating to the UK in 2009, Dr Krafft has worked extensively in both NHS and private practice. Her international background allows her to draw on a broad range of clinical perspectives, supporting thoughtful, individualised care for patients of all ages.\n\nShe is especially valued by patients who want careful explanations, realistic expectations and treatment that enhances confidence without unnecessary intervention."
         },
         {
           "id": "profile_credentials",
           "type": "copy-block",
           "label": "Credentials",
-          "copy": "Dr Krafft qualified as a Zahnarzt (Dental Surgeon) at the University of Cologne (Zahnklinik Köln) in 2001. In addition to her dental qualification, she is also a trained dental technician, giving her a detailed understanding of dental materials, morphology and precision.\n\nEarly in her career, she worked in general practice in Germany before moving to the United States, where she volunteered at a dental charity hospital in Miami. This experience reinforced her commitment to ethical, patient-centred care and to providing treatment that balances clinical need with individual circumstance.\n\nSince moving to the UK in 2009, Dr Krafft has gained over 15 years’ experience across NHS and private dentistry. She has developed a particular interest in aesthetic dentistry delivered conservatively, focusing on proportion, harmony and tooth preservation rather than aggressive cosmetic change.\n\nHer background as both clinician and technician informs a careful, detail-led approach, especially when planning aesthetic or restorative work. GDC: 174528."
+          "copy": "Dr Krafft qualified as a Zahnarzt (Dental Surgeon) at the University of Cologne (Zahnklinik K\u00f6ln) in 2001. In addition to her dental qualification, she is also a trained dental technician, giving her a detailed understanding of dental materials, morphology and precision.\n\nEarly in her career, she worked in general practice in Germany before moving to the United States, where she volunteered at a dental charity hospital in Miami. This experience reinforced her commitment to ethical, patient-centred care and to providing treatment that balances clinical need with individual circumstance.\n\nSince moving to the UK in 2009, Dr Krafft has gained over 15 years\u2019 experience across NHS and private dentistry. She has developed a particular interest in aesthetic dentistry delivered conservatively, focusing on proportion, harmony and tooth preservation rather than aggressive cosmetic change.\n\nHer background as both clinician and technician informs a careful, detail-led approach, especially when planning aesthetic or restorative work. GDC: 174528."
         },
         {
           "id": "profile_philosophy",
           "type": "copy-block",
           "label": "Care philosophy",
-          "copy": "Dr Krafft’s clinical approach is centred on prevention, minimal intervention and patient understanding. She believes that aesthetic dentistry should enhance natural features rather than replace them, and that successful outcomes depend on respecting the biology of teeth and gums.\n\nShe prioritises conservative solutions wherever possible and takes time to explain options clearly, including what can be achieved predictably and what may introduce unnecessary risk. Patients are encouraged to make informed decisions at a pace that feels comfortable, with realistic expectations set from the outset.\n\nFor patients who feel anxious, Dr Krafft focuses on building trust through calm communication and a supportive, unhurried approach. Treatment is adapted to individual comfort levels, and patients are kept fully informed and in control throughout their care.\n\nHer dual training as a dentist and dental technician supports a precise, considered approach to both aesthetic and functional treatment. Long-term oral health, stability and maintainability are always prioritised over short-term cosmetic change."
+          "copy": "Dr Krafft\u2019s clinical approach is centred on prevention, minimal intervention and patient understanding. She believes that aesthetic dentistry should enhance natural features rather than replace them, and that successful outcomes depend on respecting the biology of teeth and gums.\n\nShe prioritises conservative solutions wherever possible and takes time to explain options clearly, including what can be achieved predictably and what may introduce unnecessary risk. Patients are encouraged to make informed decisions at a pace that feels comfortable, with realistic expectations set from the outset.\n\nFor patients who feel anxious, Dr Krafft focuses on building trust through calm communication and a supportive, unhurried approach. Treatment is adapted to individual comfort levels, and patients are kept fully informed and in control throughout their care.\n\nHer dual training as a dentist and dental technician supports a precise, considered approach to both aesthetic and functional treatment. Long-term oral health, stability and maintainability are always prioritised over short-term cosmetic change."
         },
         {
           "id": "profile_additional_media",
@@ -3271,7 +3271,7 @@
           "id": "profile_intro",
           "type": "copy-block",
           "label": "Profile intro",
-          "copy": "Sara Burden is a Dental Hygienist at St Mary’s House Dental Care, with over 30 years’ experience in dental hygiene. She qualified from Birmingham Dental School in 1990 and has worked across general practice, specialist care and research settings.\n\nPatients commonly see Sara for periodontal care, maintenance appointments and support with gum health, particularly where long-term stability is essential. She is known for her gentle, thorough approach and for helping patients feel at ease, especially those who may feel anxious about hygiene treatment.\n\nSara plays an important role within the practice’s preventative and long-term care philosophy, working closely with the dentists to support restorative and implant treatment planning through ongoing periodontal health."
+          "copy": "Sara Burden is a Dental Hygienist at St Mary\u2019s House Dental Care, with over 30 years\u2019 experience in dental hygiene. She qualified from Birmingham Dental School in 1990 and has worked across general practice, specialist care and research settings.\n\nPatients commonly see Sara for periodontal care, maintenance appointments and support with gum health, particularly where long-term stability is essential. She is known for her gentle, thorough approach and for helping patients feel at ease, especially those who may feel anxious about hygiene treatment.\n\nSara plays an important role within the practice\u2019s preventative and long-term care philosophy, working closely with the dentists to support restorative and implant treatment planning through ongoing periodontal health."
         },
         {
           "id": "profile_credentials",
@@ -3283,7 +3283,7 @@
           "id": "profile_philosophy",
           "type": "copy-block",
           "label": "Care philosophy",
-          "copy": "Sara’s approach to dental hygiene is preventative, methodical and patient-focused. She believes effective periodontal care relies on understanding, consistency and realistic guidance that patients can apply between visits.\n\nShe takes time to explain findings clearly, discuss contributing factors and demonstrate techniques where helpful, allowing patients to feel informed rather than overwhelmed. Appointments are unhurried and adapted to individual comfort levels, with particular consideration given to patients who may feel nervous or sensitive.\n\nSara places strong emphasis on long-term maintenance, recognising that stable gum health is essential for both natural teeth and restorative work. Her aim is to support predictable, sustainable oral health outcomes through collaborative care and clear communication."
+          "copy": "Sara\u2019s approach to dental hygiene is preventative, methodical and patient-focused. She believes effective periodontal care relies on understanding, consistency and realistic guidance that patients can apply between visits.\n\nShe takes time to explain findings clearly, discuss contributing factors and demonstrate techniques where helpful, allowing patients to feel informed rather than overwhelmed. Appointments are unhurried and adapted to individual comfort levels, with particular consideration given to patients who may feel nervous or sensitive.\n\nSara places strong emphasis on long-term maintenance, recognising that stable gum health is essential for both natural teeth and restorative work. Her aim is to support predictable, sustainable oral health outcomes through collaborative care and clear communication."
         },
         {
           "id": "profile_additional_media",
@@ -3348,7 +3348,7 @@
           "id": "fees_what_fees_include",
           "type": "copy-block",
           "title": "What our fees include",
-          "copy": "Our fees are not just for the treatment you receive on the day. They reflect the full clinical process, which may include:\n\n• detailed assessment and diagnosis\n• digital imaging and planning where appropriate\n• high-quality materials and laboratory work\n• time for careful, unhurried delivery\n• follow-up care and review\n\nThis approach supports safe, well-planned care that is tailored to you — not simply completed quickly.",
+          "copy": "Our fees are not just for the treatment you receive on the day. They reflect the full clinical process, which may include:\n\n\u2022 detailed assessment and diagnosis\n\u2022 digital imaging and planning where appropriate\n\u2022 high-quality materials and laboratory work\n\u2022 time for careful, unhurried delivery\n\u2022 follow-up care and review\n\nThis approach supports safe, well-planned care that is tailored to you \u2014 not simply completed quickly.",
           "label": "What our fees include"
         },
         {
@@ -3362,7 +3362,7 @@
           "id": "fees_finance_and_affordability",
           "type": "copy-block",
           "title": "Finance and affordability",
-          "copy": "Payment is usually taken at the time of treatment. For larger treatment plans, finance options may be available to help spread the cost.\n\nIf finance is something you would like to consider, we can explain how it works and whether it may be suitable for your situation.\n\nWe’ll always explain costs clearly before treatment starts, so you’re not faced with surprises.",
+          "copy": "Payment is usually taken at the time of treatment. For larger treatment plans, finance options may be available to help spread the cost.\n\nIf finance is something you would like to consider, we can explain how it works and whether it may be suitable for your situation.\n\nWe\u2019ll always explain costs clearly before treatment starts, so you\u2019re not faced with surprises.",
           "label": "Finance and affordability"
         },
         {
@@ -3404,8 +3404,8 @@
         {
           "id": "contact_intro_copy",
           "type": "copy-block",
-          "title": "Contact St Mary’s House Dental Care",
-          "copy": "Getting in touch should feel straightforward.\n\nWhether you’d like to arrange an appointment, ask a question, or talk something through before deciding what to do next, our team will help guide you calmly and clearly.\n\nThere’s no obligation to proceed with treatment simply by contacting us. Many people get in touch because they want to understand their options, what an initial appointment involves, or whether something sounds urgent.\n\nWe’re a private dental practice based in Shoreham-by-Sea, and we see patients with a wide range of concerns — from routine check-ups to more complex dental problems.\n\nIf you feel unsure, or it’s been a while since you last saw a dentist, that’s very common. Let us know when you contact us and we can take things at a pace that feels manageable.",
+          "title": "Contact St Mary\u2019s House Dental Care",
+          "copy": "Getting in touch should feel straightforward.\n\nWhether you\u2019d like to arrange an appointment, ask a question, or talk something through before deciding what to do next, our team will help guide you calmly and clearly.\n\nThere\u2019s no obligation to proceed with treatment simply by contacting us. Many people get in touch because they want to understand their options, what an initial appointment involves, or whether something sounds urgent.\n\nWe\u2019re a private dental practice based in Shoreham-by-Sea, and we see patients with a wide range of concerns \u2014 from routine check-ups to more complex dental problems.\n\nIf you feel unsure, or it\u2019s been a while since you last saw a dentist, that\u2019s very common. Let us know when you contact us and we can take things at a pace that feels manageable.",
           "label": "Contact"
         },
         {
@@ -3414,8 +3414,8 @@
           "title": "Practice details",
           "items": [
             "Phone, email and opening hours are shown below",
-            "If you’re unsure which appointment you need, tell us what’s been happening",
-            "For urgent dental problems, it’s best to telephone the practice during opening hours"
+            "If you\u2019re unsure which appointment you need, tell us what\u2019s been happening",
+            "For urgent dental problems, it\u2019s best to telephone the practice during opening hours"
           ],
           "label": "Details"
         },
@@ -3435,7 +3435,7 @@
           "id": "contact_form_placeholder",
           "type": "copy-block",
           "title": "How to contact us",
-          "copy": "You’re welcome to contact the practice by phone or by using the enquiry form on this page.\n\nIf your question is straightforward, our reception team can usually help directly. If it’s more clinical, we’ll make sure it’s passed to the right person.\n\nMessages are read during normal opening hours and we aim to respond as promptly as we can. Email and online enquiries aren’t suitable for urgent dental problems.\n\nAny information provided before an appointment is general in nature and can’t replace a clinical assessment. Treatment recommendations, where appropriate, are only made after we’ve seen you and discussed your individual circumstances.",
+          "copy": "You\u2019re welcome to contact the practice by phone or by using the enquiry form on this page.\n\nIf your question is straightforward, our reception team can usually help directly. If it\u2019s more clinical, we\u2019ll make sure it\u2019s passed to the right person.\n\nMessages are read during normal opening hours and we aim to respond as promptly as we can. Email and online enquiries aren\u2019t suitable for urgent dental problems.\n\nAny information provided before an appointment is general in nature and can\u2019t replace a clinical assessment. Treatment recommendations, where appropriate, are only made after we\u2019ve seen you and discussed your individual circumstances.",
           "label": "Contact form"
         },
         {
@@ -3443,7 +3443,7 @@
           "type": "map",
           "label": "Map",
           "title": "Finding the practice",
-          "copy": "St Mary’s House Dental Care is located in Shoreham-by-Sea, West Sussex.\n\nClear directions, accessibility information, and parking details are provided below to help your visit go smoothly.",
+          "copy": "St Mary\u2019s House Dental Care is located in Shoreham-by-Sea, West Sussex.\n\nClear directions, accessibility information, and parking details are provided below to help your visit go smoothly.",
           "mediaHint": "Contact page map placeholder"
         },
         {
@@ -3536,7 +3536,7 @@
           "type": "copy-block",
           "title": "Care downloads",
           "label": "Overview",
-          "copy": "The documents on this page are provided to support your care with us.\n\nThey may include aftercare guidance, treatment information, and practical notes that are useful before or after an appointment. Not every document will apply to everyone, and some information is only relevant in certain situations.\n\nIf you’ve been given a specific document by the team, you can usually find it here. If you’re unsure which information applies to you, or if something isn’t clear, we’re always happy to help explain.\n\nWritten guidance is helpful, but it can’t replace a proper conversation or clinical assessment. If something doesn’t feel right, or you have concerns following treatment, it’s important to contact the practice rather than relying only on written information.\n\nThe documents here are reviewed from time to time, so you may notice updates as guidance changes.\n\n---"
+          "copy": "The documents on this page are provided to support your care with us.\n\nThey may include aftercare guidance, treatment information, and practical notes that are useful before or after an appointment. Not every document will apply to everyone, and some information is only relevant in certain situations.\n\nIf you\u2019ve been given a specific document by the team, you can usually find it here. If you\u2019re unsure which information applies to you, or if something isn\u2019t clear, we\u2019re always happy to help explain.\n\nWritten guidance is helpful, but it can\u2019t replace a proper conversation or clinical assessment. If something doesn\u2019t feel right, or you have concerns following treatment, it\u2019s important to contact the practice rather than relying only on written information.\n\nThe documents here are reviewed from time to time, so you may notice updates as guidance changes.\n\n---"
         },
         {
           "id": "downloads_contact_cta",
@@ -3570,7 +3570,7 @@
           "type": "copy-block",
           "title": "Privacy and your information",
           "label": "Overview",
-          "copy": "This privacy notice explains how St Mary’s House Dental Care uses and protects personal information.\n\nWe are committed to handling personal data responsibly and in line with UK data protection law.\n\nWe may collect personal information when you contact the practice, book an appointment, complete forms, or use this website.\n\nThis can include contact details, appointment information, and technical data such as IP address and browser type when you use the site.\n\nPersonal information is used to provide dental care, manage appointments, communicate with you, and meet our legal and professional obligations.\n\nWe do not sell personal data and only share information where necessary for care, administration, or legal reasons.\n\nWe take appropriate steps to keep personal information secure, including access controls and secure systems.\n\nData is kept only for as long as required by clinical, legal, or regulatory obligations.\n\nYou have rights under UK data protection law, including the right to access your information and request corrections.\n\nIf you have questions about how your data is used, or wish to exercise your rights, please contact the practice.\n\nThis privacy notice may be updated from time to time to reflect changes in law or how we operate.\n\nThe current version will always be available on this website."
+          "copy": "This privacy notice explains how St Mary\u2019s House Dental Care uses and protects personal information.\n\nWe are committed to handling personal data responsibly and in line with UK data protection law.\n\nWe may collect personal information when you contact the practice, book an appointment, complete forms, or use this website.\n\nThis can include contact details, appointment information, and technical data such as IP address and browser type when you use the site.\n\nPersonal information is used to provide dental care, manage appointments, communicate with you, and meet our legal and professional obligations.\n\nWe do not sell personal data and only share information where necessary for care, administration, or legal reasons.\n\nWe take appropriate steps to keep personal information secure, including access controls and secure systems.\n\nData is kept only for as long as required by clinical, legal, or regulatory obligations.\n\nYou have rights under UK data protection law, including the right to access your information and request corrections.\n\nIf you have questions about how your data is used, or wish to exercise your rights, please contact the practice.\n\nThis privacy notice may be updated from time to time to reflect changes in law or how we operate.\n\nThe current version will always be available on this website."
         },
         {
           "id": "legal_terms",
@@ -3586,7 +3586,7 @@
             },
             {
               "title": "Who we share it with",
-              "copy": "We do not sell personal data. We only share information when it’s necessary for care, administration, or legal reasons, and we aim to share the minimum needed."
+              "copy": "We do not sell personal data. We only share information when it\u2019s necessary for care, administration, or legal reasons, and we aim to share the minimum needed."
             },
             {
               "title": "How long we keep it",
@@ -3664,7 +3664,7 @@
           "type": "copy-block",
           "title": "Using this website",
           "label": "Overview",
-          "copy": "These website terms explain how you may use this site and what the information here is (and isn’t) intended for.\n\nThe content on this website is provided for general information only. It is not a substitute for a dental examination, diagnosis, or personalised advice.\n\nIf you have a dental problem, pain, swelling, trauma, or anything you’re worried about, please contact the practice so we can advise you appropriately."
+          "copy": "These website terms explain how you may use this site and what the information here is (and isn\u2019t) intended for.\n\nThe content on this website is provided for general information only. It is not a substitute for a dental examination, diagnosis, or personalised advice.\n\nIf you have a dental problem, pain, swelling, trauma, or anything you\u2019re worried about, please contact the practice so we can advise you appropriately."
         },
         {
           "id": "legal_terms",
@@ -3680,11 +3680,11 @@
             },
             {
               "title": "Your choices and controls",
-              "copy": "You are welcome to print or share pages for personal use, but please don’t copy large parts of the site for commercial use.\n\nIf you’re making decisions about treatment, the safest route is always an appointment where we can assess you properly and explain options, limits, and likely maintenance."
+              "copy": "You are welcome to print or share pages for personal use, but please don\u2019t copy large parts of the site for commercial use.\n\nIf you\u2019re making decisions about treatment, the safest route is always an appointment where we can assess you properly and explain options, limits, and likely maintenance."
             },
             {
               "title": "How to contact us",
-              "copy": "If you have questions about the website content, or you believe something is unclear or out of date, please contact the practice and we’ll do our best to help.\n\nFor clinical concerns (pain, swelling, broken teeth, lost restorations, or anything urgent), please call us so we can guide you to the right next step."
+              "copy": "If you have questions about the website content, or you believe something is unclear or out of date, please contact the practice and we\u2019ll do our best to help.\n\nFor clinical concerns (pain, swelling, broken teeth, lost restorations, or anything urgent), please call us so we can guide you to the right next step."
             },
             {
               "title": "Updates to this page",
@@ -3711,7 +3711,7 @@
           "type": "copy-block",
           "title": "Accessibility on our website",
           "label": "Overview",
-          "copy": "We want our website to be usable for as many people as possible. Accessibility is an ongoing process, and we aim to improve readability, navigation, and compatibility with assistive technologies over time. If you find any part of the site difficult to use — for example, problems with contrast, text size, forms, or keyboard navigation — please let us know. Where possible, we can provide information in an alternative format and record feedback for future improvements."
+          "copy": "We want our website to be usable for as many people as possible. Accessibility is an ongoing process, and we aim to improve readability, navigation, and compatibility with assistive technologies over time. If you find any part of the site difficult to use \u2014 for example, problems with contrast, text size, forms, or keyboard navigation \u2014 please let us know. Where possible, we can provide information in an alternative format and record feedback for future improvements."
         },
         {
           "id": "legal_terms",
@@ -3723,11 +3723,11 @@
             },
             {
               "title": "What you can do on your side",
-              "copy": "Many people improve readability using browser or device settings (text size, zoom, contrast modes, reader modes, and voice control). If you’d like help finding those settings, let us know."
+              "copy": "Many people improve readability using browser or device settings (text size, zoom, contrast modes, reader modes, and voice control). If you\u2019d like help finding those settings, let us know."
             },
             {
               "title": "Known limitations",
-              "copy": "Some third-party tools, embedded media, or older documents may not meet every accessibility standard in every situation. If you find something that isn’t working for you, we want to know so we can look at alternatives."
+              "copy": "Some third-party tools, embedded media, or older documents may not meet every accessibility standard in every situation. If you find something that isn\u2019t working for you, we want to know so we can look at alternatives."
             },
             {
               "title": "Alternative formats",
@@ -3758,7 +3758,7 @@
           "type": "copy-block",
           "title": "Raising concerns",
           "label": "Overview",
-          "copy": "If something hasn’t felt right, we want to know.\n\nWe take complaints seriously and we aim to resolve concerns fairly, calmly, and as quickly as possible.\n\nIf you feel able, please raise the issue with us directly first. Most concerns can be resolved promptly once we understand what has happened and what you’re worried about."
+          "copy": "If something hasn\u2019t felt right, we want to know.\n\nWe take complaints seriously and we aim to resolve concerns fairly, calmly, and as quickly as possible.\n\nIf you feel able, please raise the issue with us directly first. Most concerns can be resolved promptly once we understand what has happened and what you\u2019re worried about."
         },
         {
           "id": "legal_terms",
@@ -3770,7 +3770,7 @@
             },
             {
               "title": "Key points in plain English",
-              "copy": "- Tell us what happened and what outcome you’re hoping for.\n- We will listen, review what we can, and respond clearly.\n- If we need time to investigate properly, we will tell you the expected timescales.\n- You can raise concerns in writing, by email, or by speaking to the team."
+              "copy": "- Tell us what happened and what outcome you\u2019re hoping for.\n- We will listen, review what we can, and respond clearly.\n- If we need time to investigate properly, we will tell you the expected timescales.\n- You can raise concerns in writing, by email, or by speaking to the team."
             },
             {
               "title": "Your choices and controls",
@@ -3804,7 +3804,7 @@
           "id": "blog_intro_copy",
           "type": "copy-block",
           "title": "Practice insights",
-          "copy": "This is where we share practical notes and clinical insights from the practice.\n\nMost posts are written to help you make sense of common dental concerns, what tends to cause them, and what sensible next steps usually look like. From time to time we’ll also explain how planning, scanning and modern materials can make treatment more predictable.\n\nEverything here is general information. It can be a useful starting point, but it can’t replace advice tailored to you after an examination. If something you read here raises questions about your own teeth or gums, we’re happy to talk it through at an appointment.\n\n---",
+          "copy": "This is where we share practical notes and clinical insights from the practice.\n\nMost posts are written to help you make sense of common dental concerns, what tends to cause them, and what sensible next steps usually look like. From time to time we\u2019ll also explain how planning, scanning and modern materials can make treatment more predictable.\n\nEverything here is general information. It can be a useful starting point, but it can\u2019t replace advice tailored to you after an examination. If something you read here raises questions about your own teeth or gums, we\u2019re happy to talk it through at an appointment.\n\n---",
           "label": "Insights"
         },
         {
@@ -3815,7 +3815,7 @@
             "Prevention and looking after teeth and gums between visits",
             "Common problems we see (tooth wear, sensitivity, gum issues) and what they can mean",
             "Treatment planning: what an assessment involves and why stages matter",
-            "Technology and materials — what they help with, and where the limits are"
+            "Technology and materials \u2014 what they help with, and where the limits are"
           ],
           "label": "Topics"
         }
@@ -3904,7 +3904,7 @@
           "id": "video_consultation_intro",
           "type": "copy-block",
           "title": "Remote guidance with a clinician",
-          "copy": "A video consultation can be a calm first step if you’d like clinical guidance before coming into the practice.\n\nIt works well for discussing symptoms, reviewing your history, talking through options, and planning what would be most useful to do in person. If something needs a hands-on examination, X-rays or scans, we’ll be clear about that and help you book the right appointment.\n\nA video consultation is not designed for emergencies, significant swelling, trauma, or situations where you may need urgent clinical care. In those cases, please call us so we can advise promptly.",
+          "copy": "A video consultation can be a calm first step if you\u2019d like clinical guidance before coming into the practice.\n\nIt works well for discussing symptoms, reviewing your history, talking through options, and planning what would be most useful to do in person. If something needs a hands-on examination, X-rays or scans, we\u2019ll be clear about that and help you book the right appointment.\n\nA video consultation is not designed for emergencies, significant swelling, trauma, or situations where you may need urgent clinical care. In those cases, please call us so we can advise promptly.",
           "label": "Overview"
         },
         {
@@ -4004,7 +4004,7 @@
           "id": "finance_intro",
           "type": "copy-block",
           "title": "Finance support without pressure",
-          "copy": "Some patients prefer to spread the cost of dental treatment over time rather than paying for everything at once.\n\nFinance can be a practical option for larger treatment plans, but it isn’t right for everyone and isn’t a requirement for treatment.",
+          "copy": "Some patients prefer to spread the cost of dental treatment over time rather than paying for everything at once.\n\nFinance can be a practical option for larger treatment plans, but it isn\u2019t right for everyone and isn\u2019t a requirement for treatment.",
           "label": "Overview"
         },
         {
@@ -4131,7 +4131,7 @@
             },
             {
               "title": "Digital smile design",
-              "description": "Visual planning to guide decisions—helpful, but never a guarantee.",
+              "description": "Visual planning to guide decisions\u2014helpful, but never a guarantee.",
               "href": "/treatments/digital-smile-design"
             },
             {
@@ -4174,7 +4174,7 @@
             "preset": "primary"
           },
           {
-            "label": "What’s included in a check-up?",
+            "label": "What\u2019s included in a check-up?",
             "href": "/dental-checkups-oral-cancer-screening",
             "preset": "secondary"
           }
@@ -4186,7 +4186,7 @@
             "preset": "primary"
           },
           {
-            "label": "What’s included in a check-up?",
+            "label": "What\u2019s included in a check-up?",
             "href": "/dental-checkups-oral-cancer-screening",
             "preset": "secondary"
           }
@@ -4197,7 +4197,7 @@
           "id": "practice_plan_intro",
           "type": "copy-block",
           "title": "Membership that keeps care consistent",
-          "copy": "A dental practice plan is designed to help patients look after their oral health on an ongoing basis, rather than focusing only on treatment when problems arise.\n\nIt spreads the cost of routine dental care and encourages regular review, prevention, and early intervention where needed.\n\nWe’ll explain what is included, what isn’t, and how often appointments are recommended for you personally. If you’re comparing options, we can also talk through pay-as-you-go fees so you can choose what fits best.",
+          "copy": "A dental practice plan is designed to help patients look after their oral health on an ongoing basis, rather than focusing only on treatment when problems arise.\n\nIt spreads the cost of routine dental care and encourages regular review, prevention, and early intervention where needed.\n\nWe\u2019ll explain what is included, what isn\u2019t, and how often appointments are recommended for you personally. If you\u2019re comparing options, we can also talk through pay-as-you-go fees so you can choose what fits best.",
           "label": "Overview"
         },
         {
@@ -4246,7 +4246,7 @@
               "preset": "primary"
             },
             {
-              "label": "What’s included in a check-up?",
+              "label": "What\u2019s included in a check-up?",
               "href": "/dental-checkups-oral-cancer-screening",
               "preset": "secondary"
             }
@@ -4339,7 +4339,7 @@
               "preset": "secondary"
             },
             {
-              "label": "Children’s dental care",
+              "label": "Children\u2019s dental care",
               "href": "/treatments/childrens-dentistry",
               "preset": "secondary"
             },
@@ -4482,7 +4482,7 @@
               "preset": "secondary"
             },
             {
-              "label": "Children’s dental care",
+              "label": "Children\u2019s dental care",
               "href": "/treatments/childrens-dentistry",
               "preset": "secondary"
             },
@@ -4718,7 +4718,7 @@
           {
             "id": "local_shoreham_context",
             "heading": "Local Shoreham-by-Sea context",
-            "body": "Single-tooth implant assessment and follow-up are planned through St Mary’s House Dental Care in Shoreham-by-Sea so reviews, maintenance and any staged appointments remain practical for local patients."
+            "body": "Single-tooth implant assessment and follow-up are planned through St Mary\u2019s House Dental Care in Shoreham-by-Sea so reviews, maintenance and any staged appointments remain practical for local patients."
           },
           {
             "id": "clinician_expertise",
@@ -4987,7 +4987,7 @@
           {
             "id": "local_shoreham_context",
             "heading": "Local Shoreham-by-Sea context",
-            "body": "Planning, reviews and maintenance are coordinated through St Mary’s House Dental Care in Shoreham-by-Sea, which is important for multi-stage treatment that may need several visits."
+            "body": "Planning, reviews and maintenance are coordinated through St Mary\u2019s House Dental Care in Shoreham-by-Sea, which is important for multi-stage treatment that may need several visits."
           },
           {
             "id": "clinician_expertise",
@@ -5140,7 +5140,199 @@
         }
       ],
       "surface": "champagne/surface/treatment",
-      "heroFamily": "treatments.implants"
+      "heroFamily": "treatments.implants",
+      "answerSurface": {
+        "version": "TREATMENT_ANSWER_SURFACE_V1",
+        "status": "answer_surface_complete",
+        "frameworkOnly": false,
+        "exampleSeed": false,
+        "primaryGeography": "Shoreham-by-Sea",
+        "secondaryGeographies": [
+          "Brighton",
+          "Worthing",
+          "Lancing",
+          "Southwick"
+        ],
+        "sections": [
+          {
+            "id": "direct_answer",
+            "heading": "Direct answer",
+            "body": "Full-arch implant treatment can replace a full upper or lower arch of failing or missing teeth with a fixed bridge supported by dental implants, when assessment confirms it is a safe and suitable option. At Smile More Dental Care in Shoreham-by-Sea, planning includes health review, CBCT imaging, bite assessment, provisional tooth planning and clear discussion of alternatives, risks, maintenance and costs before treatment starts."
+          },
+          {
+            "id": "what_this_treatment_is",
+            "heading": "What this treatment is",
+            "body": "A full-arch implant bridge is a custom set of fixed teeth secured to several implants, commonly planned across one jaw. It may involve extractions, infection or gum stabilisation, implant placement, a provisional bridge during healing and a final bridge once tissues and bite are stable."
+          },
+          {
+            "id": "who_it_is_for",
+            "heading": "Who it is for",
+            "items": [
+              "Adults with many failing or missing teeth who want to explore a fixed full-arch option.",
+              "Denture wearers who want greater stability, if implants and general health are suitable.",
+              "Patients willing to complete diagnostics, staged planning, healing reviews and long-term hygiene maintenance."
+            ]
+          },
+          {
+            "id": "who_it_may_not_be_suitable_for",
+            "heading": "Who it may not be suitable for",
+            "items": [
+              "People with active gum disease, untreated infection or unstable oral health until these are managed.",
+              "Patients whose medical history, smoking, diabetes control, bone volume or bite forces make surgery higher risk.",
+              "Anyone needing a guaranteed same-day result before diagnostics confirm whether immediate loading is appropriate."
+            ]
+          },
+          {
+            "id": "benefits",
+            "heading": "Benefits",
+            "items": [
+              "Can provide a fixed alternative to a loose full denture when clinically suitable.",
+              "Can improve chewing stability, speech confidence and comfort compared with unstable removable teeth.",
+              "Can be planned with provisional teeth during healing when immediate or next-day provision is safe for the case."
+            ]
+          },
+          {
+            "id": "risks_and_limitations",
+            "heading": "Risks and limitations",
+            "items": [
+              "Full-arch implant care involves surgery, healing time and maintenance, and implant integration is not guaranteed.",
+              "Possible risks include swelling, bruising, infection, implant failure, gum recession, nerve or sinus complications, bridge wear and bite-related problems.",
+              "Smoking, uncontrolled health conditions, tooth grinding, poor hygiene and missed reviews can increase risk and may change the recommended plan."
+            ]
+          },
+          {
+            "id": "alternatives",
+            "heading": "Alternatives",
+            "items": [
+              "A well-made complete denture or improved denture design.",
+              "Implant-retained dentures where removable stability is more appropriate than a fixed bridge.",
+              "Staged implant bridge treatment, bone grafting, periodontal stabilisation or retaining selected teeth where this is safer."
+            ]
+          },
+          {
+            "id": "process",
+            "heading": "Process",
+            "items": [
+              "Consultation to understand concerns, medical history, expectations and existing denture or failing-tooth issues.",
+              "CBCT scan, photographs, digital records and bite analysis to assess anatomy and prosthetic design.",
+              "Treatment planning to decide implant number, provisional options, timing, fees, alternatives and consent.",
+              "Surgery and provisional phase when appropriate, followed by healing checks, bite reviews and hygiene support.",
+              "Final bridge design and fit after healing, with ongoing reviews and maintenance planning."
+            ]
+          },
+          {
+            "id": "timeline",
+            "heading": "Timeline",
+            "body": "Timelines vary by clinical findings. Some suitable cases may receive provisional fixed teeth on the day of surgery or the next day, while other cases are safer when staged. Healing, final bridge design and fit commonly take several months, depending on bone, gum health, bite, extractions, grafting needs and how tissues settle."
+          },
+          {
+            "id": "aftercare",
+            "heading": "Aftercare",
+            "items": [
+              "Expect written guidance for cleaning, diet, comfort, swelling and when to contact the practice after surgery.",
+              "Daily cleaning under the bridge and around implant posts is essential, using aids demonstrated by the clinical team.",
+              "Long-term success depends on hygiene visits, review appointments, bite checks and early attention to soreness, loosening or cleaning difficulties."
+            ]
+          },
+          {
+            "id": "cost_fee_logic",
+            "heading": "Cost and fee logic",
+            "body": "Fees are confirmed only after assessment because full-arch implant care depends on diagnostics, extraction needs, implant number, provisional and final bridge design, sedation, grafting requirements and maintenance planning. Finance or staged options can be discussed before you decide whether to proceed."
+          },
+          {
+            "id": "local_shoreham_context",
+            "heading": "Local Shoreham context",
+            "body": "The page is for patients considering full-arch dental implant rehabilitation with Smile More Dental Care in Shoreham-by-Sea. The priority is a consult-led plan rather than a one-size-fits-all promise, with suitability and alternatives explained before treatment decisions are made."
+          },
+          {
+            "id": "clinician_expertise",
+            "heading": "Clinician expertise",
+            "body": "Full-arch implant planning is clinician-led and uses diagnostic records, medical assessment, consent discussion and maintenance planning. The team explains where treatment is appropriate, where staging is safer and where an alternative may better protect oral health."
+          },
+          {
+            "id": "technology_used",
+            "heading": "Technology used",
+            "items": [
+              "CBCT imaging to assess bone volume and important anatomy.",
+              "Digital impressions, photographs and bite records to plan the provisional and final bridge.",
+              "Guided positioning and occlusion reviews where appropriate to support implant placement and bridge function."
+            ]
+          },
+          {
+            "id": "faq",
+            "heading": "Full-arch implant FAQs",
+            "faqs": [
+              {
+                "question": "Can full-arch implants be fitted in one day?",
+                "answer": "Some suitable cases can have provisional fixed teeth on the day of surgery or the next day, but this depends on bone quality, implant stability, bite and health factors confirmed during planning."
+              },
+              {
+                "question": "Will I be without teeth during treatment?",
+                "answer": "The aim is to plan a provisional option so you are not left without teeth, but the safest temporary arrangement depends on your starting point and whether treatment needs to be staged."
+              },
+              {
+                "question": "How do I clean a full-arch implant bridge?",
+                "answer": "You need daily cleaning under the bridge and around the implant supports using brushes, floss aids or other tools shown by the team, plus regular hygiene reviews."
+              },
+              {
+                "question": "How much does full-arch implant treatment cost?",
+                "answer": "The fee is individual because it depends on scans, extractions, implant number, provisional and final bridge design, sedation, grafting needs and aftercare planning."
+              }
+            ]
+          },
+          {
+            "id": "related_treatments_internal_links",
+            "heading": "Related treatments and internal links",
+            "links": [
+              {
+                "label": "Dental implants",
+                "href": "/treatments/implants"
+              },
+              {
+                "label": "CBCT 3D scanning",
+                "href": "/treatments/cbct-3d-scanning"
+              },
+              {
+                "label": "Implant-retained dentures",
+                "href": "/treatments/implants-retained-dentures"
+              },
+              {
+                "label": "Implant aftercare",
+                "href": "/treatments/implants-aftercare"
+              },
+              {
+                "label": "Teeth in a Day",
+                "href": "/treatments/teeth-in-a-day"
+              }
+            ]
+          },
+          {
+            "id": "last_reviewed_clinical_review",
+            "heading": "Clinical review",
+            "review": {
+              "status": "clinical_review_required",
+              "lastReviewed": "2026-06-19",
+              "reviewer": "Smile More Dental Care clinical team",
+              "notes": "Answer-surface completion preserves cautious YMYL posture and requires clinician review before publication claims are expanded."
+            }
+          },
+          {
+            "id": "cta",
+            "heading": "Next step",
+            "body": "Book a consultation to discuss whether full-arch implant rehabilitation, a staged approach or an alternative is most appropriate for your mouth, health and goals.",
+            "ctas": [
+              {
+                "label": "Plan a clinician-led implants full arch review",
+                "href": "/contact"
+              },
+              {
+                "label": "Consider alternatives like CBCT 3D scanning",
+                "href": "/treatments/cbct-3d-scanning"
+              }
+            ]
+          }
+        ]
+      }
     },
     "implant_retained_dentures": {
       "id": "implant_retained_dentures",
@@ -5398,7 +5590,7 @@
           {
             "id": "local_shoreham_context",
             "heading": "Local Shoreham-by-Sea context",
-            "body": "Implant consultations are arranged through St Mary’s House Dental Care in Shoreham-by-Sea, with local follow-up useful for diagnostics, treatment planning and long-term maintenance discussions."
+            "body": "Implant consultations are arranged through St Mary\u2019s House Dental Care in Shoreham-by-Sea, with local follow-up useful for diagnostics, treatment planning and long-term maintenance discussions."
           },
           {
             "id": "clinician_expertise",
@@ -6293,7 +6485,7 @@
           "id": "3d_printed_veneers_mid_cta",
           "type": "treatment_mid_cta",
           "title": "Explore options around printed veneers",
-          "strapline": "Compare complementary treatments and planning steps that often pair well with digitally designed veneer restorations. We’ll always help you choose what fits your bite, lifestyle, and long-term plan."
+          "strapline": "Compare complementary treatments and planning steps that often pair well with digitally designed veneer restorations. We\u2019ll always help you choose what fits your bite, lifestyle, and long-term plan."
         },
         {
           "id": "treatment.faq"
@@ -6354,12 +6546,12 @@
           "type": "copy-block",
           "title": "Conservative improvements, well planned",
           "label": "Introduction",
-          "copy": "Composite bonding uses tooth-coloured resin to improve shape, close small gaps, repair chips, or soften uneven edges. It can often be done with minimal drilling, making it a conservative option when the bite and enamel are suitable. We begin with an assessment of wear, staining, gum health and bite forces, because those factors determine how predictable bonding will be over time. For some patients, whitening or aligner straightening first can improve the final result and reduce the amount of composite needed. If bonding is a good fit, we’ll explain what it can achieve, how it’s maintained, and what to expect with polishing and repairs."
+          "copy": "Composite bonding uses tooth-coloured resin to improve shape, close small gaps, repair chips, or soften uneven edges. It can often be done with minimal drilling, making it a conservative option when the bite and enamel are suitable. We begin with an assessment of wear, staining, gum health and bite forces, because those factors determine how predictable bonding will be over time. For some patients, whitening or aligner straightening first can improve the final result and reduce the amount of composite needed. If bonding is a good fit, we\u2019ll explain what it can achieve, how it\u2019s maintained, and what to expect with polishing and repairs."
         },
         {
           "id": "composite_indications",
           "type": "features",
-          "title": "What composite bonding can and can’t do",
+          "title": "What composite bonding can and can\u2019t do",
           "items": [
             "Adds volume to close small gaps, soften edges, and refine proportions without drilling healthy enamel",
             "Repairs chipped or worn incisal edges; larger fractures or weakened teeth may need onlays or crowns",
@@ -6396,7 +6588,7 @@
             "When colour is the main concern, dentist-led whitening is usually recommended before bonding so shades align",
             "If teeth are rotated or crowded, aligners or other orthodontic treatment can set the foundation before cosmetic bonding",
             "For larger shape changes or durability, porcelain veneers or digitally designed 3D veneers may be more appropriate",
-            "Composite bonding often forms part of an Align → Bleach → Composite pathway, with veneers reserved for specific needs"
+            "Composite bonding often forms part of an Align \u2192 Bleach \u2192 Composite pathway, with veneers reserved for specific needs"
           ]
         },
         {
@@ -6413,7 +6605,7 @@
         {
           "id": "composite_not_suited",
           "type": "features",
-          "title": "When bonding isn’t the best choice",
+          "title": "When bonding isn\u2019t the best choice",
           "items": [
             "Heavy bites or active clenching with limited space may need occlusal therapy or guards first",
             "Severe wear or bite collapse often requires orthodontics, onlays, or veneers for stability",
@@ -7143,7 +7335,7 @@
           "type": "copy-block",
           "title": "Strength, function, and maintainability",
           "label": "Introduction",
-          "copy": "A dental crown is a protective restoration that covers and strengthens a tooth that is heavily filled, cracked, worn down, or has had root canal treatment. The goal is to restore function and protect the remaining tooth structure, while keeping the bite comfortable and the margins clean and maintainable. We plan crowns using a full assessment and digital scans so we can check contact points, bite forces and appearance before anything is finalised. Where appropriate, we’ll discuss onlays or adhesive options that preserve more natural tooth. If a crown is recommended, we’ll explain materials, preparation, and how to look after it."
+          "copy": "A dental crown is a protective restoration that covers and strengthens a tooth that is heavily filled, cracked, worn down, or has had root canal treatment. The goal is to restore function and protect the remaining tooth structure, while keeping the bite comfortable and the margins clean and maintainable. We plan crowns using a full assessment and digital scans so we can check contact points, bite forces and appearance before anything is finalised. Where appropriate, we\u2019ll discuss onlays or adhesive options that preserve more natural tooth. If a crown is recommended, we\u2019ll explain materials, preparation, and how to look after it."
         },
         {
           "id": "treatment_overview_copy"
@@ -7186,7 +7378,7 @@
         {
           "id": "restorative_full_inventory",
           "type": "routing_cards",
-          "title": "Restorative Dentistry — full treatment list",
+          "title": "Restorative Dentistry \u2014 full treatment list",
           "label": "Full list",
           "items": [
             {
@@ -7530,7 +7722,7 @@
           "id": "whitening_consult_overview",
           "type": "treatment_overview_rich",
           "title": "A measured plan tailored to your smile",
-          "copy": "We assess enamel, existing restorations, and gum health before prescribing a gel strength and schedule. You’ll see a realistic shade range, understand how whitening supports planned alignment or bonding, and know when we’ll review progress.",
+          "copy": "We assess enamel, existing restorations, and gum health before prescribing a gel strength and schedule. You\u2019ll see a realistic shade range, understand how whitening supports planned alignment or bonding, and know when we\u2019ll review progress.",
           "bullets": [
             "Clinical exam and baseline shade recording",
             "Digital scans for precise tray production",
@@ -7593,7 +7785,7 @@
         {
           "id": "aesthetic_full_inventory",
           "type": "routing_cards",
-          "title": "Aesthetic Dentistry — full treatment list",
+          "title": "Aesthetic Dentistry \u2014 full treatment list",
           "label": "Full list",
           "items": [
             {
@@ -7642,7 +7834,7 @@
           {
             "id": "direct_answer",
             "heading": "Direct answer",
-            "body": "Teeth whitening at St Mary’s House Dental Care is a dentist-led cosmetic treatment for suitable adults who want to lighten natural tooth enamel. Suitability and likely response depend on oral health, restorations, sensitivity, staining type and clinical assessment; no specific shade change can be guaranteed."
+            "body": "Teeth whitening at St Mary\u2019s House Dental Care is a dentist-led cosmetic treatment for suitable adults who want to lighten natural tooth enamel. Suitability and likely response depend on oral health, restorations, sensitivity, staining type and clinical assessment; no specific shade change can be guaranteed."
           },
           {
             "id": "what_this_treatment_is",
@@ -7811,7 +8003,7 @@
             "heading": "Last reviewed",
             "review": {
               "lastReviewed": "2026-05-29",
-              "clinicalReviewer": "St Mary’s House Dental Care clinical team",
+              "clinicalReviewer": "St Mary\u2019s House Dental Care clinical team",
               "nextReviewDue": "2027-05-29"
             }
           },
@@ -7917,7 +8109,7 @@
           "faqs": [
             {
               "question": "How long will I wear the trays each day?",
-              "answer": "Most patients whiten for a set period each evening based on the prescribed gel. We’ll agree the exact cadence with you."
+              "answer": "Most patients whiten for a set period each evening based on the prescribed gel. We\u2019ll agree the exact cadence with you."
             },
             {
               "question": "What if my teeth feel sensitive?",
@@ -7981,7 +8173,7 @@
           "bullets": [
             "Shade comparison against your baseline",
             "Inspection of trays for seal and comfort",
-            "Discussion of how often you’ll realistically top-up",
+            "Discussion of how often you\u2019ll realistically top-up",
             "Guidance if restorations need refreshing instead of whitening",
             "Written instructions for the latest gel strength"
           ]
@@ -8017,7 +8209,7 @@
             },
             {
               "question": "Can I reuse my old trays?",
-              "answer": "Yes, provided the fit is still secure. We’ll check for wear or gaps before supplying gel."
+              "answer": "Yes, provided the fit is still secure. We\u2019ll check for wear or gaps before supplying gel."
             },
             {
               "question": "Will I need stronger gel each time?",
@@ -8098,7 +8290,7 @@
           "id": "whitening_sensitivity_mid_cta",
           "type": "treatment_mid_cta",
           "title": "Sensitivity-aware whitening options",
-          "strapline": "If sensitivity is the main issue, it can help to address the cause first — such as gum health, tooth wear, or hygiene care — then decide whether whitening still makes sense."
+          "strapline": "If sensitivity is the main issue, it can help to address the cause first \u2014 such as gum health, tooth wear, or hygiene care \u2014 then decide whether whitening still makes sense."
         },
         {
           "id": "whitening_sensitivity_faq",
@@ -8188,11 +8380,11 @@
             },
             {
               "question": "How long does whitening last?",
-              "answer": "Results are maintained with good hygiene and occasional top-ups. We’ll guide you on a safe refresh schedule using your existing trays."
+              "answer": "Results are maintained with good hygiene and occasional top-ups. We\u2019ll guide you on a safe refresh schedule using your existing trays."
             },
             {
               "question": "Is whitening part of a smile makeover?",
-              "answer": "Often yes. Whitening is the “B” in our Align, Bleach, Composite approach so colour is set before aligning teeth or adding bonding."
+              "answer": "Often yes. Whitening is the \u201cB\u201d in our Align, Bleach, Composite approach so colour is set before aligning teeth or adding bonding."
             }
           ]
         },
@@ -8287,7 +8479,7 @@
         {
           "id": "orthodontics_full_inventory",
           "type": "routing_cards",
-          "title": "Orthodontics & Retainers — full treatment list",
+          "title": "Orthodontics & Retainers \u2014 full treatment list",
           "label": "Full list",
           "items": [
             {
@@ -8346,7 +8538,7 @@
           "id": "full_smile_makeover_overview_rich",
           "type": "treatment_overview_rich",
           "title": "Smile makeovers guided by a shared plan",
-          "copy": "A full smile makeover is a way of looking at your teeth together, rather than treating individual problems in isolation. People often come to us with a mix of concerns — how their teeth look, how they function, or how they’ve changed over time.\n\nRather than jumping straight to treatment, we start by understanding what matters to you and what’s realistically achievable. In many cases, there is more than one way forward. Some options are simpler and more conservative, while others are more involved and take longer.\n\nOur role is to help you understand those options clearly, including their limits, so you can decide what feels right for you.\n\n---",
+          "copy": "A full smile makeover is a way of looking at your teeth together, rather than treating individual problems in isolation. People often come to us with a mix of concerns \u2014 how their teeth look, how they function, or how they\u2019ve changed over time.\n\nRather than jumping straight to treatment, we start by understanding what matters to you and what\u2019s realistically achievable. In many cases, there is more than one way forward. Some options are simpler and more conservative, while others are more involved and take longer.\n\nOur role is to help you understand those options clearly, including their limits, so you can decide what feels right for you.\n\n---",
           "bullets": [
             "Plan designed from scans and photos",
             "Sequence options reviewed together",
@@ -8370,7 +8562,7 @@
           "items": [
             {
               "title": "Digital smile design",
-              "description": "We start by understanding your concerns, examining your teeth and bite, and discussing what you’d like to change. This helps identify which problems need addressing first and which can be left alone."
+              "description": "We start by understanding your concerns, examining your teeth and bite, and discussing what you\u2019d like to change. This helps identify which problems need addressing first and which can be left alone."
             },
             {
               "title": "Phase timeline",
@@ -8386,7 +8578,7 @@
           "id": "full_smile_makeover_clinician_insight",
           "type": "clinician_insight",
           "label": "Clinician insight",
-          "quote": "A full smile makeover isn’t a single treatment. It’s a way of planning several treatments together so they work well as a whole.\n\nWhat that involves varies from person to person. For some, it may focus on alignment and tooth position. For others, it may involve whitening, bonding, veneers or restorative work to address wear, damage or long-standing problems.\n\nThe most important part is the assessment and planning stage. We take time to understand what’s bothering you, examine your teeth and bite carefully, and look at what is realistically achievable. In many cases, treatment is staged over time rather than rushed.\n\nNot everyone needs a full smile makeover. Sometimes smaller, simpler steps can make a meaningful difference. Part of our role is helping you understand the options, the limitations, and what makes sense for you in the long term.",
+          "quote": "A full smile makeover isn\u2019t a single treatment. It\u2019s a way of planning several treatments together so they work well as a whole.\n\nWhat that involves varies from person to person. For some, it may focus on alignment and tooth position. For others, it may involve whitening, bonding, veneers or restorative work to address wear, damage or long-standing problems.\n\nThe most important part is the assessment and planning stage. We take time to understand what\u2019s bothering you, examine your teeth and bite carefully, and look at what is realistically achievable. In many cases, treatment is staged over time rather than rushed.\n\nNot everyone needs a full smile makeover. Sometimes smaller, simpler steps can make a meaningful difference. Part of our role is helping you understand the options, the limitations, and what makes sense for you in the long term.",
           "attribution": "Clinical team",
           "role": "Smile design"
         },
@@ -8397,15 +8589,15 @@
           "title": "Makeover journeys",
           "stories": [
             {
-              "summary": "“I wanted to improve how my teeth looked, but I was nervous about doing too much. We talked through different options and took things step by step, which made the whole process feel manageable.”",
+              "summary": "\u201cI wanted to improve how my teeth looked, but I was nervous about doing too much. We talked through different options and took things step by step, which made the whole process feel manageable.\u201d",
               "name": "Case P"
             },
             {
-              "summary": "“My teeth had worn over time and I wasn’t sure what could realistically be done. The planning stage helped me understand what was possible and what wasn’t, before deciding how far to go.”",
+              "summary": "\u201cMy teeth had worn over time and I wasn\u2019t sure what could realistically be done. The planning stage helped me understand what was possible and what wasn\u2019t, before deciding how far to go.\u201d",
               "name": "Case Q"
             },
             {
-              "summary": "“I didn’t want anything rushed. Having time to think things through and spread treatment out made a big difference to how comfortable I felt.”",
+              "summary": "\u201cI didn\u2019t want anything rushed. Having time to think things through and spread treatment out made a big difference to how comfortable I felt.\u201d",
               "name": "Case R"
             }
           ]
@@ -8414,7 +8606,7 @@
           "id": "full_smile_makeover_mid_cta",
           "type": "treatment_mid_cta",
           "title": "Planning a wider smile change",
-          "strapline": "If you’re considering a full smile makeover, the first step is a conversation. An assessment allows us to look at your teeth properly and talk through whether this approach makes sense for you."
+          "strapline": "If you\u2019re considering a full smile makeover, the first step is a conversation. An assessment allows us to look at your teeth properly and talk through whether this approach makes sense for you."
         },
         {
           "id": "full_smile_makeover_faq",
@@ -8424,7 +8616,7 @@
           "faqs": [
             {
               "question": "Who is a full smile makeover for?",
-              "answer": "It may be suitable for people with several concerns they’d like to address together, such as worn, discoloured, misaligned or damaged teeth. An assessment is needed to see whether this approach is appropriate."
+              "answer": "It may be suitable for people with several concerns they\u2019d like to address together, such as worn, discoloured, misaligned or damaged teeth. An assessment is needed to see whether this approach is appropriate."
             },
             {
               "question": "What treatments might be involved?",
@@ -8432,11 +8624,11 @@
             },
             {
               "question": "How long does it take?",
-              "answer": "Timeframes vary. Some treatment plans take a few months, while others are staged over a longer period. We’ll talk this through during planning so you know what to expect."
+              "answer": "Timeframes vary. Some treatment plans take a few months, while others are staged over a longer period. We\u2019ll talk this through during planning so you know what to expect."
             },
             {
               "question": "Are there alternatives?",
-              "answer": "Yes. In many cases, more limited treatment can still improve appearance or function. We’ll discuss alternatives and the likely trade-offs."
+              "answer": "Yes. In many cases, more limited treatment can still improve appearance or function. We\u2019ll discuss alternatives and the likely trade-offs."
             },
             {
               "question": "How long do results last?",
@@ -8653,7 +8845,7 @@
             "heading": "Last reviewed",
             "review": {
               "lastReviewed": "2026-05-29",
-              "clinicalReviewer": "St Mary’s House Dental Care clinical team",
+              "clinicalReviewer": "St Mary\u2019s House Dental Care clinical team",
               "nextReviewDue": "2027-05-29"
             }
           },
@@ -8742,7 +8934,7 @@
         {
           "id": "digital_full_inventory",
           "type": "routing_cards",
-          "title": "3D & Digital Dentistry — full treatment list",
+          "title": "3D & Digital Dentistry \u2014 full treatment list",
           "label": "Full list",
           "items": [
             {
@@ -8825,9 +9017,9 @@
           "id": "emergency_dentistry_overview",
           "type": "treatment_overview_rich",
           "title": "Emergency dentistry",
-          "copy": "If you’re in pain, have swelling, or you’ve damaged a tooth, the first job is to work out what’s urgent and what’s fixable — calmly.\n\nEmergency care is usually about stabilising the situation: getting you comfortable, reducing risk, and planning the right longer-term repair.\n\nIf you’re unsure whether you need to be seen quickly, contact us and we’ll guide you.",
+          "copy": "If you\u2019re in pain, have swelling, or you\u2019ve damaged a tooth, the first job is to work out what\u2019s urgent and what\u2019s fixable \u2014 calmly.\n\nEmergency care is usually about stabilising the situation: getting you comfortable, reducing risk, and planning the right longer-term repair.\n\nIf you\u2019re unsure whether you need to be seen quickly, contact us and we\u2019ll guide you.",
           "bullets": [
-            "Assess what’s happening and how urgent it is",
+            "Assess what\u2019s happening and how urgent it is",
             "Settle pain and stabilise the problem safely",
             "Explain the next step and the longer-term plan"
           ]
@@ -8837,7 +9029,7 @@
           "type": "copy-block",
           "title": "How we handle dental emergencies",
           "label": "Introduction",
-          "copy": "Dental problems rarely arrive at a convenient time.\n\nWe’ll listen to what’s happening, ask a few focused questions, and advise whether it sounds urgent. If you need to be seen, we’ll aim to book the right type of appointment rather than squeeze you into the wrong slot.\n\nIf there are signs of a serious spreading infection (rapid facial swelling, fever, difficulty swallowing, or breathing problems), seek urgent medical help immediately (A&E / 999) and then let us know as soon as you can."
+          "copy": "Dental problems rarely arrive at a convenient time.\n\nWe\u2019ll listen to what\u2019s happening, ask a few focused questions, and advise whether it sounds urgent. If you need to be seen, we\u2019ll aim to book the right type of appointment rather than squeeze you into the wrong slot.\n\nIf there are signs of a serious spreading infection (rapid facial swelling, fever, difficulty swallowing, or breathing problems), seek urgent medical help immediately (A&E / 999) and then let us know as soon as you can."
         },
         {
           "id": "emergency_dentistry_triage",
@@ -8856,7 +9048,7 @@
           "type": "steps",
           "title": "What to do right now",
           "items": [
-            "Contact us with a short description of what’s happened, where the pain is, and how long it has been going on",
+            "Contact us with a short description of what\u2019s happened, where the pain is, and how long it has been going on",
             "Use normal pain relief if safe for you (follow the packet guidance) and avoid chewing on the painful side",
             "If you develop facial swelling, fever, difficulty swallowing, or breathing problems, seek urgent medical help"
           ]
@@ -8908,14 +9100,14 @@
           "type": "treatment_media_feature",
           "label": "Common emergency situations",
           "title": "What you can expect at an emergency visit",
-          "copy": "We’ll focus on diagnosis and stabilisation.\n\nThat usually means an examination (and X-rays if needed), clear explanation of what we can see, and the least invasive step that reduces pain and risk. Sometimes that’s a temporary measure with a planned follow-up. Sometimes it’s a definitive repair — it depends on the tooth and the cause.\n\nWe’ll explain costs and options before anything starts, so you can make a clear decision under pressure.",
+          "copy": "We\u2019ll focus on diagnosis and stabilisation.\n\nThat usually means an examination (and X-rays if needed), clear explanation of what we can see, and the least invasive step that reduces pain and risk. Sometimes that\u2019s a temporary measure with a planned follow-up. Sometimes it\u2019s a definitive repair \u2014 it depends on the tooth and the cause.\n\nWe\u2019ll explain costs and options before anything starts, so you can make a clear decision under pressure.",
           "mediaHint": "Calm, stepwise care"
         },
         {
           "id": "emergency_dentistry_next_steps",
           "type": "cta",
           "title": "After an emergency visit",
-          "copy": "Following emergency care, further treatment may be recommended to address the underlying cause.\n\nWe’ll explain any findings clearly and discuss whether monitoring, further investigation, or planned treatment is appropriate.\n\nYou’ll have time to consider options once the immediate situation has settled.",
+          "copy": "Following emergency care, further treatment may be recommended to address the underlying cause.\n\nWe\u2019ll explain any findings clearly and discuss whether monitoring, further investigation, or planned treatment is appropriate.\n\nYou\u2019ll have time to consider options once the immediate situation has settled.",
           "ctas": [
             {
               "label": "Book a check-up",
@@ -8937,11 +9129,11 @@
           "faqs": [
             {
               "question": "When urgent care may not be necessary",
-              "answer": "Some issues can wait a short time — for example, a small chip with no pain, a lost filling that isn’t sensitive, or mild sensitivity that settles quickly.\n\nIf you’re unsure, it’s still worth contacting us. We can help you work out whether it sounds urgent, and what to do while you’re waiting."
+              "answer": "Some issues can wait a short time \u2014 for example, a small chip with no pain, a lost filling that isn\u2019t sensitive, or mild sensitivity that settles quickly.\n\nIf you\u2019re unsure, it\u2019s still worth contacting us. We can help you work out whether it sounds urgent, and what to do while you\u2019re waiting."
             },
             {
               "question": "Questions and reassurance",
-              "answer": "If you’re anxious, tell us. We’ll take things step-by-step, explain what we’re doing, and keep the plan simple.\n\nEmergency dentistry isn’t about pressure-selling or starting big treatment on the spot. It’s about getting you safe, comfortable, and clear on the next sensible step."
+              "answer": "If you\u2019re anxious, tell us. We\u2019ll take things step-by-step, explain what we\u2019re doing, and keep the plan simple.\n\nEmergency dentistry isn\u2019t about pressure-selling or starting big treatment on the spot. It\u2019s about getting you safe, comfortable, and clear on the next sensible step."
             }
           ]
         },
@@ -8966,7 +9158,7 @@
         {
           "id": "emergency_full_inventory",
           "type": "routing_cards",
-          "title": "Emergency Dentistry — full treatment list",
+          "title": "Emergency Dentistry \u2014 full treatment list",
           "label": "Full list",
           "items": [
             {
@@ -9058,9 +9250,9 @@
           "id": "emergency_appointments_overview",
           "type": "treatment_overview_rich",
           "title": "Emergency dental appointments",
-          "copy": "If you’re in pain, have swelling, or you’ve damaged a tooth, an emergency appointment is about stabilising the situation.\n\nThat usually means diagnosis, getting you comfortable, reducing risk, and agreeing the next sensible step. Sometimes we can fix the problem on the day. Sometimes the safest care is staged.\n\nWe’ll explain what we can see, what’s realistic, and what you can do next — without pressure.",
+          "copy": "If you\u2019re in pain, have swelling, or you\u2019ve damaged a tooth, an emergency appointment is about stabilising the situation.\n\nThat usually means diagnosis, getting you comfortable, reducing risk, and agreeing the next sensible step. Sometimes we can fix the problem on the day. Sometimes the safest care is staged.\n\nWe\u2019ll explain what we can see, what\u2019s realistic, and what you can do next \u2014 without pressure.",
           "bullets": [
-            "Work out what’s happening and how urgent it is",
+            "Work out what\u2019s happening and how urgent it is",
             "Relieve pain and stabilise the tooth or gum",
             "Reduce risk of infection or worsening symptoms",
             "Plan the next step clearly and realistically"
@@ -9069,7 +9261,7 @@
         {
           "id": "treatment.heroIntro",
           "type": "copy-block",
-          "copy": "Dental problems rarely happen at a convenient time.\n\nIf you’re not sure whether you need to be seen urgently, contact us. We’ll ask a few focused questions and advise timing.\n\nIf you have rapid facial swelling, fever, difficulty swallowing, or breathing problems, seek urgent medical help immediately (A&E / 999) and then let us know as soon as you can."
+          "copy": "Dental problems rarely happen at a convenient time.\n\nIf you\u2019re not sure whether you need to be seen urgently, contact us. We\u2019ll ask a few focused questions and advise timing.\n\nIf you have rapid facial swelling, fever, difficulty swallowing, or breathing problems, seek urgent medical help immediately (A&E / 999) and then let us know as soon as you can."
         },
         {
           "id": "emergency_appointments_symptoms",
@@ -9088,7 +9280,7 @@
           "type": "steps",
           "title": "What to do now",
           "items": [
-            "Contact us and describe what’s happened, where the pain is, and how long it has been going on",
+            "Contact us and describe what\u2019s happened, where the pain is, and how long it has been going on",
             "Use normal pain relief if safe for you (follow the packet guidance)",
             "Avoid chewing on the painful side and stick to softer foods",
             "If swelling, fever, or swallowing/breathing issues develop, seek urgent medical help"
@@ -9098,7 +9290,7 @@
           "id": "emergency_appointments_importance",
           "type": "copy-block",
           "title": "Why assessment matters",
-          "copy": "Emergency care works best when we diagnose the cause properly, not just the symptom.\n\nPain can come from decay, infection, cracks, gum problems, or failed restorations — and the right solution depends on what we find.\n\nSeeing you early often gives more conservative options, better comfort, and fewer repeat flare-ups.",
+          "copy": "Emergency care works best when we diagnose the cause properly, not just the symptom.\n\nPain can come from decay, infection, cracks, gum problems, or failed restorations \u2014 and the right solution depends on what we find.\n\nSeeing you early often gives more conservative options, better comfort, and fewer repeat flare-ups.",
           "label": "Prompt care"
         },
         {
@@ -9106,7 +9298,7 @@
           "type": "treatment_media_feature",
           "label": "What we can do",
           "title": "What an emergency appointment can involve",
-          "copy": "An emergency visit usually includes an examination and, where appropriate, X-rays to understand what’s happening under the surface.\n\nWe’ll explain the likely cause, discuss options and costs, and agree the safest next step. That might be a temporary stabilisation, a simple repair, or a plan for staged treatment.\n\nOur aim is clarity, comfort, and a sensible route forward.",
+          "copy": "An emergency visit usually includes an examination and, where appropriate, X-rays to understand what\u2019s happening under the surface.\n\nWe\u2019ll explain the likely cause, discuss options and costs, and agree the safest next step. That might be a temporary stabilisation, a simple repair, or a plan for staged treatment.\n\nOur aim is clarity, comfort, and a sensible route forward.",
           "mediaHint": "Calm chairside care"
         },
         {
@@ -9122,15 +9314,15 @@
           "faqs": [
             {
               "question": "Can you always fix the problem on the day?",
-              "answer": "Not always — it depends on the cause and what’s safest for the tooth. Sometimes we can provide a definitive repair. Other times the priority is stabilisation and pain control, followed by a planned appointment for the longer-term fix. We’ll explain this clearly at the visit."
+              "answer": "Not always \u2014 it depends on the cause and what\u2019s safest for the tooth. Sometimes we can provide a definitive repair. Other times the priority is stabilisation and pain control, followed by a planned appointment for the longer-term fix. We\u2019ll explain this clearly at the visit."
             },
             {
               "question": "What if I am nervous about urgent treatment?",
-              "answer": "Tell us. We’ll take a calm, step-by-step approach: clear explanation, breaks if you need them, and a plan that feels manageable. Emergency dentistry isn’t about rushing you — it’s about getting you safe and comfortable."
+              "answer": "Tell us. We\u2019ll take a calm, step-by-step approach: clear explanation, breaks if you need them, and a plan that feels manageable. Emergency dentistry isn\u2019t about rushing you \u2014 it\u2019s about getting you safe and comfortable."
             },
             {
               "question": "Do I need a referral for an emergency visit?",
-              "answer": "No. You can contact the practice directly. If we think you need another service urgently (for example, medical assessment after trauma or signs of a serious spreading infection), we’ll tell you clearly and help you choose the safest next step."
+              "answer": "No. You can contact the practice directly. If we think you need another service urgently (for example, medical assessment after trauma or signs of a serious spreading infection), we\u2019ll tell you clearly and help you choose the safest next step."
             }
           ]
         },
@@ -9171,7 +9363,7 @@
           "id": "emergency_pain_overview",
           "type": "treatment_overview_rich",
           "title": "Severe toothache and dental pain",
-          "copy": "Severe toothache can feel urgent, and it’s hard to think about anything else. Here in Shoreham-by-Sea, we see how quickly pain can disrupt sleep, eating, and work.\n\nPain relief can help you cope, but it doesn’t fix the underlying cause. Toothache can come from decay, infection, cracks, gum problems, grinding, or a filling or crown that’s failed.\n\nWe’ll assess what’s going on, explain what we can see, and recommend the most sensible way to settle pain and protect the tooth.",
+          "copy": "Severe toothache can feel urgent, and it\u2019s hard to think about anything else. Here in Shoreham-by-Sea, we see how quickly pain can disrupt sleep, eating, and work.\n\nPain relief can help you cope, but it doesn\u2019t fix the underlying cause. Toothache can come from decay, infection, cracks, gum problems, grinding, or a filling or crown that\u2019s failed.\n\nWe\u2019ll assess what\u2019s going on, explain what we can see, and recommend the most sensible way to settle pain and protect the tooth.",
           "bullets": [
             "Identify the cause of pain",
             "Relieve discomfort safely",
@@ -9182,7 +9374,7 @@
         {
           "id": "treatment.heroIntro",
           "type": "copy-block",
-          "copy": "Toothache can range from mild twinges to severe, throbbing pain that disrupts sleep. If it’s persistent, worsening, or triggered by biting, heat, or cold, it’s worth getting checked even if it comes and goes.\n\nWe can talk through what’s happening and advise timing. If pain is getting worse, you notice swelling, fever, a bad taste, or you cannot open your mouth comfortably, call us promptly.\n\nIf you have rapid facial swelling, fever, difficulty swallowing, or breathing problems, seek urgent medical help immediately (A&E / 999) and then let us know as soon as you can."
+          "copy": "Toothache can range from mild twinges to severe, throbbing pain that disrupts sleep. If it\u2019s persistent, worsening, or triggered by biting, heat, or cold, it\u2019s worth getting checked even if it comes and goes.\n\nWe can talk through what\u2019s happening and advise timing. If pain is getting worse, you notice swelling, fever, a bad taste, or you cannot open your mouth comfortably, call us promptly.\n\nIf you have rapid facial swelling, fever, difficulty swallowing, or breathing problems, seek urgent medical help immediately (A&E / 999) and then let us know as soon as you can."
         },
         {
           "id": "emergency_pain_symptoms",
@@ -9220,7 +9412,7 @@
           "type": "treatment_media_feature",
           "label": "What we can do",
           "title": "Possible treatments",
-          "copy": "At an emergency appointment we start with an assessment, look for the cause, and confirm a diagnosis with any checks or X-rays needed.\n\nWhere appropriate we provide immediate stabilisation to relieve pain and protect the tooth. Not all treatment is completed in one visit, so we’ll outline the next stages and timing.\n\nOptions may include replacing or repairing a filling, root canal treatment to treat infection inside the tooth, gum treatment, adjusting the bite, or in some cases removing a tooth that can’t be predictably saved.\n\nWe’ll explain the findings and the pros and cons of each option before anything is done.",
+          "copy": "At an emergency appointment we start with an assessment, look for the cause, and confirm a diagnosis with any checks or X-rays needed.\n\nWhere appropriate we provide immediate stabilisation to relieve pain and protect the tooth. Not all treatment is completed in one visit, so we\u2019ll outline the next stages and timing.\n\nOptions may include replacing or repairing a filling, root canal treatment to treat infection inside the tooth, gum treatment, adjusting the bite, or in some cases removing a tooth that can\u2019t be predictably saved.\n\nWe\u2019ll explain the findings and the pros and cons of each option before anything is done.",
           "mediaHint": "Comfort-first care"
         },
         {
@@ -9236,15 +9428,15 @@
           "faqs": [
             {
               "question": "Can I wait to see if the pain settles?",
-              "answer": "Sometimes pain eases for a while, but the cause may still be there. If pain is severe, waking you, lingering, or getting worse, it’s best to get advice promptly. Contact us and we’ll guide you on timing."
+              "answer": "Sometimes pain eases for a while, but the cause may still be there. If pain is severe, waking you, lingering, or getting worse, it\u2019s best to get advice promptly. Contact us and we\u2019ll guide you on timing."
             },
             {
               "question": "Will treatment be painful?",
-              "answer": "Our aim is to get you comfortable first. We use effective local anaesthetic and we work in a calm, step-by-step way. If you’re anxious, tell us — pacing, breaks, and clear explanation make a big difference."
+              "answer": "Our aim is to get you comfortable first. We use effective local anaesthetic and we work in a calm, step-by-step way. If you\u2019re anxious, tell us \u2014 pacing, breaks, and clear explanation make a big difference."
             },
             {
               "question": "What if the pain starts overnight?",
-              "answer": "Use normal pain relief if safe for you (follow the packet guidance), keep the area clean, and avoid chewing on that side. If you develop swelling, fever, or difficulty swallowing/breathing, seek urgent medical help. Contact us as soon as we’re open and we’ll advise next steps."
+              "answer": "Use normal pain relief if safe for you (follow the packet guidance), keep the area clean, and avoid chewing on that side. If you develop swelling, fever, or difficulty swallowing/breathing, seek urgent medical help. Contact us as soon as we\u2019re open and we\u2019ll advise next steps."
             }
           ]
         },
@@ -9296,7 +9488,7 @@
         {
           "id": "treatment.heroIntro",
           "type": "copy-block",
-          "copy": "Infections can start quietly — sometimes as a dull ache, sometimes as sensitivity, and sometimes with no pain until swelling appears.\n\nAn abscess can come from the tooth nerve, from gum disease, or from a crack or deep decay letting bacteria in.\n\nIf you’re unsure whether it’s an emergency, call us. We can advise on urgency and what to do while you’re waiting to be seen."
+          "copy": "Infections can start quietly \u2014 sometimes as a dull ache, sometimes as sensitivity, and sometimes with no pain until swelling appears.\n\nAn abscess can come from the tooth nerve, from gum disease, or from a crack or deep decay letting bacteria in.\n\nIf you\u2019re unsure whether it\u2019s an emergency, call us. We can advise on urgency and what to do while you\u2019re waiting to be seen."
         },
         {
           "id": "emergency_abscess_symptoms",
@@ -9326,7 +9518,7 @@
           "id": "emergency_abscess_importance",
           "type": "copy-block",
           "title": "Why it needs proper assessment",
-          "copy": "Infections are not always solved by antibiotics alone. Antibiotics may be appropriate in certain situations, but the source of the infection usually needs treating.\n\nThat might mean draining the infection, cleaning and sealing the tooth with root canal treatment, treating gum infection, or removing a tooth that cannot be saved.\n\nOur job is to assess the cause, explain the realistic options, and help you get stable quickly — then plan longer-term care calmly.",
+          "copy": "Infections are not always solved by antibiotics alone. Antibiotics may be appropriate in certain situations, but the source of the infection usually needs treating.\n\nThat might mean draining the infection, cleaning and sealing the tooth with root canal treatment, treating gum infection, or removing a tooth that cannot be saved.\n\nOur job is to assess the cause, explain the realistic options, and help you get stable quickly \u2014 then plan longer-term care calmly.",
           "label": "Act early"
         },
         {
@@ -9334,7 +9526,7 @@
           "type": "treatment_media_feature",
           "label": "What we can do",
           "title": "Possible treatments",
-          "copy": "Treatment depends on where the infection is coming from and how advanced it is.\n\nOptions may include local measures to relieve pressure, root canal treatment to save a tooth, periodontal (gum) treatment, or extraction where the tooth cannot be predictably restored.\n\nIf antibiotics are needed, we’ll explain why, what they can and can’t do, and what follow-up is required.",
+          "copy": "Treatment depends on where the infection is coming from and how advanced it is.\n\nOptions may include local measures to relieve pressure, root canal treatment to save a tooth, periodontal (gum) treatment, or extraction where the tooth cannot be predictably restored.\n\nIf antibiotics are needed, we\u2019ll explain why, what they can and can\u2019t do, and what follow-up is required.",
           "mediaHint": "Gentle relief"
         },
         {
@@ -9350,11 +9542,11 @@
           "faqs": [
             {
               "question": "Do I always need antibiotics?",
-              "answer": "Sometimes antibiotics are necessary, especially if there is spreading swelling or you are unwell. But an abscess usually needs the source treated as well — for example drainage, root canal treatment, gum treatment, or extraction. We’ll advise what’s appropriate after assessment."
+              "answer": "Sometimes antibiotics are necessary, especially if there is spreading swelling or you are unwell. But an abscess usually needs the source treated as well \u2014 for example drainage, root canal treatment, gum treatment, or extraction. We\u2019ll advise what\u2019s appropriate after assessment."
             },
             {
               "question": "Will the swelling go away on its own?",
-              "answer": "Symptoms can ease if an abscess drains, but the infection often remains and can flare again. Leaving it can increase risk of spread and reduce the chance of saving the tooth. It’s safest to get it assessed."
+              "answer": "Symptoms can ease if an abscess drains, but the infection often remains and can flare again. Leaving it can increase risk of spread and reduce the chance of saving the tooth. It\u2019s safest to get it assessed."
             },
             {
               "question": "Can I work or travel after treatment?",
@@ -9399,7 +9591,7 @@
           "id": "emergency_chipped_overview",
           "type": "treatment_overview_rich",
           "title": "Broken, chipped or cracked teeth",
-          "copy": "If you’ve chipped a tooth, cracked a corner, or something feels sharp or painful, it’s worth getting it checked promptly.\n\nSome problems look small but involve deeper cracks or exposed dentine, which can lead to sensitivity, infection, or a larger fracture.\n\nWe’ll assess what’s happened, explain what we can see, and recommend the least invasive repair that keeps the tooth stable.",
+          "copy": "If you\u2019ve chipped a tooth, cracked a corner, or something feels sharp or painful, it\u2019s worth getting it checked promptly.\n\nSome problems look small but involve deeper cracks or exposed dentine, which can lead to sensitivity, infection, or a larger fracture.\n\nWe\u2019ll assess what\u2019s happened, explain what we can see, and recommend the least invasive repair that keeps the tooth stable.",
           "bullets": [
             "Quick smoothing to prevent cuts to cheeks or tongue",
             "Temporary coverings where needed",
@@ -9410,7 +9602,7 @@
         {
           "id": "treatment.heroIntro",
           "type": "copy-block",
-          "copy": "Teeth can chip or crack for lots of reasons — biting something hard, an old filling giving way, grinding, or an accident.\n\nSometimes it’s mainly cosmetic. Sometimes it’s an early warning that the tooth is under stress.\n\nIf you’re unsure, we’d rather you call and ask. We can advise whether it sounds urgent and what to do in the meantime."
+          "copy": "Teeth can chip or crack for lots of reasons \u2014 biting something hard, an old filling giving way, grinding, or an accident.\n\nSometimes it\u2019s mainly cosmetic. Sometimes it\u2019s an early warning that the tooth is under stress.\n\nIf you\u2019re unsure, we\u2019d rather you call and ask. We can advise whether it sounds urgent and what to do in the meantime."
         },
         {
           "id": "emergency_chipped_symptoms",
@@ -9439,8 +9631,8 @@
         {
           "id": "emergency_chipped_importance",
           "type": "copy-block",
-          "title": "Why it’s worth checking",
-          "copy": "A chip or crack isn’t always an emergency, but it can change quickly.\n\nSmall fractures can spread, and exposed dentine can become very sensitive. In some cases, cracks allow bacteria to reach the nerve, leading to infection.\n\nSeeing you early gives us more conservative options — and helps prevent the problem turning into a bigger repair.",
+          "title": "Why it\u2019s worth checking",
+          "copy": "A chip or crack isn\u2019t always an emergency, but it can change quickly.\n\nSmall fractures can spread, and exposed dentine can become very sensitive. In some cases, cracks allow bacteria to reach the nerve, leading to infection.\n\nSeeing you early gives us more conservative options \u2014 and helps prevent the problem turning into a bigger repair.",
           "label": "Protect the tooth"
         },
         {
@@ -9448,7 +9640,7 @@
           "type": "treatment_media_feature",
           "label": "What we can do",
           "title": "Possible treatments",
-          "copy": "Treatment depends on where the crack is, how deep it goes, and how much tooth is missing.\n\nOptions may include smoothing a sharp edge, a bonded repair (composite), replacing or reshaping an old filling, or protecting the tooth with an onlay or crown.\n\nIf the nerve is involved, root canal treatment may be needed — but we only recommend that when it’s clearly indicated.",
+          "copy": "Treatment depends on where the crack is, how deep it goes, and how much tooth is missing.\n\nOptions may include smoothing a sharp edge, a bonded repair (composite), replacing or reshaping an old filling, or protecting the tooth with an onlay or crown.\n\nIf the nerve is involved, root canal treatment may be needed \u2014 but we only recommend that when it\u2019s clearly indicated.",
           "mediaHint": "Restorative options"
         },
         {
@@ -9464,7 +9656,7 @@
           "faqs": [
             {
               "question": "Can a chipped tooth wait?",
-              "answer": "Sometimes a small chip can wait a short time, but it’s best to get advice. Chips can expose dentine, increase sensitivity, or develop into a larger fracture. Call us and we’ll guide you on timing."
+              "answer": "Sometimes a small chip can wait a short time, but it\u2019s best to get advice. Chips can expose dentine, increase sensitivity, or develop into a larger fracture. Call us and we\u2019ll guide you on timing."
             },
             {
               "question": "Will I need a crown straight away?",
@@ -9472,7 +9664,7 @@
             },
             {
               "question": "Is it safe to keep eating?",
-              "answer": "Try to avoid chewing on the affected side until we’ve assessed the tooth. Softer foods and careful cleaning help. If biting triggers sharp pain, stop and contact us as that can suggest a deeper crack."
+              "answer": "Try to avoid chewing on the affected side until we\u2019ve assessed the tooth. Softer foods and careful cleaning help. If biting triggers sharp pain, stop and contact us as that can suggest a deeper crack."
             }
           ]
         },
@@ -9513,9 +9705,9 @@
           "id": "emergency_avulsion_overview",
           "type": "treatment_overview_rich",
           "title": "Knocked-out tooth",
-          "copy": "A knocked-out adult tooth can sometimes be saved, but timing and handling matter.\n\nIf you can get advice immediately, bring the tooth with you and avoid touching the root. If it’s safe to do so, gentle first aid can improve the chances of a good outcome — but it isn’t always possible in real life, especially after an accident.\n\nCall us straight away so we can guide you on what to do next and how urgently you need to be seen.",
+          "copy": "A knocked-out adult tooth can sometimes be saved, but timing and handling matter.\n\nIf you can get advice immediately, bring the tooth with you and avoid touching the root. If it\u2019s safe to do so, gentle first aid can improve the chances of a good outcome \u2014 but it isn\u2019t always possible in real life, especially after an accident.\n\nCall us straight away so we can guide you on what to do next and how urgently you need to be seen.",
           "bullets": [
-            "Act quickly — time matters",
+            "Act quickly \u2014 time matters",
             "Handle the tooth carefully (avoid the root)",
             "Keep it moist and protected",
             "Get assessed promptly for the best chance of stabilisation"
@@ -9524,7 +9716,7 @@
         {
           "id": "treatment.heroIntro",
           "type": "copy-block",
-          "copy": "Having a tooth knocked out is frightening — and it often happens alongside a fall, collision, or sports injury.\n\nIf the tooth is an adult tooth, there may be a chance of replantation depending on timing and what’s happened to the tooth and socket.\n\nIf you’re unsure whether it’s a baby tooth or an adult tooth, or there are other injuries, call us and we’ll guide you to the safest next step."
+          "copy": "Having a tooth knocked out is frightening \u2014 and it often happens alongside a fall, collision, or sports injury.\n\nIf the tooth is an adult tooth, there may be a chance of replantation depending on timing and what\u2019s happened to the tooth and socket.\n\nIf you\u2019re unsure whether it\u2019s a baby tooth or an adult tooth, or there are other injuries, call us and we\u2019ll guide you to the safest next step."
         },
         {
           "id": "emergency_avulsion_symptoms",
@@ -9544,7 +9736,7 @@
           "items": [
             "Check for head injury, heavy bleeding, or breathing problems and seek urgent medical help if needed",
             "Find the tooth, pick it up by the crown (not the root), and avoid scrubbing it",
-            "If it’s dirty, rinse gently for a few seconds with milk or saline (avoid disinfectants)",
+            "If it\u2019s dirty, rinse gently for a few seconds with milk or saline (avoid disinfectants)",
             "Keep it moist: ideally in milk, saline, or inside the cheek if safe (not in water)",
             "Call us immediately so we can advise urgency and prepare for assessment"
           ]
@@ -9553,7 +9745,7 @@
           "id": "emergency_avulsion_importance",
           "type": "copy-block",
           "title": "Why speed matters",
-          "copy": "The tissues that help an adult tooth reattach can be damaged quickly if the tooth dries out or is handled roughly.\n\nEven with prompt care, replantation isn’t always possible or successful — but early assessment usually gives the best chance of stabilising the situation and planning next steps.\n\nWe’ll also check for associated injuries, fractures, and whether nearby teeth have been damaged or loosened.",
+          "copy": "The tissues that help an adult tooth reattach can be damaged quickly if the tooth dries out or is handled roughly.\n\nEven with prompt care, replantation isn\u2019t always possible or successful \u2014 but early assessment usually gives the best chance of stabilising the situation and planning next steps.\n\nWe\u2019ll also check for associated injuries, fractures, and whether nearby teeth have been damaged or loosened.",
           "label": "Act quickly"
         },
         {
@@ -9561,7 +9753,7 @@
           "type": "treatment_media_feature",
           "label": "What we can do",
           "title": "Possible treatments",
-          "copy": "Treatment depends on whether the tooth is an adult tooth, how long it has been out, how it has been stored, and the condition of the socket and surrounding bone.\n\nOptions may include careful replantation and stabilisation (splinting) where appropriate, monitoring healing, and follow-up assessment. In some situations, replacement options are discussed if replantation isn’t possible.\n\nWe’ll explain the likely risks, the aftercare required, and what long-term maintenance might involve.",
+          "copy": "Treatment depends on whether the tooth is an adult tooth, how long it has been out, how it has been stored, and the condition of the socket and surrounding bone.\n\nOptions may include careful replantation and stabilisation (splinting) where appropriate, monitoring healing, and follow-up assessment. In some situations, replacement options are discussed if replantation isn\u2019t possible.\n\nWe\u2019ll explain the likely risks, the aftercare required, and what long-term maintenance might involve.",
           "mediaHint": "Stabilisation and healing"
         },
         {
@@ -9577,15 +9769,15 @@
           "faqs": [
             {
               "question": "Can a baby tooth be replanted?",
-              "answer": "Usually no. Baby (primary) teeth are not normally replanted because doing so can damage the developing adult tooth underneath. If you’re unsure whether it’s a baby or adult tooth, call us and we’ll advise quickly."
+              "answer": "Usually no. Baby (primary) teeth are not normally replanted because doing so can damage the developing adult tooth underneath. If you\u2019re unsure whether it\u2019s a baby or adult tooth, call us and we\u2019ll advise quickly."
             },
             {
               "question": "What if the tooth looks damaged?",
-              "answer": "If the tooth is broken, cracked, or has obvious contamination, replantation may be less suitable — but it depends on the situation. Keep the tooth safe and moist, avoid touching the root, and contact us so we can assess what’s realistic."
+              "answer": "If the tooth is broken, cracked, or has obvious contamination, replantation may be less suitable \u2014 but it depends on the situation. Keep the tooth safe and moist, avoid touching the root, and contact us so we can assess what\u2019s realistic."
             },
             {
               "question": "Do I need a tetanus check?",
-              "answer": "If the injury involved a dirty wound, soil, or a cut that may have been contaminated, a tetanus check may be sensible. If you’re unsure, contact your GP, NHS 111, or urgent care for advice — and still contact us so we can deal with the dental side promptly."
+              "answer": "If the injury involved a dirty wound, soil, or a cut that may have been contaminated, a tetanus check may be sensible. If you\u2019re unsure, contact your GP, NHS 111, or urgent care for advice \u2014 and still contact us so we can deal with the dental side promptly."
             }
           ]
         },
@@ -9626,7 +9818,7 @@
           "id": "emergency_crown_overview",
           "type": "treatment_overview_rich",
           "title": "Lost crowns, veneers or fillings",
-          "copy": "If a crown, veneer or filling has come out, it can feel urgent — especially if the tooth is sensitive or looks unfinished.\n\nIn many cases the tooth can be protected and repaired conservatively, but timing matters. A lost restoration can leave sharp edges, exposed dentine, or a tooth that is more likely to fracture.\n\nWe’ll assess what’s happened, explain the options clearly, and help you stabilise the tooth as simply as possible.",
+          "copy": "If a crown, veneer or filling has come out, it can feel urgent \u2014 especially if the tooth is sensitive or looks unfinished.\n\nIn many cases the tooth can be protected and repaired conservatively, but timing matters. A lost restoration can leave sharp edges, exposed dentine, or a tooth that is more likely to fracture.\n\nWe\u2019ll assess what\u2019s happened, explain the options clearly, and help you stabilise the tooth as simply as possible.",
           "bullets": [
             "Protect the tooth and reduce sensitivity",
             "Check for decay, cracks, or a cause for the failure",
@@ -9637,7 +9829,7 @@
         {
           "id": "treatment.heroIntro",
           "type": "copy-block",
-          "copy": "Restorations can come loose for lots of reasons — wear over time, biting something hard, decay underneath, or the tooth changing shape.\n\nSometimes it’s a straightforward re-cement. Sometimes it’s a sign the tooth needs a different kind of protection.\n\nIf you still have the crown or veneer, keep it safe and bring it with you. We can often learn a lot from seeing it."
+          "copy": "Restorations can come loose for lots of reasons \u2014 wear over time, biting something hard, decay underneath, or the tooth changing shape.\n\nSometimes it\u2019s a straightforward re-cement. Sometimes it\u2019s a sign the tooth needs a different kind of protection.\n\nIf you still have the crown or veneer, keep it safe and bring it with you. We can often learn a lot from seeing it."
         },
         {
           "id": "emergency_crown_symptoms",
@@ -9659,15 +9851,15 @@
             "Keep the area clean with gentle brushing and warm salt-water rinses",
             "Avoid chewing on that side and stick to softer foods",
             "If the tooth is sharp, cover it temporarily with sugar-free gum or dental wax",
-            "Keep the crown/veneer if you have it and bring it with you (don’t force it back on)",
+            "Keep the crown/veneer if you have it and bring it with you (don\u2019t force it back on)",
             "Call us so we can advise urgency and book the right appointment"
           ]
         },
         {
           "id": "emergency_crown_importance",
           "type": "copy-block",
-          "title": "Why it’s worth seeing us promptly",
-          "copy": "When a restoration comes out, the underlying tooth is often more vulnerable than it looks.\n\nExposed dentine can be very sensitive, and the tooth can fracture more easily — especially if it’s already heavily filled. If there is decay or a crack underneath, delaying can reduce the options.\n\nSeeing you early helps us protect the tooth, manage discomfort, and plan a repair that lasts.",
+          "title": "Why it\u2019s worth seeing us promptly",
+          "copy": "When a restoration comes out, the underlying tooth is often more vulnerable than it looks.\n\nExposed dentine can be very sensitive, and the tooth can fracture more easily \u2014 especially if it\u2019s already heavily filled. If there is decay or a crack underneath, delaying can reduce the options.\n\nSeeing you early helps us protect the tooth, manage discomfort, and plan a repair that lasts.",
           "label": "Protect exposed teeth"
         },
         {
@@ -9675,7 +9867,7 @@
           "type": "treatment_media_feature",
           "label": "What we can do",
           "title": "Possible treatments",
-          "copy": "The right solution depends on why the restoration came out and what the tooth looks like underneath.\n\nOptions may include re-cementing the existing crown or veneer (if it’s intact and the fit is still appropriate), replacing a filling, or making a new restoration if the tooth needs better protection.\n\nIf decay or a crack is present, we’ll explain the findings and the most sensible way to stabilise the tooth long-term.",
+          "copy": "The right solution depends on why the restoration came out and what the tooth looks like underneath.\n\nOptions may include re-cementing the existing crown or veneer (if it\u2019s intact and the fit is still appropriate), replacing a filling, or making a new restoration if the tooth needs better protection.\n\nIf decay or a crack is present, we\u2019ll explain the findings and the most sensible way to stabilise the tooth long-term.",
           "mediaHint": "Restoration check"
         },
         {
@@ -9751,7 +9943,7 @@
         {
           "id": "treatment.heroIntro",
           "type": "copy-block",
-          "copy": "Dental trauma can range from chipped enamel to displaced or loosened teeth, fractures, and injuries to gums or supporting bone. What matters most is prompt assessment: we check tooth stability, nerve response, bite changes and soft tissue injury, and take X-rays to rule out hidden fractures. Treatment might include smoothing or repairing a chip, splinting a tooth, dressing an exposed nerve, or planning follow-up care if the tooth’s nerve is at risk. We’ll also advise on pain control and what to avoid while the area heals. If a tooth has been knocked out, time is critical — see that page for immediate steps."
+          "copy": "Dental trauma can range from chipped enamel to displaced or loosened teeth, fractures, and injuries to gums or supporting bone. What matters most is prompt assessment: we check tooth stability, nerve response, bite changes and soft tissue injury, and take X-rays to rule out hidden fractures. Treatment might include smoothing or repairing a chip, splinting a tooth, dressing an exposed nerve, or planning follow-up care if the tooth\u2019s nerve is at risk. We\u2019ll also advise on pain control and what to avoid while the area heals. If a tooth has been knocked out, time is critical \u2014 see that page for immediate steps."
         },
         {
           "id": "emergency_trauma_symptoms",
@@ -10624,7 +10816,7 @@
           "id": "night_guards_occlusal_splints_mid_cta",
           "type": "treatment_mid_cta",
           "title": "Protection options to compare",
-          "strapline": "Compare connected options for clenching, jaw joint symptoms, and tooth wear — and choose the calm next step."
+          "strapline": "Compare connected options for clenching, jaw joint symptoms, and tooth wear \u2014 and choose the calm next step."
         },
         {
           "id": "treatment.faq"
@@ -10636,7 +10828,7 @@
           "id": "night_guards_occlusal_splints_closing_cta",
           "type": "treatment_closing_cta",
           "title": "Night guards for grinding and jaw tension",
-          "strapline": "A custom occlusal splint can reduce wear, ease muscle strain, and protect heavily filled or worn teeth — without over-treating.",
+          "strapline": "A custom occlusal splint can reduce wear, ease muscle strain, and protect heavily filled or worn teeth \u2014 without over-treating.",
           "ctas": [
             {
               "label": "Book a night guard assessment",
@@ -10658,7 +10850,7 @@
         {
           "id": "night_guards_full_inventory",
           "type": "routing_cards",
-          "title": "Night guards & occlusal therapy — related treatments",
+          "title": "Night guards & occlusal therapy \u2014 related treatments",
           "label": "Explore the full list",
           "items": [
             {
@@ -10854,7 +11046,7 @@
           "bullets": [
             "Gentle, unhurried check-ups with the same clinical team",
             "Prevention plans tailored to your enamel, gums, and lifestyle",
-            "Clear guidance if you’re anxious or prefer slower appointments"
+            "Clear guidance if you\u2019re anxious or prefer slower appointments"
           ],
           "ctas": [
             {
@@ -10917,7 +11109,7 @@
             "Polishing and airflow-style finishing where suitable for stain control",
             "Tips to improve brushing and interdental cleaning at home",
             "Why visits matter even if you brush well: hidden build-up and hard-to-reach areas",
-            "Preventing gum disease and bad breath with tailored intervals—see periodontal care (/treatments/periodontal-gum-care)"
+            "Preventing gum disease and bad breath with tailored intervals\u2014see periodontal care (/treatments/periodontal-gum-care)"
           ],
           "strapline": "Regular hygiene keeps gums healthy and helps fillings, crowns, and implants last longer."
         },
@@ -10932,7 +11124,7 @@
           "title": "Simple, science-led guidance you can follow",
           "body": "We create a plan that fits your daily routine so small adjustments have a big impact.",
           "bullets": [
-            "Fluoride advice matched to your risk level—no pushy sales",
+            "Fluoride advice matched to your risk level\u2014no pushy sales",
             "Diet and sugar-frequency guidance with practical swaps",
             "Support for sensitive teeth, including gentle techniques and desensitising care",
             "Custom lab-made sports mouthguards for contact or ball sports (/treatments/sports-mouthguards)"
@@ -10969,7 +11161,7 @@
             "Teens and young adults: monitoring wisdom teeth, orthodontic retainers, and sports protection",
             "Young-at-heart retirees: focus on comfort, function, and maintaining existing restorations",
             "Medical changes considered so your plan stays safe and effective",
-            "Appointment pacing adjusted if you’re nervous or prefer slower visits"
+            "Appointment pacing adjusted if you\u2019re nervous or prefer slower visits"
           ]
         },
         {
@@ -11012,11 +11204,11 @@
             },
             {
               "question": "Do you check for mouth cancer?",
-              "answer": "Yes. Oral cancer screening is part of every exam. We review soft tissues, lymph areas, and any changes you’ve noticed."
+              "answer": "Yes. Oral cancer screening is part of every exam. We review soft tissues, lymph areas, and any changes you\u2019ve noticed."
             },
             {
-              "question": "I’m nervous — can you go slowly?",
-              "answer": "Absolutely. Tell us ahead of time and we’ll pace the visit, explain each step, and link you to our nervous patient support if helpful (/treatments/nervous-patients)."
+              "question": "I\u2019m nervous \u2014 can you go slowly?",
+              "answer": "Absolutely. Tell us ahead of time and we\u2019ll pace the visit, explain each step, and link you to our nervous patient support if helpful (/treatments/nervous-patients)."
             },
             {
               "question": "Is home whitening better?",
@@ -11033,7 +11225,7 @@
           "seoRole": "cta",
           "eyebrow": "Next steps",
           "title": "Book your comprehensive dental exam",
-          "body": "Speak to us about a prevention-first plan. If you’re anxious, tell us — we’ll tailor the visit and pace it carefully.",
+          "body": "Speak to us about a prevention-first plan. If you\u2019re anxious, tell us \u2014 we\u2019ll tailor the visit and pace it carefully.",
           "ctas": [
             {
               "label": "Dental check-ups & oral cancer screening",
@@ -11050,7 +11242,7 @@
         {
           "id": "general_full_inventory",
           "type": "routing_cards",
-          "title": "General Dentistry — full treatment list",
+          "title": "General Dentistry \u2014 full treatment list",
           "label": "Full list",
           "items": [
             {
@@ -11067,7 +11259,7 @@
               "href": "/treatments/periodontal-gum-care"
             },
             {
-              "title": "Children’s dentistry",
+              "title": "Children\u2019s dentistry",
               "href": "/treatments/childrens-dentistry"
             },
             {
@@ -11100,7 +11292,7 @@
                 "href": "/treatments/periodontal-gum-care"
               },
               {
-                "title": "Children’s dentistry",
+                "title": "Children\u2019s dentistry",
                 "href": "/treatments/childrens-dentistry"
               },
               {
@@ -11124,7 +11316,7 @@
     },
     "childrens_dentistry": {
       "id": "childrens_dentistry",
-      "label": "Children’s dentistry",
+      "label": "Children\u2019s dentistry",
       "path": "/treatments/childrens-dentistry",
       "category": "treatment",
       "hero": "treatment_neutral_hero_v1",
@@ -11140,7 +11332,7 @@
           "variantId": "smh_childrens_dentistry_hero",
           "order": 10,
           "seoRole": "hero",
-          "eyebrow": "Children’s dentistry",
+          "eyebrow": "Children\u2019s dentistry",
           "title": "Gentle check-ups that build lifelong habits",
           "body": "We keep appointments short, positive, and age-appropriate so children feel relaxed while we protect their growing smiles.",
           "bullets": [
@@ -11150,7 +11342,7 @@
           ],
           "ctas": [
             {
-              "label": "Book a children’s check-up",
+              "label": "Book a children\u2019s check-up",
               "href": "/contact?topic=children",
               "preset": "primary"
             },
@@ -11185,7 +11377,7 @@
           "variantId": "smh_childrens_dentistry_checkup",
           "order": 30,
           "seoRole": "primaryContent",
-          "eyebrow": "What a children’s check-up includes",
+          "eyebrow": "What a children\u2019s check-up includes",
           "title": "Gentle exams with practical guidance",
           "body": "Each visit is paced slowly so children stay comfortable while we check teeth, gums, and bite development.",
           "bullets": [
@@ -11250,7 +11442,7 @@
           "seoRole": "supporting",
           "eyebrow": "When we suggest an orthodontic chat",
           "title": "Early guidance keeps options open",
-          "body": "If we spot crowding, bite discrepancies, or habits affecting jaw growth, we’ll recommend an orthodontic assessment. We collaborate with orthodontic colleagues for fixed or removable options when the time is right—always explained clearly to families.",
+          "body": "If we spot crowding, bite discrepancies, or habits affecting jaw growth, we\u2019ll recommend an orthodontic assessment. We collaborate with orthodontic colleagues for fixed or removable options when the time is right\u2014always explained clearly to families.",
           "mediaHint": "Monitoring bite, spacing, and eruption patterns"
         },
         {
@@ -11260,12 +11452,12 @@
           "variantId": "smh_childrens_dentistry_faq",
           "order": 80,
           "seoRole": "faq",
-          "eyebrow": "Children’s dentistry FAQs",
+          "eyebrow": "Children\u2019s dentistry FAQs",
           "title": "Answers for parents",
           "faqs": [
             {
               "question": "When should my child first visit?",
-              "answer": "We’re happy to see children as soon as their first teeth appear or by their first birthday. Early visits help them get used to the chair and let us spot any early issues."
+              "answer": "We\u2019re happy to see children as soon as their first teeth appear or by their first birthday. Early visits help them get used to the chair and let us spot any early issues."
             },
             {
               "question": "How often should they come?",
@@ -11277,7 +11469,7 @@
             },
             {
               "question": "What if my child is scared?",
-              "answer": "Tell us ahead of time and we’ll keep visits short, use tell-show-do, and let them stay in control. We can build up gradually with positive language and plenty of breaks."
+              "answer": "Tell us ahead of time and we\u2019ll keep visits short, use tell-show-do, and let them stay in control. We can build up gradually with positive language and plenty of breaks."
             }
           ]
         },
@@ -11296,10 +11488,10 @@
           "seoRole": "cta",
           "eyebrow": "Next steps",
           "title": "Book a gentle check-up for your child",
-          "body": "We’ll keep things calm, answer your questions, and map out a prevention plan that fits family life.",
+          "body": "We\u2019ll keep things calm, answer your questions, and map out a prevention plan that fits family life.",
           "ctas": [
             {
-              "label": "Book a children’s appointment",
+              "label": "Book a children\u2019s appointment",
               "href": "/contact?topic=children",
               "variant": "primary"
             },
@@ -11353,11 +11545,11 @@
           "seoRole": "hero",
           "eyebrow": "Periodontal & gum care",
           "title": "Gum disease",
-          "body": "Gum disease is a common condition that affects the tissues supporting the teeth.\n\nIt often develops gradually and may not cause pain in its early stages, which means it can progress unnoticed for some time.\n\nAt St Mary’s House Dental Care, gum disease is managed with a long-term view, focusing on understanding causes, stabilising the condition, and supporting ongoing oral health.",
+          "body": "Gum disease is a common condition that affects the tissues supporting the teeth.\n\nIt often develops gradually and may not cause pain in its early stages, which means it can progress unnoticed for some time.\n\nAt St Mary\u2019s House Dental Care, gum disease is managed with a long-term view, focusing on understanding causes, stabilising the condition, and supporting ongoing oral health.",
           "bullets": [
             "Gum disease is a common condition that affects the tissues supporting the teeth.",
             "It often develops gradually and may not cause pain in its early stages, which means it can progress unnoticed for some time.",
-            "At St Mary’s House Dental Care, gum disease is managed with a long-term view, focusing on understanding causes, stabilising the condition, and supporting ongoing oral health."
+            "At St Mary\u2019s House Dental Care, gum disease is managed with a long-term view, focusing on understanding causes, stabilising the condition, and supporting ongoing oral health."
           ],
           "ctas": [
             {
@@ -11478,7 +11670,7 @@
           "faqs": [
             {
               "question": "Does deep cleaning hurt?",
-              "answer": "Treatment is planned gently with numbing gels or local anaesthetic where needed. You’ll be guided on what to expect and how to keep things comfortable afterwards."
+              "answer": "Treatment is planned gently with numbing gels or local anaesthetic where needed. You\u2019ll be guided on what to expect and how to keep things comfortable afterwards."
             },
             {
               "question": "How long does it take to see improvement?",
@@ -11486,11 +11678,11 @@
             },
             {
               "question": "Can gum tissue grow back?",
-              "answer": "Inflammation can reduce and pockets can tighten with good care. Recession usually needs protective maintenance rather than regrowth, and we’ll discuss options if grafting or referral is appropriate."
+              "answer": "Inflammation can reduce and pockets can tighten with good care. Recession usually needs protective maintenance rather than regrowth, and we\u2019ll discuss options if grafting or referral is appropriate."
             },
             {
               "question": "What about implants with gum inflammation?",
-              "answer": "Peri-implant tissues can often be stabilised with careful cleaning, airflow-style stain removal, and close reviews. If advanced peri-implantitis is present, we’ll outline referral options calmly."
+              "answer": "Peri-implant tissues can often be stabilised with careful cleaning, airflow-style stain removal, and close reviews. If advanced peri-implantitis is present, we\u2019ll outline referral options calmly."
             }
           ]
         },
@@ -11540,10 +11732,10 @@
           "seoRole": "hero",
           "eyebrow": "Endodontics & root canal care",
           "title": "Root canal treatment",
-          "body": "Root canal treatment is used when the nerve inside a tooth has become inflamed or infected.\n\nThe aim is to remove infection, seal the tooth, and keep it stable long-term — often avoiding the need for extraction.\n\nWe’ll assess the tooth carefully, explain what we can see (and what we can’t), and recommend the most predictable option for your situation.",
+          "body": "Root canal treatment is used when the nerve inside a tooth has become inflamed or infected.\n\nThe aim is to remove infection, seal the tooth, and keep it stable long-term \u2014 often avoiding the need for extraction.\n\nWe\u2019ll assess the tooth carefully, explain what we can see (and what we can\u2019t), and recommend the most predictable option for your situation.",
           "bullets": [
             "Relieve pain and settle infection",
-            "Preserve the tooth where it’s sensible to do so",
+            "Preserve the tooth where it\u2019s sensible to do so",
             "Restore strength with the right protection afterwards"
           ],
           "ctas": [
@@ -11572,7 +11764,7 @@
             "Pain that lingers after hot or cold",
             "Throbbing pain or pain that wakes you",
             "Pain on biting or when you release the bite",
-            "Swelling, a gum ‘spot’, or a bad taste",
+            "Swelling, a gum \u2018spot\u2019, or a bad taste",
             "A tooth that has darkened after previous trauma"
           ],
           "strapline": "In some cases, there may be little or no pain, and the problem is identified during examination."
@@ -11603,7 +11795,7 @@
           "seoRole": "supporting",
           "eyebrow": "Why root canal treatment may be needed",
           "title": "Why planning and precision matter",
-          "body": "Root canal treatment is detail work.\n\nGood outcomes depend on seeing the anatomy clearly, cleaning thoroughly, and sealing the tooth well. Sometimes canals are narrow, curved, or hard to locate — and that’s where careful technique and appropriate imaging help.\n\nWe’ll explain what we can see on the day and whether the tooth looks straightforward, complex, or uncertain — before we commit you to a plan.",
+          "body": "Root canal treatment is detail work.\n\nGood outcomes depend on seeing the anatomy clearly, cleaning thoroughly, and sealing the tooth well. Sometimes canals are narrow, curved, or hard to locate \u2014 and that\u2019s where careful technique and appropriate imaging help.\n\nWe\u2019ll explain what we can see on the day and whether the tooth looks straightforward, complex, or uncertain \u2014 before we commit you to a plan.",
           "mediaHint": "CBCT mapping, rotary instruments, and apex location"
         },
         {
@@ -11616,10 +11808,10 @@
           "eyebrow": "Comfort and what to expect",
           "title": "Comfort, pacing, and anxiety",
           "items": [
-            "We take time to get you properly numb — pain control is not rushed",
+            "We take time to get you properly numb \u2014 pain control is not rushed",
             "We can work in shorter stages if you find long appointments difficult",
-            "We explain each step before we do it and agree a clear ‘stop’ signal",
-            "If you’re nervous, tell us — we’ll adapt the pace and the plan"
+            "We explain each step before we do it and agree a clear \u2018stop\u2019 signal",
+            "If you\u2019re nervous, tell us \u2014 we\u2019ll adapt the pace and the plan"
           ]
         },
         {
@@ -11631,7 +11823,7 @@
           "seoRole": "supporting",
           "eyebrow": "Alternatives and limitations",
           "title": "Limitations and risks",
-          "body": "Root canal treatment is usually very successful, but it isn’t magic.\n\nSometimes anatomy is complex, infection has been present for a long time, or cracks mean the tooth cannot be predictably saved. Occasionally a tooth needs further treatment later, even after an apparently good initial result.\n\nWe’ll talk through the realistic risks for your tooth specifically, and what the alternatives would be.",
+          "body": "Root canal treatment is usually very successful, but it isn\u2019t magic.\n\nSometimes anatomy is complex, infection has been present for a long time, or cracks mean the tooth cannot be predictably saved. Occasionally a tooth needs further treatment later, even after an apparently good initial result.\n\nWe\u2019ll talk through the realistic risks for your tooth specifically, and what the alternatives would be.",
           "bullets": [
             "Success depends on anatomy, infection level, and tooth structure",
             "Some teeth need follow-up treatment or referral if complexity is high",
@@ -11647,7 +11839,7 @@
           "seoRole": "supporting",
           "eyebrow": "After root canal treatment",
           "title": "Aftercare and long-term outlook",
-          "body": "Once the nerve is treated, the tooth still needs to be protected.\n\nBack teeth in particular often need an onlay or crown afterwards because they’re more likely to fracture. A well-sealed, well-protected tooth can last many years, but maintenance matters.\n\nWe’ll recommend the simplest protection that gives the tooth the best chance of staying stable.",
+          "body": "Once the nerve is treated, the tooth still needs to be protected.\n\nBack teeth in particular often need an onlay or crown afterwards because they\u2019re more likely to fracture. A well-sealed, well-protected tooth can last many years, but maintenance matters.\n\nWe\u2019ll recommend the simplest protection that gives the tooth the best chance of staying stable.",
           "bullets": [
             "Follow-up checks are part of good endodontic care",
             "Protecting the tooth afterwards is often the key to longevity",
@@ -11665,8 +11857,8 @@
           "title": "Questions people ask",
           "faqs": [
             {
-              "question": "What if I’m unsure whether I need root canal treatment?",
-              "answer": "Root canal treatment should not be painful — the tooth is numbed thoroughly and we work carefully.\n\nPeople often come in expecting the worst because they’re already in pain. In reality, the aim is to remove the source of that pain and make the tooth comfortable again.\n\nIf you’re anxious, tell us. We can pace the appointment, take breaks, and keep the plan simple."
+              "question": "What if I\u2019m unsure whether I need root canal treatment?",
+              "answer": "Root canal treatment should not be painful \u2014 the tooth is numbed thoroughly and we work carefully.\n\nPeople often come in expecting the worst because they\u2019re already in pain. In reality, the aim is to remove the source of that pain and make the tooth comfortable again.\n\nIf you\u2019re anxious, tell us. We can pace the appointment, take breaks, and keep the plan simple."
             }
           ]
         },
@@ -11685,7 +11877,7 @@
           "seoRole": "cta",
           "eyebrow": "Next steps",
           "title": "Talk to us about root canal treatment",
-          "body": "If you have toothache, lingering sensitivity, or swelling, it’s worth getting the tooth assessed.\n\nWe’ll explain what’s going on, whether the tooth is realistically savable, and what the next step should be — without pressure.",
+          "body": "If you have toothache, lingering sensitivity, or swelling, it\u2019s worth getting the tooth assessed.\n\nWe\u2019ll explain what\u2019s going on, whether the tooth is realistically savable, and what the next step should be \u2014 without pressure.",
           "ctas": [
             {
               "label": "Book a root canal consult",
@@ -11722,7 +11914,7 @@
           "seoRole": "hero",
           "eyebrow": "Extractions & oral surgery",
           "title": "Dental extractions",
-          "body": "A dental extraction involves the removal of a tooth that cannot be maintained comfortably or predictably over the long term.\n\nExtractions are usually considered only when other options are unlikely to succeed or would not offer a stable long-term outcome.\n\nAt St Mary’s House Dental Care, the focus is always on preserving teeth where possible and recommending extraction only when it’s genuinely in a patient’s best interest.",
+          "body": "A dental extraction involves the removal of a tooth that cannot be maintained comfortably or predictably over the long term.\n\nExtractions are usually considered only when other options are unlikely to succeed or would not offer a stable long-term outcome.\n\nAt St Mary\u2019s House Dental Care, the focus is always on preserving teeth where possible and recommending extraction only when it\u2019s genuinely in a patient\u2019s best interest.",
           "bullets": [
             "Calm assessments that explain when extraction is the safest route",
             "Minimally invasive techniques to protect bone and gum",
@@ -11753,7 +11945,7 @@
           "items": [
             "An extraction may be advised if a tooth is severely damaged by decay, infection, fracture, or advanced gum disease.",
             "It may also be considered where a tooth is causing ongoing pain, repeated infection, or is affecting the health of surrounding teeth.",
-            "We’ll always explain why removal is being suggested and what alternatives have been considered."
+            "We\u2019ll always explain why removal is being suggested and what alternatives have been considered."
           ],
           "strapline": "If you experience rapid swelling, spreading infection, or difficulty swallowing, treat it as urgent and contact us for emergency dentistry advice."
         },
@@ -11795,8 +11987,8 @@
           "title": "Comfort and what to expect",
           "items": [
             "Many patients worry about discomfort during or after an extraction.",
-            "The procedure is carried out once the area is numb, and we’ll talk you through what sensations to expect. Some soreness afterwards is normal and usually settles over time.",
-            "We’ll provide clear aftercare advice to support healing."
+            "The procedure is carried out once the area is numb, and we\u2019ll talk you through what sensations to expect. Some soreness afterwards is normal and usually settles over time.",
+            "We\u2019ll provide clear aftercare advice to support healing."
           ]
         },
         {
@@ -11808,7 +12000,7 @@
           "seoRole": "supporting",
           "eyebrow": "Risks, limits & alternatives",
           "title": "Aftercare and healing",
-          "body": "After an extraction, it’s important to allow the area to heal properly.\n\nThis may involve avoiding certain foods, keeping the area clean, and following specific instructions to reduce the risk of complications.\n\nWe’ll explain what’s normal during healing and when to get in touch if concerns arise.",
+          "body": "After an extraction, it\u2019s important to allow the area to heal properly.\n\nThis may involve avoiding certain foods, keeping the area clean, and following specific instructions to reduce the risk of complications.\n\nWe\u2019ll explain what\u2019s normal during healing and when to get in touch if concerns arise.",
           "bullets": [
             "Discussion of saving versus removing a tooth with restorative or endodontic care",
             "Clear consent for complex roots, impacted teeth, or medical considerations",
@@ -11845,11 +12037,11 @@
           "faqs": [
             {
               "question": "Questions and reassurance",
-              "answer": "Being told a tooth needs to be removed can feel daunting.\n\nIf you’re unsure why an extraction has been suggested or what it means for you, we encourage you to ask. Clear explanations help support confident, informed decisions."
+              "answer": "Being told a tooth needs to be removed can feel daunting.\n\nIf you\u2019re unsure why an extraction has been suggested or what it means for you, we encourage you to ask. Clear explanations help support confident, informed decisions."
             },
             {
               "question": "How long is recovery?",
-              "answer": "Most people are comfortable after a few days with steady improvement over 1–2 weeks. We give written instructions to support smooth healing."
+              "answer": "Most people are comfortable after a few days with steady improvement over 1\u20132 weeks. We give written instructions to support smooth healing."
             },
             {
               "question": "Can the tooth be replaced?",
@@ -11857,7 +12049,7 @@
             },
             {
               "question": "What if the tooth could be saved?",
-              "answer": "If a filling, crown, or root canal could provide a predictable result, we’ll explain that option first so you can make an informed choice."
+              "answer": "If a filling, crown, or root canal could provide a predictable result, we\u2019ll explain that option first so you can make an informed choice."
             }
           ]
         },
@@ -11896,7 +12088,7 @@
     "senior_mature_smile_care": {
       "id": "senior_mature_smile_care",
       "label": "Senior and mature smile care",
-      "description": "Comfort-first dentistry for later life, focusing on gum health, dry mouth, worn or heavily filled teeth, and realistic tooth replacement options.\n\nWe’ll look at what’s changing, what’s stable, and what would genuinely improve day-to-day comfort and confidence — without over-treating.",
+      "description": "Comfort-first dentistry for later life, focusing on gum health, dry mouth, worn or heavily filled teeth, and realistic tooth replacement options.\n\nWe\u2019ll look at what\u2019s changing, what\u2019s stable, and what would genuinely improve day-to-day comfort and confidence \u2014 without over-treating.",
       "path": "/treatments/senior-mature-smile-care",
       "category": "treatment",
       "hero": "treatment_neutral_hero_v1",
@@ -11924,7 +12116,7 @@
           "id": "senior_mature_smile_care_closing_cta",
           "type": "treatment_closing_cta",
           "title": "Plan mature smile care",
-          "strapline": "Balance comfort, function, and appearance with a tailored plan — paced to suit you.",
+          "strapline": "Balance comfort, function, and appearance with a tailored plan \u2014 paced to suit you.",
           "ctas": [
             {
               "label": "Book a mature smile review",
@@ -11991,7 +12183,7 @@
           "id": "tmj_jaw_comfort_closing_cta",
           "type": "treatment_closing_cta",
           "title": "Get help with jaw joint (TMJ) discomfort",
-          "strapline": "Understand what’s driving the symptoms, reduce strain, and build a practical plan — without hype.",
+          "strapline": "Understand what\u2019s driving the symptoms, reduce strain, and build a practical plan \u2014 without hype.",
           "ctas": [
             {
               "label": "Book a jaw (TMJ) comfort review",
@@ -12028,7 +12220,7 @@
           "id": "treatment.heroIntro",
           "type": "copy-block",
           "title": "Nervous patients",
-          "copy": "If you feel anxious about dentistry, you’re not alone — and you don’t need to ‘push through it’ to get help.\n\nWe take a calm, practical approach: clear explanations, gentle pacing, and treatment planned in stages when that makes things easier.\n\nSometimes the best first appointment is simply a conversation and an examination. We’ll agree a plan together — with comfort and control built in from the start."
+          "copy": "If you feel anxious about dentistry, you\u2019re not alone \u2014 and you don\u2019t need to \u2018push through it\u2019 to get help.\n\nWe take a calm, practical approach: clear explanations, gentle pacing, and treatment planned in stages when that makes things easier.\n\nSometimes the best first appointment is simply a conversation and an examination. We\u2019ll agree a plan together \u2014 with comfort and control built in from the start."
         },
         {
           "id": "treatment.whoIsItFor",
@@ -12053,13 +12245,13 @@
             "Fear of judgement or embarrassment",
             "Concern about costs, pressure, or unexpected treatment"
           ],
-          "strapline": "These are normal concerns — and we plan around them."
+          "strapline": "These are normal concerns \u2014 and we plan around them."
         },
         {
           "id": "treatment.consultationOverview",
           "type": "treatment_overview_rich",
           "title": "What to expect",
-          "body": "We’ll start by understanding what makes dentistry difficult for you. That might be a specific fear (needles, numbness, drilling), sensory overload, a past experience, or simply not knowing what’s going to happen.\n\nDepending on your needs, we can:\n- go at a slower pace, with breaks\n- agree a clear ‘stop’ signal so you stay in control\n- explain each step before we do it\n- stage care so it feels manageable rather than overwhelming\n\nIf sedation is relevant, we can explain when it may be appropriate and what it involves. Not everyone needs it — for many people, pacing and predictability are the biggest difference.",
+          "body": "We\u2019ll start by understanding what makes dentistry difficult for you. That might be a specific fear (needles, numbness, drilling), sensory overload, a past experience, or simply not knowing what\u2019s going to happen.\n\nDepending on your needs, we can:\n- go at a slower pace, with breaks\n- agree a clear \u2018stop\u2019 signal so you stay in control\n- explain each step before we do it\n- stage care so it feels manageable rather than overwhelming\n\nIf sedation is relevant, we can explain when it may be appropriate and what it involves. Not everyone needs it \u2014 for many people, pacing and predictability are the biggest difference.",
           "bullets": [
             "A calm, non-judgemental conversation first",
             "An examination (and X-rays only if needed)",
@@ -12267,11 +12459,11 @@
           "id": "tooth_wear_overview",
           "type": "treatment_overview_rich",
           "title": "Tooth wear and erosion",
-          "copy": "Tooth wear refers to the gradual loss of tooth structure over time.\n\nIt’s a common issue and often develops slowly, meaning many people don’t notice it until changes in shape, sensitivity, or appearance become more obvious.\n\nAt St Mary’s House Dental Care, tooth wear is managed thoughtfully, with an emphasis on understanding why it’s happening before deciding how to treat it.",
+          "copy": "Tooth wear refers to the gradual loss of tooth structure over time.\n\nIt\u2019s a common issue and often develops slowly, meaning many people don\u2019t notice it until changes in shape, sensitivity, or appearance become more obvious.\n\nAt St Mary\u2019s House Dental Care, tooth wear is managed thoughtfully, with an emphasis on understanding why it\u2019s happening before deciding how to treat it.",
           "bullets": [
             "Tooth wear refers to the gradual loss of tooth structure over time",
             "It often develops slowly before changes become more obvious",
-            "Care focuses on understanding why it’s happening before deciding how to treat it"
+            "Care focuses on understanding why it\u2019s happening before deciding how to treat it"
           ]
         },
         {
@@ -12345,8 +12537,8 @@
           "title": "Questions and reassurance",
           "faqs": [
             {
-              "question": "What if I’m unsure about what tooth wear means for me?",
-              "answer": "Learning that your teeth are wearing can be concerning.\n\nIf you’re unsure what it means for you, we encourage you to ask. Understanding the situation clearly helps avoid unnecessary treatment and supports sensible long-term decisions."
+              "question": "What if I\u2019m unsure about what tooth wear means for me?",
+              "answer": "Learning that your teeth are wearing can be concerning.\n\nIf you\u2019re unsure what it means for you, we encourage you to ask. Understanding the situation clearly helps avoid unnecessary treatment and supports sensible long-term decisions."
             }
           ]
         },
@@ -12557,7 +12749,7 @@
           "id": "bruxism_jaw_clenching_mid_cta",
           "type": "treatment_mid_cta",
           "title": "Jaw strain and tooth wear options",
-          "strapline": "Protect worn teeth, reduce jaw strain, and understand the triggers — with a practical plan."
+          "strapline": "Protect worn teeth, reduce jaw strain, and understand the triggers \u2014 with a practical plan."
         },
         {
           "id": "treatment.faq"
@@ -12569,7 +12761,7 @@
           "id": "bruxism_and_jaw_clenching_closing_cta",
           "type": "treatment_closing_cta",
           "title": "Help for grinding and clenching",
-          "strapline": "Grinding and clenching can wear teeth, crack fillings, and overload the jaw muscles. We’ll assess the pattern, explain what it suggests, and help you protect your teeth sensibly.",
+          "strapline": "Grinding and clenching can wear teeth, crack fillings, and overload the jaw muscles. We\u2019ll assess the pattern, explain what it suggests, and help you protect your teeth sensibly.",
           "ctas": [
             {
               "label": "Book a bruxism assessment",
@@ -12697,7 +12889,7 @@
           "id": "tmj_disorder_treatment_mid_cta",
           "type": "treatment_mid_cta",
           "title": "TMJ and jaw-pain options",
-          "strapline": "Jaw pain, clicking, headaches, and clenching often overlap — compare options and choose the calm next step."
+          "strapline": "Jaw pain, clicking, headaches, and clenching often overlap \u2014 compare options and choose the calm next step."
         },
         {
           "id": "treatment.faq"
@@ -12709,7 +12901,7 @@
           "id": "tmj_disorder_treatment_closing_cta",
           "type": "treatment_closing_cta",
           "title": "TMJ disorder assessment and treatment",
-          "strapline": "TMJ symptoms are rarely one simple thing. We’ll assess the joints, muscles, bite factors, and clenching patterns — then build a practical, staged plan aimed at reducing strain and improving comfort.",
+          "strapline": "TMJ symptoms are rarely one simple thing. We\u2019ll assess the joints, muscles, bite factors, and clenching patterns \u2014 then build a practical, staged plan aimed at reducing strain and improving comfort.",
           "ctas": [
             {
               "label": "Book a TMJ assessment",
@@ -12770,7 +12962,7 @@
           "id": "therapeutic_facial_injectables_mid_cta",
           "type": "treatment_mid_cta",
           "title": "Therapeutic facial options",
-          "strapline": "Jaw tension, clenching, facial pain and headaches can overlap — compare options and choose a calm next step."
+          "strapline": "Jaw tension, clenching, facial pain and headaches can overlap \u2014 compare options and choose a calm next step."
         },
         {
           "id": "treatment.faq"
@@ -12782,7 +12974,7 @@
           "id": "therapeutic_facial_injectables_closing_cta",
           "type": "treatment_closing_cta",
           "title": "Therapeutic injectables for jaw tension and facial pain",
-          "strapline": "Some muscle-related symptoms can respond well to carefully planned injectables. We’ll assess what’s driving the problem, explain what’s realistic, and only recommend treatment where it’s appropriate.",
+          "strapline": "Some muscle-related symptoms can respond well to carefully planned injectables. We\u2019ll assess what\u2019s driving the problem, explain what\u2019s realistic, and only recommend treatment where it\u2019s appropriate.",
           "ctas": [
             {
               "label": "Book a therapeutic injectables review",
@@ -12837,7 +13029,7 @@
           "id": "facial_aesthetics_mid_cta",
           "type": "treatment_mid_cta",
           "title": "Explore facial aesthetics options",
-          "strapline": "Choose a natural, clinician-led approach — with clear advice on what’s appropriate and what’s not."
+          "strapline": "Choose a natural, clinician-led approach \u2014 with clear advice on what\u2019s appropriate and what\u2019s not."
         },
         {
           "id": "treatment.faq"
@@ -12849,7 +13041,7 @@
           "id": "facial_aesthetics_closing_cta",
           "type": "treatment_closing_cta",
           "title": "Facial aesthetics consultation",
-          "strapline": "If you’re considering facial aesthetics, we’ll help you make a calm, informed decision.\n\nWe’ll talk through your goals, what’s realistic, and what would suit your facial balance — with an emphasis on subtle, natural results and safety.",
+          "strapline": "If you\u2019re considering facial aesthetics, we\u2019ll help you make a calm, informed decision.\n\nWe\u2019ll talk through your goals, what\u2019s realistic, and what would suit your facial balance \u2014 with an emphasis on subtle, natural results and safety.",
           "ctas": [
             {
               "label": "Book a facial aesthetics consultation",
@@ -12881,28 +13073,46 @@
         "heroId": "sacred-home-hero",
         "variantId": "hero.variant.treatment_v1"
       },
-      "intro": "Understand the main options for replacing missing teeth — implants, bridges, dentures, and implant-retained dentures — and find the right path for your situation.",
+      "intro": "Understand the main options for replacing missing teeth \u2014 implants, bridges, dentures, and implant-retained dentures \u2014 and find the right path for your situation.",
       "sections": [
-        { "id": "treatment.heroIntro" },
-        { "id": "treatment.trustSignals" },
-        { "id": "treatment.consultationOverview" },
-        { "id": "treatment.whoIsItFor" },
-        { "id": "treatment.processTimeline" },
-        { "id": "treatment.technology" },
-        { "id": "treatment.aftercareRisks" },
+        {
+          "id": "treatment.heroIntro"
+        },
+        {
+          "id": "treatment.trustSignals"
+        },
+        {
+          "id": "treatment.consultationOverview"
+        },
+        {
+          "id": "treatment.whoIsItFor"
+        },
+        {
+          "id": "treatment.processTimeline"
+        },
+        {
+          "id": "treatment.technology"
+        },
+        {
+          "id": "treatment.aftercareRisks"
+        },
         {
           "id": "teeth_replacement_mid_cta",
           "type": "treatment_mid_cta",
           "title": "Explore your teeth replacement options",
           "strapline": "Compare implants, bridges, and dentures to find the solution that suits your mouth and your life."
         },
-        { "id": "treatment.faq" },
-        { "id": "treatment.cta" },
+        {
+          "id": "treatment.faq"
+        },
+        {
+          "id": "treatment.cta"
+        },
         {
           "id": "teeth_replacement_closing_cta",
           "type": "treatment_closing_cta",
           "title": "Plan your teeth replacement",
-          "strapline": "Discuss your options in a calm, unhurried consultation — assessment first, treatment plan second.",
+          "strapline": "Discuss your options in a calm, unhurried consultation \u2014 assessment first, treatment plan second.",
           "ctas": [
             {
               "label": "Book a consultation",
@@ -13096,7 +13306,7 @@
           "id": "anti_wrinkle_treatments_mid_cta",
           "type": "treatment_mid_cta",
           "title": "Related facial aesthetics",
-          "strapline": "Subtle, clinician-led treatment — with clear guidance on suitability, safety, and natural results."
+          "strapline": "Subtle, clinician-led treatment \u2014 with clear guidance on suitability, safety, and natural results."
         },
         {
           "id": "treatment.faq"
@@ -13108,7 +13318,7 @@
           "id": "anti_wrinkle_treatments_closing_cta",
           "type": "treatment_closing_cta",
           "title": "Anti-wrinkle treatment consultation",
-          "strapline": "If you’re considering anti-wrinkle treatments, we’ll help you decide calmly and realistically.\n\nWe’ll talk through your goals, facial balance, and what would look natural — and we’ll only recommend treatment where it’s appropriate and safe.",
+          "strapline": "If you\u2019re considering anti-wrinkle treatments, we\u2019ll help you decide calmly and realistically.\n\nWe\u2019ll talk through your goals, facial balance, and what would look natural \u2014 and we\u2019ll only recommend treatment where it\u2019s appropriate and safe.",
           "ctas": [
             {
               "label": "Book an anti-wrinkle consultation",
@@ -13166,7 +13376,7 @@
           "id": "dermal_fillers_mid_cta",
           "type": "treatment_mid_cta",
           "title": "Related facial aesthetics",
-          "strapline": "A careful, proportion-led approach — focused on balance, structure, and natural movement."
+          "strapline": "A careful, proportion-led approach \u2014 focused on balance, structure, and natural movement."
         },
         {
           "id": "treatment.faq"
@@ -13178,7 +13388,7 @@
           "id": "dermal_fillers_closing_cta",
           "type": "treatment_closing_cta",
           "title": "Dermal filler consultation",
-          "strapline": "Dermal fillers can be used to restore balance, support facial structure, and soften changes that develop over time.\n\nWe’ll assess facial proportions, skin quality, and movement, explain what’s realistic, and only recommend treatment where it’s appropriate, subtle, and safe.",
+          "strapline": "Dermal fillers can be used to restore balance, support facial structure, and soften changes that develop over time.\n\nWe\u2019ll assess facial proportions, skin quality, and movement, explain what\u2019s realistic, and only recommend treatment where it\u2019s appropriate, subtle, and safe.",
           "ctas": [
             {
               "label": "Book a dermal filler consultation",
@@ -13248,7 +13458,7 @@
           "id": "skin_boosters_closing_cta",
           "type": "treatment_closing_cta",
           "title": "Skin booster consultation",
-          "strapline": "Skin boosters are designed to improve hydration, texture, and elasticity with subtle, natural-looking change over time.\n\nWe’ll talk through your goals, skin quality, and what’s realistic, then recommend a plan only if it’s appropriate and safe for you.",
+          "strapline": "Skin boosters are designed to improve hydration, texture, and elasticity with subtle, natural-looking change over time.\n\nWe\u2019ll talk through your goals, skin quality, and what\u2019s realistic, then recommend a plan only if it\u2019s appropriate and safe for you.",
           "ctas": [
             {
               "label": "Book a skin booster consultation",
@@ -13306,7 +13516,7 @@
           "id": "polynucleotides_mid_cta",
           "type": "treatment_mid_cta",
           "title": "Related facial therapeutics",
-          "strapline": "Compare options that support hydration, texture, and natural-looking skin quality — with clear advice on suitability."
+          "strapline": "Compare options that support hydration, texture, and natural-looking skin quality \u2014 with clear advice on suitability."
         },
         {
           "id": "treatment.faq"
@@ -13318,7 +13528,7 @@
           "id": "polynucleotides_closing_cta",
           "type": "treatment_closing_cta",
           "title": "Polynucleotides consultation",
-          "strapline": "Polynucleotides are used to support skin quality over time — often focusing on texture, hydration, and a healthier-looking finish rather than dramatic ‘instant’ change.\n\nWe’ll talk through your goals, assess what’s realistic, and recommend a plan only if it’s appropriate, subtle, and safe.",
+          "strapline": "Polynucleotides are used to support skin quality over time \u2014 often focusing on texture, hydration, and a healthier-looking finish rather than dramatic \u2018instant\u2019 change.\n\nWe\u2019ll talk through your goals, assess what\u2019s realistic, and recommend a plan only if it\u2019s appropriate, subtle, and safe.",
           "ctas": [
             {
               "label": "Book a polynucleotides consultation",
@@ -13370,7 +13580,7 @@
           "id": "mouthguards_and_retainers_mid_cta",
           "type": "treatment_mid_cta",
           "title": "Protection options to compare",
-          "strapline": "Retainers, sports guards, and night guards do different jobs — we’ll help you choose what’s appropriate."
+          "strapline": "Retainers, sports guards, and night guards do different jobs \u2014 we\u2019ll help you choose what\u2019s appropriate."
         },
         {
           "id": "treatment.faq"
@@ -13382,7 +13592,7 @@
           "id": "mouthguards_and_retainers_closing_cta",
           "type": "treatment_closing_cta",
           "title": "Protect teeth, restorations, and orthodontic results",
-          "strapline": "Mouthguards and retainers can protect teeth during sport, help maintain orthodontic results, and reduce wear from clenching in the right situations.\n\nWe’ll assess your bite and risks, then recommend the simplest option that genuinely helps — without over-treating.",
+          "strapline": "Mouthguards and retainers can protect teeth during sport, help maintain orthodontic results, and reduce wear from clenching in the right situations.\n\nWe\u2019ll assess your bite and risks, then recommend the simplest option that genuinely helps \u2014 without over-treating.",
           "ctas": [
             {
               "label": "Book a mouthguard / retainer review",

--- a/reports/WEBSITE_OS_TREATMENT_SOURCE_TRUTH_HASH_EXPORT_V1.json
+++ b/reports/WEBSITE_OS_TREATMENT_SOURCE_TRUTH_HASH_EXPORT_V1.json
@@ -1,7 +1,7 @@
 {
   "version": "WEBSITE_OS_TREATMENT_SOURCE_TRUTH_HASH_EXPORT_V1",
   "repository": "drnickmaxwell-wq/champagne",
-  "exportTimestamp": "2026-06-19T09:08:49.613Z",
+  "exportTimestamp": "2026-06-19T09:17:39.948Z",
   "mission": "Source-truth and current-text hash export only; no treatment content mutation or rewrite authority granted.",
   "hashAlgorithm": "sha256 over UTF-8 text with CRLF converted to LF only",
   "inputs": {
@@ -32,7 +32,7 @@
         "sourceEntryCount": 59,
         "firstJsonPointer": "/sections/0/body"
       },
-      "exportTimestamp": "2026-06-19T09:08:49.613Z",
+      "exportTimestamp": "2026-06-19T09:17:39.948Z",
       "blockerReasons": [],
       "implementationReadiness": "READY_FOR_AGENT_STAGING"
     },
@@ -54,7 +54,7 @@
         "sourceEntryCount": 90,
         "firstJsonPointer": "/sections/0/body"
       },
-      "exportTimestamp": "2026-06-19T09:08:49.613Z",
+      "exportTimestamp": "2026-06-19T09:17:39.948Z",
       "blockerReasons": [],
       "implementationReadiness": "READY_FOR_AGENT_STAGING"
     },
@@ -76,7 +76,7 @@
         "sourceEntryCount": 96,
         "firstJsonPointer": "/sections/0/body"
       },
-      "exportTimestamp": "2026-06-19T09:08:49.613Z",
+      "exportTimestamp": "2026-06-19T09:17:39.948Z",
       "blockerReasons": [],
       "implementationReadiness": "READY_FOR_AGENT_STAGING"
     },
@@ -88,7 +88,7 @@
       "sourceTextAvailable": true,
       "currentSourceTextHash": "b4d9f87855a002f643f7d99d53410e00b723f673c12bfa1a87d2b0ca3cce9df4",
       "currentRenderedTextHash": "1d2355796b8b4eb80b8fb8ca32b973aebe7c770ed4e7852fb679b2de5227474b",
-      "answerSurfaceStatus": "MISSING",
+      "answerSurfaceStatus": "PASS",
       "schemaStatus": "PASS_INFERRED_OR_EMITTED",
       "canonicalStatus": "PASS",
       "localSeoStatus": "PARTIAL",
@@ -98,11 +98,9 @@
         "sourceEntryCount": 79,
         "firstJsonPointer": "/sections/0/body"
       },
-      "exportTimestamp": "2026-06-19T09:08:49.613Z",
-      "blockerReasons": [
-        "Answer surface incomplete: answerSurface is missing"
-      ],
-      "implementationReadiness": "PARTIAL"
+      "exportTimestamp": "2026-06-19T09:17:39.948Z",
+      "blockerReasons": [],
+      "implementationReadiness": "READY_FOR_AGENT_STAGING"
     },
     {
       "route": "/treatments/implant-aftercare",
@@ -122,7 +120,7 @@
         "sourceEntryCount": 84,
         "firstJsonPointer": "/sections/0/body"
       },
-      "exportTimestamp": "2026-06-19T09:08:49.613Z",
+      "exportTimestamp": "2026-06-19T09:17:39.948Z",
       "blockerReasons": [],
       "implementationReadiness": "READY_FOR_AGENT_STAGING"
     }
@@ -133,16 +131,10 @@
       "/treatments/composite-bonding",
       "/treatments/dental-crowns",
       "/treatments/clear-aligners",
+      "/treatments/full-arch-dental-implants",
       "/treatments/implant-aftercare"
     ],
-    "partial": [
-      {
-        "route": "/treatments/full-arch-dental-implants",
-        "blockerReasons": [
-          "Answer surface incomplete: answerSurface is missing"
-        ]
-      }
-    ],
+    "partial": [],
     "blocked": []
   },
   "nonAuthority": {

--- a/reports/WEBSITE_OS_TREATMENT_SOURCE_TRUTH_HASH_EXPORT_V1.md
+++ b/reports/WEBSITE_OS_TREATMENT_SOURCE_TRUTH_HASH_EXPORT_V1.md
@@ -1,15 +1,15 @@
 # Website OS Treatment Source Truth Hash Export V1
 
 - Repository: `drnickmaxwell-wq/champagne`
-- Export timestamp: `2026-06-19T09:08:49.613Z`
+- Export timestamp: `2026-06-19T09:17:39.948Z`
 - Hash algorithm: sha256 over UTF-8 text with CRLF converted to LF only
 - Authority: truth/export only; no rewrite, publication, clinical approval, chatbot, behavioural capture, PHI, PMS, or patient-data authority granted.
 
 ## Summary
 
 - Target pages: 5
-- Ready for agent staging: 4
-- Partial: 1
+- Ready for agent staging: 5
+- Partial: 0
 - Blocked: 0
 
 ## Page export matrix
@@ -19,7 +19,7 @@
 | `/treatments/composite-bonding` | `/treatments/composite-bonding` | `c399770917c9d284f6599e2f09c0c138520b669234f0ac7cee53aca2401ee536` | `d8aa711118340b859f232ecd0444ab9529bf71a96dab6e4d2cbf72a2af9fc3d3` | PASS | PASS_INFERRED_OR_EMITTED | PASS | PARTIAL | PASS_SOURCE_CTA_TEXT_PRESENT | READY_FOR_AGENT_STAGING | None |
 | `/treatments/dental-crowns` | `/treatments/dental-crowns` | `be2eec7d847718e8a98906f47bb2567da02fbbbf76dd4937a1104b6be3b0d9ff` | `b6ab98b42a501cb25e65ba28b04ecb44b45e35242f0b58a85eeaed4727964cf2` | PASS | PASS_INFERRED_OR_EMITTED | PASS | PASS | PASS_SOURCE_CTA_TEXT_PRESENT | READY_FOR_AGENT_STAGING | None |
 | `/treatments/clear-aligners` | `/treatments/clear-aligners` | `a6a3ef1fd049926735f33aa761a095fa3cddfb65b67b7c06505fd33f3b3357ad` | `0297df927c2f976f2df650ffab095a6408532f51790b924b720849a66d305306` | PASS | PASS_INFERRED_OR_EMITTED | PASS | PARTIAL | PASS_SOURCE_CTA_TEXT_PRESENT | READY_FOR_AGENT_STAGING | None |
-| `/treatments/full-arch-dental-implants` | `/treatments/implants-full-arch` | `b4d9f87855a002f643f7d99d53410e00b723f673c12bfa1a87d2b0ca3cce9df4` | `1d2355796b8b4eb80b8fb8ca32b973aebe7c770ed4e7852fb679b2de5227474b` | MISSING | PASS_INFERRED_OR_EMITTED | PASS | PARTIAL | PASS_SOURCE_CTA_TEXT_PRESENT | PARTIAL | Answer surface incomplete: answerSurface is missing |
+| `/treatments/full-arch-dental-implants` | `/treatments/implants-full-arch` | `b4d9f87855a002f643f7d99d53410e00b723f673c12bfa1a87d2b0ca3cce9df4` | `1d2355796b8b4eb80b8fb8ca32b973aebe7c770ed4e7852fb679b2de5227474b` | PASS | PASS_INFERRED_OR_EMITTED | PASS | PARTIAL | PASS_SOURCE_CTA_TEXT_PRESENT | READY_FOR_AGENT_STAGING | None |
 | `/treatments/implant-aftercare` | `/treatments/implant-aftercare` | `ff08c0cda0606625b730273f9ee3d150072f6880024ca9255f9b9d12ae9400a5` | `6691c11dff7ef149fc261115ec6b3d0ee95999aaca38ac7067b580107a8edc10` | PASS | PASS_INFERRED_OR_EMITTED | PASS | PARTIAL | PASS_SOURCE_CTA_TEXT_PRESENT | READY_FOR_AGENT_STAGING | None |
 
 ## Source text locations

--- a/reports/WEBSITE_TRUTH_EXPORT_REPORT_V1.json
+++ b/reports/WEBSITE_TRUTH_EXPORT_REPORT_V1.json
@@ -1,6 +1,6 @@
 {
   "version": "WEBSITE_TRUTH_EXPORT_REPORT_V1",
-  "generatedAt": "2026-06-19T08:29:38.332Z",
+  "generatedAt": "2026-06-19T09:17:37.764Z",
   "contract": {
     "file": "ops/contracts/WEBSITE_TRUTH_EXPORT_CONTRACT_V1.json",
     "version": "CHAMPAGNE_WEBSITE_TRUTH_EXPORT_CONTRACT_V1"
@@ -6646,31 +6646,17 @@
       "sectionCount": 11,
       "surface": "champagne/surface/treatment",
       "answerSurface": {
-        "frameworkPresent": false,
-        "valid": false,
-        "status": null,
-        "presentSectionCount": 0,
-        "missingSectionIds": [
-          "direct_answer",
-          "what_this_treatment_is",
-          "who_it_is_for",
-          "who_it_may_not_be_suitable_for",
-          "benefits",
-          "risks_and_limitations",
-          "alternatives",
-          "process",
-          "timeline",
-          "aftercare",
-          "cost_fee_logic",
-          "local_shoreham_context",
-          "clinician_expertise",
-          "technology_used",
-          "faq",
-          "related_treatments_internal_links",
-          "last_reviewed_clinical_review",
-          "cta"
-        ],
-        "secondaryGeographyMentions": {},
+        "frameworkPresent": true,
+        "valid": true,
+        "status": "answer_surface_complete",
+        "presentSectionCount": 18,
+        "missingSectionIds": [],
+        "secondaryGeographyMentions": {
+          "Brighton": 0,
+          "Worthing": 0,
+          "Lancing": 0,
+          "Southwick": 0
+        },
         "secondaryGeographyStuffing": false
       }
     },
@@ -9470,8 +9456,8 @@
       "cta"
     ],
     "treatmentRouteCount": 79,
-    "frameworkPresentCount": 12,
-    "completeCount": 12,
+    "frameworkPresentCount": 13,
+    "completeCount": 13,
     "exampleSeedRoutes": [
       "/treatments/implants"
     ],
@@ -9479,7 +9465,6 @@
       "/treatments/clear-aligners-spark",
       "/treatments/fixed-braces",
       "/treatments/dental-checkups-oral-cancer-screening",
-      "/treatments/implants-full-arch",
       "/treatments/implant-retained-dentures",
       "/treatments/implants-bone-grafting",
       "/treatments/sinus-lift",
@@ -9886,12 +9871,11 @@
         "pageId": "implants_full_arch",
         "label": "Full arch implant rehabilitation",
         "validation": {
-          "frameworkPresent": false,
-          "valid": false,
-          "status": null,
+          "frameworkPresent": true,
+          "valid": true,
+          "status": "answer_surface_complete",
           "exampleSeed": false,
-          "presentSectionIds": [],
-          "missingSectionIds": [
+          "presentSectionIds": [
             "direct_answer",
             "what_this_treatment_is",
             "who_it_is_for",
@@ -9911,11 +9895,18 @@
             "last_reviewed_clinical_review",
             "cta"
           ],
-          "secondaryGeographyMentions": {},
+          "missingSectionIds": [],
+          "duplicateSectionIds": [],
+          "unknownSectionIds": [],
+          "emptySectionIds": [],
+          "secondaryGeographyMentions": {
+            "Brighton": 0,
+            "Worthing": 0,
+            "Lancing": 0,
+            "Southwick": 0
+          },
           "secondaryGeographyStuffing": false,
-          "errors": [
-            "answerSurface is missing"
-          ],
+          "errors": [],
           "warnings": []
         }
       },
@@ -12705,7 +12696,7 @@
     "frameworkPresent": true,
     "coverageMode": "framework_contract_only_for_non_treatment_families",
     "routeCount": 118,
-    "treatmentRoutesWithTreatmentAnswerSurface": 12,
+    "treatmentRoutesWithTreatmentAnswerSurface": 13,
     "generalizedPageSurfaceRouteCount": 0,
     "entries": [
       {
@@ -13442,8 +13433,8 @@
         "pageFamily": "treatment",
         "framework": "TREATMENT_ANSWER_SURFACE_V1",
         "generalizedPageSurfacePresent": false,
-        "treatmentAnswerSurfacePresent": false,
-        "valid": false,
+        "treatmentAnswerSurfacePresent": true,
+        "valid": true,
         "launchState": "launch_candidate_treatment_review_required"
       },
       {
@@ -13813,7 +13804,6 @@
     "/treatments/home-teeth-whitening",
     "/treatments/implant-retained-dentures",
     "/treatments/implants-bone-grafting",
-    "/treatments/implants-full-arch",
     "/treatments/injection-moulded-composite",
     "/treatments/inlays-onlays",
     "/treatments/knocked-out-tooth",
@@ -13908,7 +13898,7 @@
     "missingPageTruthRoutes": []
   },
   "internalLinkInventory": {
-    "count": 867,
+    "count": 874,
     "links": [
       {
         "from": "/",
@@ -17827,6 +17817,48 @@
         "to": "/treatments/implant-retained-dentures",
         "source": "machine_manifest_page",
         "pointer": "/sections/10/ctas/2/href"
+      },
+      {
+        "from": "/treatments/implants-full-arch",
+        "to": "/treatments/implants",
+        "source": "machine_manifest_page",
+        "pointer": "/answerSurface/sections/15/links/0/href"
+      },
+      {
+        "from": "/treatments/implants-full-arch",
+        "to": "/treatments/cbct-3d-scanning",
+        "source": "machine_manifest_page",
+        "pointer": "/answerSurface/sections/15/links/1/href"
+      },
+      {
+        "from": "/treatments/implants-full-arch",
+        "to": "/treatments/implants-retained-dentures",
+        "source": "machine_manifest_page",
+        "pointer": "/answerSurface/sections/15/links/2/href"
+      },
+      {
+        "from": "/treatments/implants-full-arch",
+        "to": "/treatments/implants-aftercare",
+        "source": "machine_manifest_page",
+        "pointer": "/answerSurface/sections/15/links/3/href"
+      },
+      {
+        "from": "/treatments/implants-full-arch",
+        "to": "/treatments/teeth-in-a-day",
+        "source": "machine_manifest_page",
+        "pointer": "/answerSurface/sections/15/links/4/href"
+      },
+      {
+        "from": "/treatments/implants-full-arch",
+        "to": "/contact",
+        "source": "machine_manifest_page",
+        "pointer": "/answerSurface/sections/17/ctas/0/href"
+      },
+      {
+        "from": "/treatments/implants-full-arch",
+        "to": "/treatments/cbct-3d-scanning",
+        "source": "machine_manifest_page",
+        "pointer": "/answerSurface/sections/17/ctas/1/href"
       },
       {
         "from": "/treatments/implants-multiple-teeth",

--- a/tools/audits/seo-ai-answer-foundation/AI_ANSWER_FOUNDATION_REPORT_V1.json
+++ b/tools/audits/seo-ai-answer-foundation/AI_ANSWER_FOUNDATION_REPORT_V1.json
@@ -1,6 +1,6 @@
 {
   "version": "AI_ANSWER_FOUNDATION_REPORT_V1",
-  "generatedAt": "2026-06-19T08:33:29.597Z",
+  "generatedAt": "2026-06-19T09:17:33.439Z",
   "mission": "SEO_AI_ANSWER_AND_ZERO_CLICK_FOUNDATION_V1",
   "scopeBoundaries": [
     "Foundation only",
@@ -14,8 +14,8 @@
     "treatmentManifests": {
       "source": "packages/champagne-manifests/data/champagne_machine_manifest_full.json",
       "treatmentPageCount": 79,
-      "answerSurfaceTreatmentPageCount": 12,
-      "treatmentAnswerSurfaceFaqCount": 37
+      "answerSurfaceTreatmentPageCount": 13,
+      "treatmentAnswerSurfaceFaqCount": 41
     },
     "contentManifests": {
       "pageCount": 103,
@@ -62,8 +62,8 @@
       ]
     },
     "faqStructures": {
-      "answerSurfaceFaqCount": 37,
-      "pagesWithAnswerSurfaceFaqs": 12
+      "answerSurfaceFaqCount": 41,
+      "pagesWithAnswerSurfaceFaqs": 13
     },
     "metadataSources": [
       "manifest page labels/descriptions/intro fields",
@@ -99,7 +99,7 @@
   },
   "scores": {
     "aiReadinessScore": 83,
-    "zeroClickReadinessScore": 79
+    "zeroClickReadinessScore": 81
   },
   "majorGapsDiscovered": [
     "0 approved priority services do not yet have AI answer registry entries.",

--- a/tools/audits/seo-ai-answer-foundation/AI_ANSWER_FOUNDATION_REPORT_V1.md
+++ b/tools/audits/seo-ai-answer-foundation/AI_ANSWER_FOUNDATION_REPORT_V1.md
@@ -11,8 +11,8 @@ Foundation only. No mass content generation, page redesign, chatbot runtime muta
 ## Audit findings
 
 - Treatment manifests audited: 79 treatment pages from the machine manifest.
-- Treatment answer surfaces found: 12.
-- Existing answer-surface FAQ items found: 37.
+- Treatment answer surfaces found: 13.
+- Existing answer-surface FAQ items found: 41.
 - Page/content manifests audited: 103 pages with 37 reusable section types detected.
 - Metadata surfaces detected: 103.
 - Approved fact sources audited: approved facts, local identity, and team registry.
@@ -38,7 +38,7 @@ Foundation only. No mass content generation, page redesign, chatbot runtime muta
 ## Scores
 
 - AI readiness score: 83.
-- Zero-click readiness score: 79.
+- Zero-click readiness score: 81.
 
 ## Major gaps discovered
 

--- a/tools/audits/seo-ai-answer-foundation/AI_SEARCH_READINESS_AUDIT_V1.json
+++ b/tools/audits/seo-ai-answer-foundation/AI_SEARCH_READINESS_AUDIT_V1.json
@@ -1,10 +1,10 @@
 {
   "version": "AI_SEARCH_READINESS_AUDIT_V1",
-  "generatedAt": "2026-06-19T08:33:29.597Z",
+  "generatedAt": "2026-06-19T09:17:33.439Z",
   "status": "foundation_ready_with_gaps",
   "scores": {
     "aiReadinessScore": 83,
-    "zeroClickReadinessScore": 79
+    "zeroClickReadinessScore": 81
   },
   "coverage": {
     "answerCoverage": {
@@ -47,8 +47,8 @@
     },
     "faqCoverage": {
       "treatmentPageCount": 79,
-      "answerSurfaceTreatmentPageCount": 12,
-      "answerSurfaceFaqCount": 37,
+      "answerSurfaceTreatmentPageCount": 13,
+      "answerSurfaceFaqCount": 41,
       "priorityTreatmentPagesMissingAnswerSurface": [
         {
           "service": "emergency-dentist",

--- a/tools/audits/seo-ai-answer-foundation/CHATBOT_ALIGNMENT_AUDIT_V1.json
+++ b/tools/audits/seo-ai-answer-foundation/CHATBOT_ALIGNMENT_AUDIT_V1.json
@@ -1,6 +1,6 @@
 {
   "version": "CHATBOT_ALIGNMENT_AUDIT_V1",
-  "generatedAt": "2026-06-19T08:33:29.597Z",
+  "generatedAt": "2026-06-19T09:17:33.439Z",
   "status": "alignment_foundation_only",
   "runtimeMutation": false,
   "mappingCount": 17,

--- a/tools/audits/seo-ai-answer-foundation/QUESTION_INVENTORY_AUDIT_V1.json
+++ b/tools/audits/seo-ai-answer-foundation/QUESTION_INVENTORY_AUDIT_V1.json
@@ -1,6 +1,6 @@
 {
   "version": "QUESTION_INVENTORY_AUDIT_V1",
-  "generatedAt": "2026-06-19T08:33:29.597Z",
+  "generatedAt": "2026-06-19T09:17:33.439Z",
   "status": "partial_foundation",
   "targetServices": [
     "dental-implants",

--- a/tools/audits/seo-ai-answer-foundation/ZERO_CLICK_READINESS_AUDIT_V1.json
+++ b/tools/audits/seo-ai-answer-foundation/ZERO_CLICK_READINESS_AUDIT_V1.json
@@ -1,6 +1,6 @@
 {
   "version": "ZERO_CLICK_READINESS_AUDIT_V1",
-  "generatedAt": "2026-06-19T08:33:29.597Z",
+  "generatedAt": "2026-06-19T09:17:33.439Z",
   "status": "recommendations_only",
   "checks": {
     "missingAnswerBlocks": [],
@@ -60,8 +60,8 @@
     "answerRegistryEntries": 18,
     "priorityServiceCount": 12,
     "priorityServicesWithAnswers": 12,
-    "answerSurfaceTreatmentPages": 12,
-    "answerSurfaceFaqCount": 37
+    "answerSurfaceTreatmentPages": 13,
+    "answerSurfaceFaqCount": 41
   },
   "recommendations": [
     "Prioritise one short direct answer plus one FAQ set for each approved priority service.",

--- a/tools/audits/seo-ai-answer-priority-service-packet/SEO_AI_ANSWER_PRIORITY_SERVICE_PACKET_REPORT_V1.json
+++ b/tools/audits/seo-ai-answer-priority-service-packet/SEO_AI_ANSWER_PRIORITY_SERVICE_PACKET_REPORT_V1.json
@@ -1,6 +1,6 @@
 {
   "version": "SEO_AI_ANSWER_PRIORITY_SERVICE_PACKET_REPORT_V1",
-  "generatedAt": "2026-06-19T08:33:30.850Z",
+  "generatedAt": "2026-06-19T09:17:34.839Z",
   "status": "pass_activation_supported",
   "mission": "SEO_AI_ANSWER_PRIORITY_SERVICE_PACKET_V1",
   "scopeBoundary": [
@@ -215,7 +215,7 @@
   ],
   "scores": {
     "previousAiReadinessScore": 83,
-    "previousZeroClickReadinessScore": 79,
+    "previousZeroClickReadinessScore": 81,
     "aiReadinessScore": 88,
     "zeroClickReadinessScore": 79
   },

--- a/tools/audits/seo-ai-answer-priority-service-packet/SEO_AI_ANSWER_PRIORITY_SERVICE_PACKET_REPORT_V1.md
+++ b/tools/audits/seo-ai-answer-priority-service-packet/SEO_AI_ANSWER_PRIORITY_SERVICE_PACKET_REPORT_V1.md
@@ -20,7 +20,7 @@ Bounded answer-packet population only. No page redesign, no mass treatment rewri
 ## Scores
 
 - Previous AI readiness score: 83.
-- Previous zero-click readiness score: 79.
+- Previous zero-click readiness score: 81.
 - Packet AI readiness score: 88.
 - Packet zero-click readiness score: 79.
 

--- a/tools/audits/seo-ai-answer-priority-service-packet/SEO_PRIORITY_SERVICE_ANSWER_COVERAGE_V1.json
+++ b/tools/audits/seo-ai-answer-priority-service-packet/SEO_PRIORITY_SERVICE_ANSWER_COVERAGE_V1.json
@@ -1,6 +1,6 @@
 {
   "version": "SEO_PRIORITY_SERVICE_ANSWER_COVERAGE_V1",
-  "generatedAt": "2026-06-19T08:33:30.850Z",
+  "generatedAt": "2026-06-19T09:17:34.839Z",
   "priorityServices": [
     {
       "id": "emergency-dentist",

--- a/tools/audits/seo-ai-answer-priority-service-packet/SEO_TREATMENT_FACT_GAP_TODO_V1.json
+++ b/tools/audits/seo-ai-answer-priority-service-packet/SEO_TREATMENT_FACT_GAP_TODO_V1.json
@@ -1,6 +1,6 @@
 {
   "version": "SEO_TREATMENT_FACT_GAP_TODO_V1",
-  "generatedAt": "2026-06-19T08:33:30.850Z",
+  "generatedAt": "2026-06-19T09:17:34.839Z",
   "status": "clinician_review_required",
   "nullOrUnknownFacts": [
     {

--- a/tools/audits/seo-ai-answer-priority-service-packet/SEO_VISIBLE_RENDERING_TODO_V1.json
+++ b/tools/audits/seo-ai-answer-priority-service-packet/SEO_VISIBLE_RENDERING_TODO_V1.json
@@ -1,6 +1,6 @@
 {
   "version": "SEO_VISIBLE_RENDERING_TODO_V1",
-  "generatedAt": "2026-06-19T08:33:30.850Z",
+  "generatedAt": "2026-06-19T09:17:34.839Z",
   "status": "future_rendering_mission_required",
   "items": [
     {

--- a/tools/audits/seo-ai-answer-priority-service-packet/SEO_ZERO_CLICK_PACKET_QA_RESULTS_V1.json
+++ b/tools/audits/seo-ai-answer-priority-service-packet/SEO_ZERO_CLICK_PACKET_QA_RESULTS_V1.json
@@ -1,6 +1,6 @@
 {
   "version": "SEO_ZERO_CLICK_PACKET_QA_RESULTS_V1",
-  "generatedAt": "2026-06-19T08:33:30.850Z",
+  "generatedAt": "2026-06-19T09:17:34.839Z",
   "status": "pass",
   "errors": [],
   "warnings": [],
@@ -43,7 +43,7 @@
   },
   "scores": {
     "previousAiReadinessScore": 83,
-    "previousZeroClickReadinessScore": 79,
+    "previousZeroClickReadinessScore": 81,
     "aiReadinessScore": 88,
     "zeroClickReadinessScore": 79
   }

--- a/tools/audits/seo-visible-answer-surface-rendering/SEO_ROUTE_RENDERING_STATUS_V1.json
+++ b/tools/audits/seo-visible-answer-surface-rendering/SEO_ROUTE_RENDERING_STATUS_V1.json
@@ -1,6 +1,6 @@
 {
   "version": "SEO_ROUTE_RENDERING_STATUS_V1",
-  "generatedAt": "2026-06-19T08:33:32.092Z",
+  "generatedAt": "2026-06-19T09:17:36.330Z",
   "status": "pass",
   "routes": [
     {

--- a/tools/audits/seo-visible-answer-surface-rendering/SEO_VISIBLE_ANSWER_SURFACE_COVERAGE_V1.json
+++ b/tools/audits/seo-visible-answer-surface-rendering/SEO_VISIBLE_ANSWER_SURFACE_COVERAGE_V1.json
@@ -1,6 +1,6 @@
 {
   "version": "SEO_VISIBLE_ANSWER_SURFACE_COVERAGE_V1",
-  "generatedAt": "2026-06-19T08:33:32.092Z",
+  "generatedAt": "2026-06-19T09:17:36.330Z",
   "targetServiceCount": 11,
   "renderedCount": 11,
   "coveragePercentage": 100,

--- a/tools/audits/seo-visible-answer-surface-rendering/SEO_VISIBLE_ANSWER_SURFACE_RENDERING_REPORT_V1.json
+++ b/tools/audits/seo-visible-answer-surface-rendering/SEO_VISIBLE_ANSWER_SURFACE_RENDERING_REPORT_V1.json
@@ -1,6 +1,6 @@
 {
   "version": "SEO_VISIBLE_ANSWER_SURFACE_RENDERING_REPORT_V1",
-  "generatedAt": "2026-06-19T08:33:32.092Z",
+  "generatedAt": "2026-06-19T09:17:36.330Z",
   "status": "pass",
   "mission": "SEO_VISIBLE_ANSWER_SURFACE_RENDERING_V1",
   "architecture": {
@@ -12,7 +12,7 @@
   },
   "coverage": {
     "version": "SEO_VISIBLE_ANSWER_SURFACE_COVERAGE_V1",
-    "generatedAt": "2026-06-19T08:33:32.092Z",
+    "generatedAt": "2026-06-19T09:17:36.330Z",
     "targetServiceCount": 11,
     "renderedCount": 11,
     "coveragePercentage": 100,
@@ -288,7 +288,7 @@
   ],
   "qa": {
     "version": "SEO_ZERO_CLICK_RENDERING_QA_V1",
-    "generatedAt": "2026-06-19T08:33:32.092Z",
+    "generatedAt": "2026-06-19T09:17:36.330Z",
     "status": "pass",
     "checks": [
       {

--- a/tools/audits/seo-visible-answer-surface-rendering/SEO_VISIBLE_ANSWER_SURFACE_RENDERING_REPORT_V1.md
+++ b/tools/audits/seo-visible-answer-surface-rendering/SEO_VISIBLE_ANSWER_SURFACE_RENDERING_REPORT_V1.md
@@ -1,6 +1,6 @@
 # SEO Visible Answer Surface Rendering Report V1
 
-Generated: 2026-06-19T08:33:32.092Z
+Generated: 2026-06-19T09:17:36.330Z
 
 ## Status
 

--- a/tools/audits/seo-visible-answer-surface-rendering/SEO_ZERO_CLICK_RENDERING_QA_V1.json
+++ b/tools/audits/seo-visible-answer-surface-rendering/SEO_ZERO_CLICK_RENDERING_QA_V1.json
@@ -1,6 +1,6 @@
 {
   "version": "SEO_ZERO_CLICK_RENDERING_QA_V1",
-  "generatedAt": "2026-06-19T08:33:32.092Z",
+  "generatedAt": "2026-06-19T09:17:36.330Z",
   "status": "pass",
   "checks": [
     {


### PR DESCRIPTION
### Motivation
- Finish the missing TREATMENT_ANSWER_SURFACE_V1 answer-surface for the full-arch implants route so the treatment page moves from PARTIAL to READY_FOR_AGENT_STAGING while preserving canonical routes and alias mapping.
- Provide a machine-readable, guarded answer-surface (direct answer, FAQ, risks, alternatives, cost logic, clinician review metadata) required by the Website OS treatment answer-surface contract and downstream QA/reporting pipelines.

### Description
- Added a complete `answerSurface` for `implants_full_arch` in `packages/champagne-manifests/data/champagne_machine_manifest_full.json` including `version: "TREATMENT_ANSWER_SURFACE_V1"`, `status: "answer_surface_complete"`, `frameworkOnly: false`, `exampleSeed: false`, `primaryGeography: "Shoreham-by-Sea"`, `secondaryGeographies: ["Brighton","Worthing","Lancing","Southwick"]`, and all required sections (`direct_answer`, `what_this_treatment_is`, `who_it_is_for`, `who_it_may_not_be_suitable_for`, `benefits`, `risks_and_limitations`, `alternatives`, `process`, `timeline`, `aftercare`, `cost_fee_logic`, `local_shoreham_context`, `clinician_expertise`, `technology_used`, `faq`, `related_treatments_internal_links`, `last_reviewed_clinical_review`, `cta`).
- Regenerated and committed the derived truth and QA artifacts including `reports/WEBSITE_OS_TREATMENT_SOURCE_TRUTH_HASH_EXPORT_V1.*`, `reports/WEBSITE_TRUTH_EXPORT_REPORT_V1.json`, and updated audit outputs under `tools/audits/seo-ai-answer-foundation`, `tools/audits/seo-ai-answer-priority-service-packet`, and `tools/audits/seo-visible-answer-surface-rendering` to reflect the new answer-surface and counts.
- Minor manifest content encoding normalisations and many report timestamps/coverage counters updated to reflect the export run; key files changed include `packages/champagne-manifests/data/champagne_machine_manifest_full.json`, `ops/contracts/WEBSITE_TRUTH_EXPORT_CONTRACT_V1.json`, `reports/WEBSITE_OS_TREATMENT_SOURCE_TRUTH_HASH_EXPORT_V1.*`, `reports/WEBSITE_TRUTH_EXPORT_REPORT_V1.json`, and multiple `tools/audits/*` JSON/MD outputs.
- Capability gained: the full-arch implant route now exposes a validated, machine-readable answer-surface that satisfies the `TREATMENT_ANSWER_SURFACE_V1` contract and enables downstream zero-click/AI answer and staging workflows without redesigning the page.

### Testing
- Ran `pnpm run guard:treatment-answer-surface` and it passed, signalling the answer-surface framework and section coverage validation succeeded.
- Ran `pnpm run seo:answer-foundation-qa`, `pnpm run seo:answer-packet-qa`, and `pnpm run seo:answer-rendering-qa` and all three reports returned `PASS` (visible rendering QA reported 11/11 coverage); outputs were written to `tools/audits/`.
- Export and truth workflows `pnpm run export:website-truth`, `pnpm run export:page-truth`, and `node scripts/export-treatment-source-truth-hashes.mjs` were executed and wrote updated reports showing `ready=5 partial=0 blocked=0` for the first-batch targets.
- Ran the guard suite and verification: `pnpm --filter @champagne/guards guard:route-truth`, `pnpm run guard:seo-launch-safety`, `pnpm run guard:hero`, `pnpm run guard:canon`, and `pnpm run verify` which all completed successfully (some commands emitted informational warnings about Browserslist/Tailwind patterns/workspace dependency warnings but did not fail the guards or build); `git diff --check` and `git diff --cached --check` returned no blocking errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3508d5e5988332b1abf58c547c1810)