### PR TITLE
Design Website OS & Live Canvas contracts (design-only, fail-closed)

### DIFF
--- a/CHAMPAGNE_LIVE_CANVAS_SAFE_EDIT_CONTRACT_V1.md
+++ b/CHAMPAGNE_LIVE_CANVAS_SAFE_EDIT_CONTRACT_V1.md
@@ -1,0 +1,151 @@
+# Champagne Live Canvas Safe-Edit Contract V1
+
+Status: `DESIGN_ONLY_FAIL_CLOSED`  
+Purpose: define how Live Canvas may propose safe edits for Champagne without mutating runtime code directly.
+
+## Principle
+
+Live Canvas is a preview and proposal interface. It may collect human edits inside declared editable zones, render non-production previews, and emit Website OS patch packets. It must not directly commit runtime code, deploy, call providers, or edit sacred zones.
+
+## Editable zones
+
+Live Canvas editable zones must be explicit, typed, and source-hashed.
+
+Allowed zone classes:
+
+- `page.metadataDraft`: title, description, canonical, OpenGraph/Twitter fields.
+- `page.jsonLdDraft`: structured data payloads backed by evidence.
+- `content.copyField`: approved page/section copy fields.
+- `content.ctaLabel`: CTA labels from approved manifests, without changing destination semantics unless separately authorized.
+- `content.ctaDestinationDraft`: proposed destination changes requiring journey review.
+- `section.visibilityDraft`: proposed enable/disable of approved non-sacred sections.
+- `section.orderDraft`: proposed reorder of approved non-sacred sections.
+- `design.tokenBindingDraft`: replacement among existing semantic tokens only.
+
+Every editable zone must carry:
+
+- stable `zoneId`
+- route or source file identity
+- JSON pointer or field path
+- current source hash
+- allowed operation list
+- required reviewer roles
+- rollback field/value
+
+## Sacred zones
+
+Live Canvas must mark these as locked and non-editable:
+
+- Sacred hero engine core.
+- Sacred hero manifests.
+- Sacred render entry.
+- Guards and CI unless the packet is explicitly guard/CI scoped.
+- Token source files unless the packet explicitly has token-authorized scope.
+- Provider/PMS/booking integration code.
+- Runtime layout/global styling files unless fresh Director scope exists.
+
+A locked zone may be displayed for context only if it is clearly labelled read-only.
+
+## Token boundaries
+
+Live Canvas design edits must obey token-only styling:
+
+- No raw hex, RGB, RGBA, HSL, named colours, or arbitrary non-token Tailwind colour classes.
+- No inline gradients.
+- No new token creation from Canvas.
+- No semantic misuse: glass is not a default card, ink is not a porcelain replacement, footer emotion is footer-only.
+- Allowed design operation is token rebinding among pre-existing approved semantic tokens.
+
+## Preview requirements
+
+Before a patch packet can be emitted, Live Canvas must generate preview evidence:
+
+1. Route preview URL or local preview artifact identifier.
+2. Before/after textual diff for content and SEO fields.
+3. Token-diff table for design edits.
+4. Sacred-zone untouched receipt.
+5. Guard plan receipt.
+6. Accessibility checklist for headings, labels, links, and reduced-motion considerations.
+7. SEO preview for title/description/canonical/JSON-LD when relevant.
+
+Preview must be labelled non-production and not launch-certified.
+
+## Rollback requirements
+
+Every emitted packet must include rollback data:
+
+- exact source field path or file path;
+- prior value hash;
+- prior value or reversible operation description;
+- dependent routes/pages;
+- expected guard commands after rollback;
+- owner responsible for approving rollback.
+
+Live Canvas must reject edits that cannot be rolled back precisely.
+
+## Validation gates
+
+A Canvas proposal can become a Website OS patch packet only after:
+
+- source hash still matches;
+- zone is editable and operation is allowed;
+- sacred zones remain untouched;
+- no raw colour/style residue exists in the proposal;
+- required reviews are assigned;
+- preview evidence exists;
+- rollback evidence exists;
+- packet declares required guards: `npm run guard:hero`, `npm run guard:canon`, `npm run verify`.
+
+## Evidence-review workflow
+
+### Founder review
+
+Checks:
+
+- business intent;
+- patient journey fit;
+- tone and trust;
+- no premature launch/readiness claims.
+
+### Clinical review
+
+Checks:
+
+- clinical safety;
+- no diagnosis/treatment guarantee;
+- no unsupported efficacy claim;
+- content is general information unless explicitly clinician-approved.
+
+### Brand review
+
+Checks:
+
+- Champagne canon alignment;
+- token-only design;
+- surface semantics;
+- typography and visual tone;
+- no visual guesses without diagnostics.
+
+### SEO review
+
+Checks:
+
+- anti-doorway compliance;
+- metadata correctness;
+- structured-data evidence;
+- canonical and route family consistency;
+- no fabricated local/service claims.
+
+### Launch-proof review
+
+Checks:
+
+- all previous reviews complete;
+- guards pass;
+- deployment plan exists outside Live Canvas;
+- live-provider evidence, if claimed, comes from an approved separate audit;
+- launch readiness remains false unless explicitly certified by a later launch packet.
+
+## Failure handling
+
+Live Canvas must fail closed by refusing packet emission when any gate is unknown, stale, missing, or contradictory.

