### PR TITLE
Add CI guard for Champagne contract validation and wire into `verify`

### DIFF
--- a/CHAMPAGNE_CONTRACT_CI_GUARD_IMPLEMENTATION_REPORT_V1.md
+++ b/CHAMPAGNE_CONTRACT_CI_GUARD_IMPLEMENTATION_REPORT_V1.md
@@ -1,0 +1,35 @@
+# CHAMPAGNE_CONTRACT_CI_GUARD_IMPLEMENTATION_REPORT_V1
+
+## Mission
+Wire the Champagne Website OS / Live Canvas contract validator into safe CI-style guard commands without runtime app code, UI changes, deployment, provider calls, PHI/PMS access, secret access, or production mutation.
+
+## Implementation
+- Added `contract:validate` as an independent npm entrypoint for explicit packet validation via `scripts/validate-champagne-contract-packet.mjs`.
+- Added `guard:champagne-contracts` as a CI-style guard entrypoint via `scripts/guard-champagne-contracts.mjs`.
+- Wired `guard:champagne-contracts` into the root `verify` flow after SEO launch safety and before aggregate guard/lint/typecheck/build steps.
+- The contract guard validates only safe fixture files matching `contracts/champagne-os/fixtures/valid-*.json`.
+- The guard fails closed when no safe fixtures exist or when any safe fixture fails validation.
+
+## Failure-Test Coverage
+The existing contract validator test suite proves invalid packets fail closed for:
+- forbidden deployment/provider-call authority;
+- sacred-zone mutation attempts;
+- PHI/PMS flags and sensitive text;
+- missing review gates.
+
+## Non-Runtime Boundary Confirmation
+No Website OS or Live Canvas runtime wiring was implemented. No runtime app code, UI code, deployment code, provider calls, PHI/PMS integrations, secrets handling, or production mutation paths were added.
+
+## Future Runtime-Wiring Prerequisites
+Before any future runtime consumption of Website OS or Live Canvas contract packets, Champagne must have all of the following in place:
+1. Fresh Director authorization naming the exact runtime files and allowed mutation scope.
+2. A reviewed packet lifecycle with explicit reviewer roles, immutable audit evidence, and a fail-closed approval state.
+3. A read-only dry-run renderer or preview layer that cannot deploy, call providers, touch PMS data, use secrets, or mutate production.
+4. Sacred-zone protection confirmed for every proposed operation before runtime interpretation.
+5. PHI/PMS/secret scanning before packet persistence and before runtime consumption.
+6. Rollback evidence and a disabled-by-default feature flag for any runtime adapter.
+7. CI visibility for `guard:champagne-contracts`, `guard:hero`, `guard:canon`, and `verify` as named steps before merge.
+8. Dedicated failure tests for every newly permitted operation before that operation is accepted by the validator or runtime adapter.
+
+## Result
+The contract validator is now available as both an independent npm command and a safe guard command inside the verify flow, while preserving fail-closed behaviour and avoiding runtime mutation.

--- a/NEXT_CODEX_PROMPT_V1.md
+++ b/NEXT_CODEX_PROMPT_V1.md
@@ -1,25 +1,32 @@
 # NEXT_CODEX_PROMPT_V1
 
-ROLE: CHAMPAGNE_CONTRACT_SCHEMA_VALIDATOR_PROGRAMME_V1_FOLLOWUP
+ROLE: CHAMPAGNE_CONTRACT_RUNTIME_READINESS_DIAGNOSTIC_V1
 
 MISSION:
-Review the non-runtime Champagne OS contract schemas and validators added under `contracts/champagne-os/` and decide whether to add CI-only validation wiring. Do not wire schemas into runtime app code.
+Perform a read-only readiness review for future Website OS / Live Canvas runtime wiring. Do not implement runtime code.
 
 SCOPE:
-- Champagne repo only.
-- No runtime app code.
+- Read-only diagnostics only.
+- No runtime app code changes.
 - No UI changes.
-- No deployment.
+- No deploy.
 - No provider calls.