--- a/CHAMPAGNE_TENANT_BLUEPRINT_EXTRACTION_PLAN_V1.md
+++ b/CHAMPAGNE_TENANT_BLUEPRINT_EXTRACTION_PLAN_V1.md
@@ -1,0 +1,77 @@
+# Champagne Tenant Blueprint Extraction Plan V1
+
+Status: `DESIGN_ONLY`  
+Purpose: define what may become reusable tenant architecture and what must remain SMH/Champagne-specific.
+
+## Extraction posture
+
+Champagne can inform a reusable Website OS tenant blueprint, but extraction must not dilute the Champagne Canon or copy SMH-specific clinical, brand, or operational truth into generic tenants.
+
+## Reusable tenant architecture candidates
+
+| Candidate | Reusable boundary | Exclusion |
+| --- | --- | --- |
+| Import/export envelope | Contract version, source hashes, guard state, data class declarations | Champagne-specific report names become examples only. |
+| Safe patch packet schema | Operation taxonomy, validation gates, rollback structure | No Champagne sacred file paths in generic schema except as tenant-supplied locks. |
+| Evidence-review workflow | Founder/clinical/brand/SEO/launch-proof roles | Reviewer names, SMH policies, and claims remain tenant-local. |
+| Editable zone registry | Zone IDs, field paths, allowed operations, source hashes | Champagne section IDs and route families remain tenant data. |
+| Sacred-zone mechanism | Tenant declares locked paths/manifests/components | Champagne hero engine is not reusable default code. |
+| Token boundary rules | Token-only styling and semantic surface mapping | Champagne token names are an adapter, not universal primitives. |
+| Guard visibility model | Required guard command registry and CI receipts | Actual guard scripts remain repo-specific unless extracted deliberately. |
+| Rollback contract | Prior hash/value, affected routes, guard commands | Tenant-specific rollback owners and files remain tenant data. |
+
+## Must remain SMH/Champagne-specific
+
+- Champagne Canon, brand chroma, Persian Midnight/porcelain/glass semantics, and emotional material language.
+- Sacred Hero Engine implementation, sacred manifests, hero renderer, hero diagnostics, and hero variant identities.
+- SMH treatment content, clinical copy, fees, FAQs, patient stories, local geography, CTAs, and Dentally/portal semantics.
+- Campaign 007 artifacts and PR #850 audit findings as Champagne evidence, not generic proof.
+- Any founder-approved tone, launch gaps, weak-copy registers, and review outcomes.
+- Any practice/provider IDs, booking destinations, operational workflows, or clinical governance decisions.
+
+## Extraction boundaries
+
+### Layer 1: Generic contract kernel
+
+Extract later into a tenant-neutral package only after design approval:
+
+- JSON schema for import/export envelopes.
+- JSON schema for patch packets.
+- Review-state machine.
+- Editable-zone registry interface.
+- Fail-closed validator interface.
+
+### Layer 2: Tenant adapter
+
+Champagne-specific adapter should provide:
+
+- sacred-zone list;
+- guard command list;
+- token map;
+- section capability map;
+- route/page inventory imports;
+- evidence-review role mapping.
+
+### Layer 3: Runtime implementation
+
+Runtime implementation remains outside this design packet. Later Codex work must be scoped to docs/contracts first, then validators, then UI preview surfaces. No runtime app edits are authorized by this plan.
+
+## Exact implementation slices for later Codex work
+
+1. **Schema slice**: add JSON schemas for Website OS import/export envelopes and patch packets under a docs/contracts or ops/contracts schema path.
+2. **Validator slice**: implement a CLI validator that reads a packet and fails closed on missing hashes, forbidden files, raw styles, or missing review gates.
+3. **Editable-zone registry slice**: produce a read-only registry generator from existing page/section truth exports.
+4. **Review workflow slice**: add review-state fixtures and validation examples for founder, clinical, brand, SEO, and launch-proof review.
+5. **Live Canvas preview receipt slice**: define and validate preview receipt artifacts without touching runtime preview UI.
+6. **Tenant adapter slice**: design a Champagne adapter file containing sacred zones, guard commands, token boundaries, and data-class exclusions.
+7. **CI visibility slice**: add non-runtime contract validation as a named CI step only after schemas and fixtures exist.
+8. **Documentation slice**: document how Website OS/Live Canvas packets move from proposal to Codex implementation.
+
+## Non-goals
+
+- No deployment automation.
+- No provider calls.
+- No PMS mutation.
+- No runtime UI implementation.
+- No hero refactor.
+- No launch-readiness certification.

--- a/CHAMPAGNE_WEBSITE_OS_CONTRACT_DESIGN_V1.json
+++ b/CHAMPAGNE_WEBSITE_OS_CONTRACT_DESIGN_V1.json
@@ -1,0 +1,136 @@
+{
+  "contractVersion": "CHAMPAGNE_WEBSITE_OS_CONTRACT_DESIGN_V1",
+  "status": "DESIGN_ONLY_FAIL_CLOSED",
+  "scope": {
+    "repository": "champagne",
+    "runtimeMutationAllowed": false,
+    "deploymentAllowed": false,
+    "providerCallsAllowed": false,
+    "phiAllowed": false,
+    "secretsAllowed": false,
+    "launchReadinessClaimsAllowed": false
+  },
+  "evidenceInputs": {
+    "pr850Reports": [
+      "HERO_ENGINE_V2_MASTER_TRUTH_AUDIT.md",
+      "ATMOSPHERIC_SYSTEM_MASTER_TRUTH_AUDIT.md",
+      "SURFACE_TOKEN_MASTER_TRUTH_AUDIT.md",
+      "ROGUE_HEX_AND_TOKEN_DRIFT_AUDIT.md",
+      "TYPOGRAPHY_MASTER_TRUTH_AUDIT.md",
+      "STRUCTURE_AUDIT_REPORT.md"
+    ],
+    "campaign007": [
+      "CHAMPAGNE_CAMPAIGN007_REALITY_AUDIT_V1.md"
+    ],
+    "existingContracts": [
+      "ops/contracts/WEBSITE_TRUTH_EXPORT_CONTRACT_V1.json",
+      "ops/contracts/EVIDENCE_REVIEW_METADATA_CONTRACT_V1.json",
+      "ops/contracts/PAGE_SURFACE_V1.json",
+      "ops/contracts/PAGE_FAMILY_ROUTE_CANON_V1.json"
+    ]
+  },
+  "importContract": {
+    "requiredEnvelopeFields": [
+      "contractVersion",
+      "repo",
+      "branch",
+      "commitSha",
+      "generatedAt",
+      "sourceReports",
+      "sourceHashes",
+      "guardStatus",
+      "scopeDeclaration",
+      "dataClassDeclaration",
+      "launchReadinessDeclaration"
+    ],
+    "allowedFamilies": [
+      "routePageInventory",
+      "treatmentSourceTruth",
+      "sectionRegistry",
+      "seoMetadataTruth",
+      "tokenSurfaceCapability",
+      "heroBindingTruthReadOnly",
+      "evidenceReviewMetadata"
+    ],
+    "forbiddenFamilies": [
+      "phi",
+      "pmsData",
+      "appointmentData",
+      "clinicalRecords",
+      "providerCredentials",
+      "secrets",
+      "cookies",
+      "sessionData",
+      "productionLogs",
+      "runtimePatchesDisguisedAsImports"
+    ]
+  },
+  "exportContract": {
+    "types": [
+      "truth_export",
+      "patch_packet",
+      "review_packet",
+      "tenant_blueprint_candidate"
+    ],
+    "rules": [
+      "source_hashes_required",
+      "sacred_zones_preserved",
+      "launch_readiness_false_by_default",
+      "deterministic_json_required"
+    ]
+  },
+  "patchPacketSchema": {
+    "requiredTopLevelFields": [
+      "packetId",
+      "contractVersion",
+      "createdAt",
+      "createdBy",
+      "repo",
+      "baseCommitSha",
+      "objective",
+      "changeClass",
+      "allowedFiles",
+      "forbiddenFiles",
+      "sourcePreconditions",
+      "proposedOperations",
+      "tokenPolicy",
+      "heroPolicy",
+      "seoPolicy",
+      "evidenceReview",
+      "validationPlan",
+      "rollbackPlan",
+      "failureMode"
+    ],
+    "allowedOperationTypes": [
+      "content.replaceField",
+      "seo.updateMetadata",
+      "seo.addJsonLd",
+      "design.bindToken",
+      "section.reorderAllowed",
+      "section.toggleAllowed",
+      "route.addDraftPage"
+    ],
+    "forbiddenOperationTypes": [
+      "sacredHeroEdit",
+      "providerCall",
+      "pmsMutation",
+      "deployment",
+      "rawColorStyle",
+      "inlineGradient",
+      "guardWeakening",
+      "unsupportedLaunchClaim"
+    ]
+  },
+  "validationGates": [
+    "source_hash_match",
+    "exact_allowed_files",
+    "sacred_zones_excluded",
+    "token_only_policy",
+    "required_reviews_complete",
+    "rollback_plan_present",
+    "guard_hero_present_and_planned",
+    "guard_canon_present_and_planned",
+    "verify_present_and_planned"
+  ],
+  "failureMode": "reject_packet_fail_closed"
+}