-- No secrets, PHI, PMS, or production mutation.
-- Preserve sacred-zone boundaries.
+- No PHI/PMS/secrets access.
+- No production mutation.
 
-REQUIRED CHECKS:
-- Run targeted contract tests.
-- Run `npm run guard:hero`.
-- Run `npm run guard:canon`.
-- Run `npm run verify`.
+OBJECTIVES:
+1. Confirm `contract:validate` and `guard:champagne-contracts` are still wired and passing.
+2. Identify the exact files that would require fresh Director authorization before runtime wiring.
+3. Propose a disabled-by-default dry-run adapter design that cannot mutate production.
+4. Propose additional failure tests needed before any runtime adapter is implemented.
+5. Produce a readiness report only.
 
-OUTPUT:
-- Report whether CI-only wiring is recommended.
-- If implemented, keep it non-runtime and fail-closed.
+REQUIRED COMMANDS:
+- `pnpm run guard:champagne-contracts`
+- `node --test tests/contracts/champagne-contract-validator.test.mjs`
+- `pnpm run guard:hero`
+- `pnpm run guard:canon`
+- `pnpm run verify`
+
+DELIVERABLE:
+- `CHAMPAGNE_CONTRACT_RUNTIME_READINESS_REPORT_V1.md`

--- a/TEST_RESULTS_V1.md
+++ b/TEST_RESULTS_V1.md
@@ -1,13 +1,15 @@
 # TEST_RESULTS_V1
 
-## Targeted Tests
-- `node --test tests/contracts/champagne-contract-validator.test.mjs` — PASS.
-- `node scripts/validate-champagne-contract-packet.mjs contracts/champagne-os/fixtures/valid-website-os-import-packet.json contracts/champagne-os/fixtures/valid-website-os-patch-proposal.json` — PASS.
+## Commands Run
 
-## Required Guards
-- `npm run guard:hero` — PASS.
-- `npm run guard:canon` — PASS.
-- `npm run verify` — PASS.
+| Command | Result | Notes |
+| --- | --- | --- |
+| `pnpm run guard:champagne-contracts` | PASS | Validated all safe `valid-*.json` contract fixtures. |
+| `node --test tests/contracts/champagne-contract-validator.test.mjs` | PASS | Confirmed valid fixtures pass and invalid fixtures fail closed. |
+| `pnpm run guard:hero` | PASS | Hero guard and sacred hero lock passed. |
+| `pnpm run guard:canon` | PASS | Canon guard passed; emitted existing Browserslist/Tailwind warnings only. |
+| `pnpm run verify` | PASS | Full verify completed, including the new contract guard, aggregate guards, lint, typecheck, and web build; emitted existing non-fatal warnings. |
 
 ## Notes
-- `npm run verify` emitted existing non-fatal warnings about Browserslist age, Tailwind content pattern breadth, workspace dependency legacy allowlist entries, SEO inventory count drift, and missing optional chatbot QA/conversation files. The command exited successfully.
+- No provider calls, deploys, PHI/PMS access, secret access, or production mutations were performed.
+- No runtime app code was changed.

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "guard:seo-launch-safety": "node scripts/seo-launch-safety-check.mjs",
     "hero:fit:sacred": "node scripts/hero_fit_sacred.mjs",
     "hero:match:sacred": "pnpm exec playwright install --with-deps chromium && node scripts/hero_match_sacred.mjs",
-    "verify": "node scripts/verify-token-purity.cjs && pnpm run guard:workspace-deps && pnpm run guard:seo-launch-safety && pnpm run guard:all && pnpm run lint && pnpm run typecheck && CI=1 pnpm run build:web",
+    "verify": "node scripts/verify-token-purity.cjs && pnpm run guard:workspace-deps && pnpm run guard:seo-launch-safety && pnpm run guard:champagne-contracts && pnpm run guard:all && pnpm run lint && pnpm run typecheck && CI=1 pnpm run build:web",
     "export:page-truth": "node scripts/export-page-truth.mjs",
     "guard:stock-canon": "node scripts/guard-stock-canon.mjs",
     "guard:no-phi-logs-stock": "node scripts/guard-no-phi-logs-stock.mjs",