--- a/CHAMPAGNE_WEBSITE_OS_CONTRACT_DESIGN_V1.md
+++ b/CHAMPAGNE_WEBSITE_OS_CONTRACT_DESIGN_V1.md
@@ -1,0 +1,154 @@
+# Champagne Website OS Contract Design V1
+
+Status: `DESIGN_ONLY_FAIL_CLOSED`  
+Scope: Champagne repo only  
+Runtime mutation: none  
+Provider calls: none  
+Launch readiness claim: none
+
+## Evidence read
+
+This contract is based on repository evidence only:
+
+- PR #850 true-state audit reports, including hero, atmosphere, surface, token, typography, performance, and structural audits.
+- Campaign 007 evidence harvest, especially `CHAMPAGNE_CAMPAIGN007_REALITY_AUDIT_V1.md`.
+- Existing Website OS contracts under `ops/contracts/**`.
+- Required guards: `npm run guard:hero`, `npm run guard:canon`, `npm run verify`.
+
+Campaign 007 is treated as useful repository evidence, not live-provider proof. Website OS must therefore never infer public launch readiness from Campaign 007 alone.
+
+## Operating posture
+
+Website OS for Champagne is a governed import/export and proposal system. It may describe repo truth, generate candidate changes, and package review evidence. It must not directly mutate production runtime, call PMS/provider systems, deploy, or bypass guards.
+
+The default outcome for uncertainty is rejection.
+
+## Import contract
+
+Website OS may import only non-secret, non-PHI repository truth exported from approved sources.
+
+### Required import envelope
+
+Every import must include:
+
+- `contractVersion`
+- `repo`
+- `branch`
+- `commitSha`
+- `generatedAt`
+- `sourceReports`
+- `sourceHashes`
+- `guardStatus`
+- `scopeDeclaration`
+- `dataClassDeclaration`
+- `launchReadinessDeclaration`
+
+### Allowed import data families
+
+| Family | Allowed examples | Notes |
+| --- | --- | --- |
+| Route/page inventory | public routes, page IDs, manifest links | Must include source hash and stale-state marker. |
+| Treatment source truth | slug, route, content hash, SEO hash | Must not contain patient records or provider data. |
+| Section registry | section kind, compatibility, editable field metadata | No runtime component code in the import payload. |
+| SEO metadata truth | title, description, canonical, JSON-LD presence | Claims must remain evidence-backed. |
+| Token/surface capability | semantic token names, allowed surface contexts | No raw colour proposals. |
+| Hero binding truth | read-only hero IDs/variant IDs/diagnostic state | Sacred hero manifests and renderer remain immutable to Website OS. |
+| Evidence-review metadata | reviewer state, evidence references, decision logs | Human review gates are mandatory before implementation. |
+
+### Forbidden import data
+
+Website OS must reject imports containing:
+
+- PHI, PMS data, appointment data, clinical records, enquiry payloads, or secrets.
+- Provider credentials, API keys, deployment tokens, cookies, session data, or private logs.
+- Raw runtime source patches disguised as imports.
+- Claims of live Search Console, analytics, or provider validation unless accompanied by a separate approved evidence artifact.
+
+## Export contract
+
+Website OS exports must be immutable evidence bundles or proposal packets, not runtime side effects.
+
+### Export types
+
+1. `truth_export`: normalized repo truth for routes, manifests, content hashes, section capabilities, and guard state.
+2. `patch_packet`: a proposed change packet for later Codex implementation.
+3. `review_packet`: founder/clinical/brand/SEO/launch-proof review queue.
+4. `tenant_blueprint_candidate`: extraction candidate with Champagne-specific exclusions.
+
+### Export rules
+
+- Exports must include source hashes for every editable source they reference.
+- Exports must preserve sacred-zone declarations.
+- Exports must mark launch readiness as `false` unless a separate future launch-proof audit authorizes otherwise.
+- Exports must be deterministic JSON plus human-readable Markdown where useful.
+
+## Safe patch packet schema
+
+A Website OS patch packet is a proposal, not an applied diff.
+
+### Required top-level fields
+
+- `packetId`
+- `contractVersion`
+- `createdAt`
+- `createdBy`
+- `repo`
+- `baseCommitSha`
+- `objective`
+- `changeClass`
+- `allowedFiles`
+- `forbiddenFiles`
+- `sourcePreconditions`
+- `proposedOperations`
+- `tokenPolicy`
+- `heroPolicy`
+- `seoPolicy`
+- `evidenceReview`
+- `validationPlan`
+- `rollbackPlan`
+- `failureMode`
+
+### Allowed operation types
+
+| Operation | Meaning | Required constraints |
+| --- | --- | --- |
+| `content.replaceField` | Replace a manifest/content field | Requires source hash, reviewer approval, no PHI. |
+| `seo.updateMetadata` | Update title/description/canonical/OG/Twitter field | Requires SEO review and route evidence. |
+| `seo.addJsonLd` | Add structured data payload | Must be schema-valid and evidence-backed. |
+| `design.bindToken` | Swap an existing semantic token binding | No raw colours, gradients, or new tokens unless separately authorized. |
+| `section.reorderAllowed` | Reorder approved non-sacred sections | Requires layout preview and rollback. |
+| `section.toggleAllowed` | Enable/disable approved non-sacred section | Requires review of content and journey impact. |
+| `route.addDraftPage` | Propose a draft route/page | Requires anti-doorway, SEO, founder, and clinical review. |
+
+### Forbidden operation types
+
+- Direct edits to sacred hero engine files, sacred manifests, or sacred render entry.
+- Provider calls, PMS writes, Dentally mutation, deployment, or production cache purge.
+- Raw CSS colour literals, inline gradients, or non-token Tailwind colour utilities.
+- Changes to guards that weaken enforcement.
+- Claims that convert evidence into medical advice, guarantees, or launch certification.
+
+## Validation gates
+
+A patch packet may advance to Codex implementation only if:
+
+1. Source hashes match current repository state.
+2. Allowed files are exact and minimal.
+3. Sacred zones are excluded unless explicit fresh authority exists.
+4. Token policy is token-only.
+5. Evidence-review statuses are complete for the change class.
+6. Rollback plan names the exact files/fields to revert.
+7. Required guards are present and planned: `npm run guard:hero`, `npm run guard:canon`, `npm run verify`.
+
+## Fail-closed rejection reasons
+
+Website OS must reject a packet if any of the following are true:
+
+- Unknown source hash.
+- Ambiguous editable zone.
+- Missing reviewer approval.
+- Proposed raw colour or gradient.
+- Sacred-zone touch without fresh named authority.
+- Missing rollback path.
+- Guard missing or not wired.
+- Launch-readiness claim unsupported by separate live evidence.

--- a/NEXT_CODEX_PROMPT_V1.md
+++ b/NEXT_CODEX_PROMPT_V1.md
@@ -1,5 +1,62 @@
-# Next Codex Prompt V1
+# NEXT_CODEX_PROMPT_V1
 
-ROLE: WEBSITE_OS_CHAMPAGNE_CONTRACT_DESIGNER_READ_ONLY_V1
+ROLE: CHAMPAGNE_WEBSITE_OS_CONTRACT_SCHEMA_IMPLEMENTER_V1
 
-MISSION: Design, do not implement, the minimum Website OS to Champagne adapter contract and Live Canvas safe-edit protocol. Use repository evidence only. Include schemas for tenant identity, route manifest import, section patch transaction, SEO/schema patch, guard execution handoff, evidence packet generation, rollback ledger, and sacred-zone read-only handling. Do not mutate code. Run no providers. Stop if implementation is requested.
+MISSION:
+Implement the first non-runtime contract slice for Website OS and Live Canvas packet validation.
+
+Scope:
+- Champagne repo only.
+- Contract/schema/docs only unless explicitly authorized.
+- Do not mutate runtime app code.
+- Do not deploy.
+- Do not call providers.
+- No PHI, PMS, secrets, or production changes.
+
+Read first:
+- AGENTS.md
+- CHAMPAGNE_WEBSITE_OS_CONTRACT_DESIGN_V1.md
+- CHAMPAGNE_WEBSITE_OS_CONTRACT_DESIGN_V1.json
+- CHAMPAGNE_LIVE_CANVAS_SAFE_EDIT_CONTRACT_V1.md
+- CHAMPAGNE_TENANT_BLUEPRINT_EXTRACTION_PLAN_V1.md
+- CHAMPAGNE_CAMPAIGN007_REALITY_AUDIT_V1.md
+- PR #850 audit reports in the repo root
+- ops/contracts/WEBSITE_TRUTH_EXPORT_CONTRACT_V1.json
+- ops/contracts/EVIDENCE_REVIEW_METADATA_CONTRACT_V1.json
+
+Objectives:
+1. Add JSON schema files for:
+   - Website OS import envelope
+   - Website OS export envelope
+   - Website OS safe patch packet
+   - Live Canvas preview receipt
+2. Add example valid and invalid packets as fixtures.
+3. Add a fail-closed validator script for the fixtures only.
+4. Ensure the validator rejects:
+   - forbidden files
+   - raw colour/style proposals
+   - missing source hashes
+   - missing review gates
+   - launch-readiness claims
+   - provider/PMS/PHI/secrets fields
+5. Do not wire CI until a separate packet authorizes CI changes.
+
+Rules:
+- Design/contract tooling only.
+- No runtime app code changes.
+- No sacred hero edits.
+- No guard weakening.
+- Fail closed.
+
+Run:
+- npm run guard:hero
+- npm run guard:canon
+- npm run verify
+- any new validator command you add
+
+Produce:
+- schema files
+- fixture files
+- validator script if authorized by allowed zones
+- implementation report
+- test results