@@ -37,7 +37,9 @@
     "seo:answer-packet-qa": "node scripts/seo-ai-answer-priority-service-packet-qa.mjs",
     "seo:answer-rendering-qa": "node scripts/seo-visible-answer-surface-rendering-qa.mjs",
     "cutover:validate": "node scripts/validate-cutover-inventory.mjs data/cutover/wordpress-url-inventory.csv && node scripts/validate-redirect-map.mjs data/cutover/redirect-map.csv",
-    "cutover:test": "node --test tests/cutover/redirect-map.coverage.test.mjs"
+    "cutover:test": "node --test tests/cutover/redirect-map.coverage.test.mjs",
+    "contract:validate": "node scripts/validate-champagne-contract-packet.mjs",
+    "guard:champagne-contracts": "node scripts/guard-champagne-contracts.mjs"
   },
   "dependencies": {
     "framer-motion": "^11.11.17",

--- a/scripts/guard-champagne-contracts.mjs
+++ b/scripts/guard-champagne-contracts.mjs
@@ -1,0 +1,36 @@
+#!/usr/bin/env node
+import fs from "node:fs";
+import path from "node:path";
+import { validateFile } from "../contracts/champagne-os/contract-validator.mjs";
+
+const repoRoot = path.resolve(new URL("..", import.meta.url).pathname);
+const fixturesDir = path.join(repoRoot, "contracts/champagne-os/fixtures");
+const safeFixturePattern = /^valid-.*\.json$/;
+
+const files = fs
+  .readdirSync(fixturesDir)
+  .filter((file) => safeFixturePattern.test(file))
+  .sort()
+  .map((file) => path.join(fixturesDir, file));
+
+if (files.length === 0) {
+  console.error("FAIL no safe Champagne contract fixtures found.");
+  process.exit(1);
+}
+
+let failed = false;
+for (const file of files) {
+  const relativeFile = path.relative(repoRoot, file);
+  const result = validateFile(file);
+  if (result.valid) {
+    console.log(`PASS ${relativeFile}`);
+  } else {
+    failed = true;
+    console.error(`FAIL ${relativeFile}`);
+    for (const error of result.errors) console.error(`- ${error}`);
+  }
+}
+
+if (failed) process.exit(1);
+
+console.log(`Champagne contract guard passed (${files.length} safe fixture${files.length === 1 ? "" : "s"}).`);


### PR DESCRIPTION
### Motivation
- Provide a CI-only, fail-closed guard that validates Champagne Website OS / Live Canvas contract packets without adding any runtime wiring or mutation paths.

### Description
- Add `scripts/guard-champagne-contracts.mjs` which validates safe fixtures in `contracts/champagne-os/fixtures` using `validateFile` and fails if no safe fixtures exist or any fixture fails. 
- Expose the validator as npm scripts `contract:validate` and `guard:champagne-contracts` and insert `guard:champagne-contracts` into the root `verify` flow before aggregate guards and build. 
- Update `package.json` scripts and record results and guidance in `CHAMPAGNE_CONTRACT_CI_GUARD_IMPLEMENTATION_REPORT_V1.md` and `NEXT_CODEX_PROMPT_V1.md` to reflect a read-only readiness diagnostic scope. 
- Update `TEST_RESULTS_V1.md` with the executed guard/test commands and outcomes and assert no runtime app code, provider calls, PHI/PMS, secrets access, or production mutations were performed. 

### Testing
- `pnpm run guard:champagne-contracts` — PASS validating all safe `valid-*.json` fixtures. 
- `node --test tests/contracts/champagne-contract-validator.test.mjs` — PASS confirming valid fixtures pass and invalid fixtures fail closed. 
- `pnpm run guard:hero` — PASS. 
- `pnpm run guard:canon` — PASS with non-fatal warnings. 
- `pnpm run verify` — PASS and completed the full verify flow including the new contract guard.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4d11617d7883329fcecf93af4a277c)