--- a/TEST_RESULTS_V1.md
+++ b/TEST_RESULTS_V1.md
@@ -1,13 +1,16 @@
-# Test Results V1
+# TEST_RESULTS_V1
 
-- PASS: npm run guard:hero
-- PASS: npm run guard:canon
-- PASS: npm run verify
+Status: `PASS_WITH_EXISTING_WARNINGS`
 
-## Warnings captured
+## Commands run
 
-- npm warned about unknown env config http-proxy.
-- Browserslist/caniuse-lite is 7 months old.
-- Tailwind content pattern may match node_modules.
-- SEO launch safety warns REPORTS/TREATMENT_INVENTORY.md has 78 entries while machine manifest has 79.
-- Chatbot engine copy guard notes missing QA report and no conversation files.
+| Command | Result | Notes |
+| --- | --- | --- |
+| `npm run guard:hero` | PASS | Hero guard and sacred hero lock passed. |
+| `npm run guard:canon` | PASS | Canon guard passed; emitted existing npm, Browserslist, and Tailwind content warnings. |
+| `npm run verify` | PASS | Token purity, workspace deps guard, SEO launch safety, all guards, lint, typecheck, and web build completed successfully. Existing warnings included stale Browserslist data, Tailwind content pattern warning, Next.js lint deprecation/plugin warning, workspace dependency legacy warnings, SEO inventory mismatch warning, and missing chatbot QA report warning. |
+| `node -e "JSON.parse(require('fs').readFileSync('CHAMPAGNE_WEBSITE_OS_CONTRACT_DESIGN_V1.json','utf8'))"` | PASS | Contract JSON parsed successfully. |
+
+## Important warning context
+
+The verify command reported an existing SEO launch-safety warning that the treatment inventory total does not match the live machine manifest (`inventory: 78`, `machine manifest: 79`) and recommends refreshing `REPORTS/TREATMENT_INVENTORY.md`. This design packet does not claim launch readiness and did not remediate that warning.


### PR DESCRIPTION
### Motivation

- Provide a governed, design-only import/export and proposal contract for Website OS that preserves Champagne canon and forbids runtime or provider mutations. 
- Define a Live Canvas safe-edit contract and tenant-extraction boundaries so previews and proposals can be produced without weakening guards or touching sacred hero/runtime files. 

### Description

- Added a human-readable Website OS contract at `CHAMPAGNE_WEBSITE_OS_CONTRACT_DESIGN_V1.md` and a machine-readable summary at `CHAMPAGNE_WEBSITE_OS_CONTRACT_DESIGN_V1.json` describing import/export envelopes, allowed/forbidden data families, patch-packet schema, validation gates, and fail-closed rules. 
- Added `CHAMPAGNE_LIVE_CANVAS_SAFE_EDIT_CONTRACT_V1.md` to define editable zones, sacred zones, token boundaries, preview and rollback requirements, and the evidence-review workflow. 
- Added `CHAMPAGNE_TENANT_BLUEPRINT_EXTRACTION_PLAN_V1.md` describing reusable tenant architecture candidates, Champagne-specific exclusions, and exact implementation slices for later Codex work. 
- Updated `NEXT_CODEX_PROMPT_V1.md` with the next non-runtime implementation prompt and added `TEST_RESULTS_V1.md` with guard/build outputs and warning context; no runtime app code, sacred hero files, or CI wiring were changed. 

### Testing

- Ran `npm run guard:hero` which passed (hero guard and sacred hero lock verified). 
- Ran `npm run guard:canon` which passed (canon guard passed with existing environment/Browserslist/Tailwind warnings). 
- Ran `npm run verify` which completed and passed all checks including token purity, workspace guards, SEO launch-safety checks, lint, typecheck, and `next build`, with recorded non-blocking warnings such as stale Browserslist data, Tailwind content pattern warning, Next.js lint deprecation notice, workspace dependency legacy warnings, an SEO inventory count mismatch (`inventory: 78` vs `machine manifest: 79`), and a missing chatbot QA report; these warnings are documented in `TEST_RESULTS_V1.md`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4cfed1a2408332812b9e42d3ebd818)