### PR TITLE
Stabilize Hero V2 navigation lifecycle

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -164,6 +164,66 @@ jobs:
           set -euxo pipefail
           pnpm -w build:web
 
+  stage-b-regression:
+    name: stage-b-regression
+    runs-on: ubuntu-latest
+    env:
+      NEXT_PUBLIC_HERO_ENGINE: v2
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - name: Enable corepack + pnpm
+        run: |
+          set -euxo pipefail
+          corepack enable
+          corepack prepare pnpm@9.15.4 --activate
+          pnpm --version
+      - name: Install dependencies
+        run: |
+          set -euxo pipefail
+          pnpm install --frozen-lockfile
+      - name: Run Stage B contract guards
+        run: |
+          set -euxo pipefail
+          pnpm exec vitest run \
+            apps/web/app/_components/HeroMount.lifecycle-contract.test.ts \
+            apps/web/app/components/layout/Header.navigation-contract.test.ts
+      - name: Install Chromium
+        run: |
+          set -euxo pipefail
+          pnpm exec playwright install --with-deps chromium
+      - name: Build and start web workspace
+        run: |
+          set -euxo pipefail
+          pnpm -w build:web
+          pnpm --filter web start --hostname 127.0.0.1 --port 3000 \
+            > "$RUNNER_TEMP/stage-b-web.log" 2>&1 &
+          for attempt in {1..60}; do
+            if curl --fail --silent http://127.0.0.1:3000/ > /dev/null; then
+              exit 0
+            fi
+            sleep 1
+          done
+          cat "$RUNNER_TEMP/stage-b-web.log"
+          exit 1
+      - name: Run Stage B Chromium regression matrix
+        run: |
+          set -euxo pipefail
+          PLAYWRIGHT_BASE_URL=http://127.0.0.1:3000 \
+            pnpm exec playwright test \
+              tests/hero-v2-navigation-continuity.spec.ts \
+              --reporter=line
+      - name: Upload server log on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: stage-b-web-log
+          path: ${{ runner.temp }}/stage-b-web.log
+          if-no-files-found: ignore
+
   verify:
     name: verify
     runs-on: ubuntu-latest
@@ -175,6 +235,7 @@ jobs:
       - lint
       - typecheck
       - build-web
+      - stage-b-regression
     steps:
       - uses: actions/checkout@v4
       - name: Setup Node

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -171,9 +171,9 @@ jobs:
       NEXT_PUBLIC_FEATURE_BRAND_HERO: "true"
       NEXT_PUBLIC_HERO_ENGINE: v2
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: "20"
       - name: Enable corepack + pnpm
@@ -219,7 +219,7 @@ jobs:
               --reporter=line
       - name: Upload server log on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: stage-b-web-log
           path: ${{ runner.temp }}/stage-b-web.log

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -168,6 +168,7 @@ jobs:
     name: stage-b-regression
     runs-on: ubuntu-latest
     env:
+      NEXT_PUBLIC_FEATURE_BRAND_HERO: "true"
       NEXT_PUBLIC_HERO_ENGINE: v2
     steps:
       - uses: actions/checkout@v4

--- a/apps/web/app/_components/HeroMount.lifecycle-contract.test.ts
+++ b/apps/web/app/_components/HeroMount.lifecycle-contract.test.ts
@@ -5,17 +5,56 @@ import { describe, expect, it } from "vitest";
 
 const currentDir = dirname(fileURLToPath(import.meta.url));
 const mountSource = readFileSync(join(currentDir, "HeroMount.tsx"), "utf8");
+const rendererSource = readFileSync(
+  join(currentDir, "../components/hero/v2/HeroRendererV2.tsx"),
+  "utf8",
+);
+const clientSource = readFileSync(
+  join(currentDir, "../components/hero/v2/HeroV2Client.tsx"),
+  "utf8",
+);
 
 describe("HeroMount V2 lifecycle contract", () => {
   it("hands the server-built first frame to the persistent client renderer", () => {
     expect(mountSource).toContain("initialModel={v2Model}");
     expect(mountSource).toContain("initialPathname={pathnameKey}");
     expect(mountSource).toContain("<HeroRendererV2");
+    expect(rendererSource).toContain(
+      "const seededModel = initialModel ?? lastResolvedHeroV2Model",
+    );
+    expect(rendererSource).toContain(
+      "useState<HeroV2Model | null>(() => seededModel)",
+    );
+    expect(rendererSource).toContain(
+      "heroV2ModelCache.set(normalizedInitialPathname, initialModel)",
+    );
   });
 
   it("does not directly own the V2 surface stack or content-fade lifecycle", () => {
     expect(mountSource).not.toContain("HeroSurfaceStackV2");
     expect(mountSource).not.toContain("HeroContentFade");
     expect(mountSource).not.toContain("<HeroV2Frame");
+  });
+
+  it("keeps one memoized surface stack with a stable continuity identity", () => {
+    expect(clientSource).toContain(
+      "export const HeroSurfaceStackV2 = memo(HeroSurfaceStackV2Base)",
+    );
+    expect(clientSource).toContain('data-v2-persistent-stack="true"');
+    expect(clientSource).toContain(
+      "data-v2-stack-instance={instanceId.current}",
+    );
+  });
+
+  it("starts content visible and never hides it for reduced motion or a disabled fade", () => {
+    expect(clientSource).toContain(
+      "const [isVisible, setIsVisible] = useState(true)",
+    );
+    expect(clientSource).toContain(
+      "if (prefersReducedMotion || !HERO_CONTENT_FADE_ENABLED)",
+    );
+    expect(clientSource).toMatch(
+      /if \(prefersReducedMotion \|\| !HERO_CONTENT_FADE_ENABLED\) \{\s*setIsVisible\(true\)/,
+    );
   });
 });

--- a/apps/web/app/_components/HeroMount.lifecycle-contract.test.ts
+++ b/apps/web/app/_components/HeroMount.lifecycle-contract.test.ts
@@ -1,0 +1,21 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const currentDir = dirname(fileURLToPath(import.meta.url));
+const mountSource = readFileSync(join(currentDir, "HeroMount.tsx"), "utf8");
+
+describe("HeroMount V2 lifecycle contract", () => {
+  it("hands the server-built first frame to the persistent client renderer", () => {
+    expect(mountSource).toContain("initialModel={v2Model}");
+    expect(mountSource).toContain("initialPathname={pathnameKey}");
+    expect(mountSource).toContain("<HeroRendererV2");
+  });
+
+  it("does not directly own the V2 surface stack or content-fade lifecycle", () => {
+    expect(mountSource).not.toContain("HeroSurfaceStackV2");
+    expect(mountSource).not.toContain("HeroContentFade");
+    expect(mountSource).not.toContain("<HeroV2Frame");
+  });
+});

--- a/apps/web/app/_components/HeroMount.tsx
+++ b/apps/web/app/_components/HeroMount.tsx
@@ -2,7 +2,6 @@ import { headers } from "next/headers";
 
 import type { HeroRendererProps } from "../components/hero/HeroRenderer";
 import { buildHeroV2Model } from "../components/hero/v2/buildHeroV2Model";
-import { HeroContentFade, HeroSurfaceStackV2 } from "../components/hero/v2/HeroV2Client";
 import type { HeroRendererV2Props } from "../components/hero/v2/HeroRendererV2";
 
 const normalizeHeroPathname = (path?: string) => {
@@ -45,7 +44,7 @@ export async function HeroMount(props: HeroRendererProps) {
       }
     }
 
-    const { HeroContentV2, HeroRendererV2, HeroV2Frame } = await import("../components/hero/v2/HeroRendererV2");
+    const { HeroRendererV2 } = await import("../components/hero/v2/HeroRendererV2");
     const v2Props = props as HeroRendererV2Props;
     const v2PropsWithPath = { ...v2Props, pageSlugOrPath: pathname };
     const v2Model = await buildHeroV2Model(v2PropsWithPath);
@@ -70,30 +69,11 @@ export async function HeroMount(props: HeroRendererProps) {
         style={{ minHeight: "72vh" }}
         {...heroDebugAttributes}
       >
-        {v2Model ? (
-          <HeroV2Frame
-            layout={v2Model.layout}
-            gradient={v2Model.gradient}
-            rootStyle={{ ...v2PropsWithPath.rootStyle, ...v2Model.surfaceStack.surfaceVars }}
-            heroId={v2Model.surfaceStack.heroId}
-            variantId={v2Model.surfaceStack.variantId}
-            particlesPath={v2Model.surfaceStack.particlesPath}
-            particlesOpacity={v2Model.surfaceStack.particlesOpacity}
-            motionCount={v2Model.surfaceStack.motionLayers.length}
-            prm={v2Model.surfaceStack.prmEnabled}
-            debug={v2PropsWithPath.debug}
-          >
-            <HeroSurfaceStackV2
-              surfaceRef={v2PropsWithPath.surfaceRef}
-              {...v2Model.surfaceStack}
-            />
-            <HeroContentFade>
-              <HeroContentV2 content={v2Model.content} layout={v2Model.layout} />
-            </HeroContentFade>
-          </HeroV2Frame>
-        ) : (
-          <HeroRendererV2 {...v2PropsWithPath} />
-        )}
+        <HeroRendererV2
+          {...v2PropsWithPath}
+          initialModel={v2Model}
+          initialPathname={pathnameKey}
+        />
       </div>
     );
   }

--- a/apps/web/app/components/hero/v2/HeroRendererV2.tsx
+++ b/apps/web/app/components/hero/v2/HeroRendererV2.tsx
@@ -34,6 +34,8 @@ export interface HeroRendererV2Props {
     dotGridPosition: string;
     dotGridImageRendering: string;
   }>;
+  initialModel?: HeroV2Model | null;
+  initialPathname?: string;
 }
 
 export type HeroV2SurfaceLayerModel = {
@@ -115,6 +117,24 @@ const normalizeHeroPathname = (path?: string) => {
   const normalized = trimmed.split("?")[0]?.split("#")[0] ?? "/";
   if (!normalized) return "/";
   return normalized.startsWith("/") ? normalized : `/${normalized}`;
+};
+
+const resolvePageCategoryForPathname = (pathname: string) => {
+  if (pathname === "/") return "home";
+  if (pathname.startsWith("/treatments/")) return "treatment";
+  if (pathname.startsWith("/team/")) return "profile";
+  if (pathname === "/blog" || pathname.startsWith("/blog/")) return "editorial";
+  if (
+    pathname === "/about" ||
+    pathname === "/contact" ||
+    pathname === "/fees" ||
+    pathname === "/smile-gallery" ||
+    pathname === "/team" ||
+    pathname === "/treatments"
+  ) {
+    return "utility";
+  }
+  return undefined;
 };
 
 
@@ -746,12 +766,25 @@ export function HeroRendererV2(props: HeroRendererV2Props) {
     glueVars,
     rootStyle,
     surfaceRef,
+    initialModel,
+    initialPathname,
   } = props;
-  const [renderModel, setRenderModel] = useState<HeroV2Model | null>(() => lastResolvedHeroV2Model);
-  const renderModelRef = useRef<HeroV2Model | null>(lastResolvedHeroV2Model);
+  const normalizedInitialPathname = normalizeHeroPathname(initialPathname);
+  const seededModel = initialModel ?? lastResolvedHeroV2Model;
+  const [renderModel, setRenderModel] = useState<HeroV2Model | null>(() => seededModel);
+  const renderModelRef = useRef<HeroV2Model | null>(seededModel);
   const [isHeroVisuallyReady, setIsHeroVisuallyReady] = useState(false);
   const visualReadyRef = useRef(false);
   const debugEnabled = searchParams?.get("heroDebug") === "1";
+  const routePageCategory =
+    resolvePageCategoryForPathname(pathnameKey) ??
+    (pathnameKey === normalizedInitialPathname ? pageCategory : undefined);
+
+  useEffect(() => {
+    if (initialModel && initialPathname) {
+      heroV2ModelCache.set(normalizedInitialPathname, initialModel);
+    }
+  }, [initialModel, initialPathname, normalizedInitialPathname]);
 
   useEffect(() => {
     renderModelRef.current = renderModel;
@@ -789,7 +822,9 @@ export function HeroRendererV2(props: HeroRendererV2Props) {
 
   useEffect(() => {
     let isActive = true;
-    const cached = heroV2ModelCache.get(pathnameKey);
+    const cached =
+      heroV2ModelCache.get(pathnameKey) ??
+      (initialModel && pathnameKey === normalizedInitialPathname ? initialModel : undefined);
     if (cached) {
       setRenderModel(cached);
     }
@@ -804,7 +839,7 @@ export function HeroRendererV2(props: HeroRendererV2Props) {
       particles,
       filmGrain,
       diagnosticBoost,
-      pageCategory,
+      pageCategory: routePageCategory,
       glueVars,
     }).then((nextModel) => {
       if (!isActive) return;
@@ -825,7 +860,21 @@ export function HeroRendererV2(props: HeroRendererV2Props) {
     return () => {
       isActive = false;
     };
-  }, [debugEnabled, diagnosticBoost, filmGrain, glueVars, mode, pageCategory, particles, pathnameKey, prm, timeOfDay, treatmentSlug]);
+  }, [
+    debugEnabled,
+    diagnosticBoost,
+    filmGrain,
+    glueVars,
+    initialModel,
+    mode,
+    normalizedInitialPathname,
+    particles,
+    pathnameKey,
+    prm,
+    routePageCategory,
+    timeOfDay,
+    treatmentSlug,
+  ]);
 
   useEffect(() => {
     if (!debugEnabled) return;

--- a/apps/web/app/components/hero/v2/HeroV2Client.tsx
+++ b/apps/web/app/components/hero/v2/HeroV2Client.tsx
@@ -599,8 +599,10 @@ export function HeroContentFade({ children }: HeroContentFadeProps) {
   }, []);
 
   useEffect(() => {
-    if (prefersReducedMotion) return;
-    if (!HERO_CONTENT_FADE_ENABLED) return;
+    if (prefersReducedMotion || !HERO_CONTENT_FADE_ENABLED) {
+      setIsVisible(true);
+      return;
+    }
     setIsVisible(false);
     const id = requestAnimationFrame(() => setIsVisible(true));
     return () => cancelAnimationFrame(id);

--- a/apps/web/app/components/layout/Header.navigation-contract.test.ts
+++ b/apps/web/app/components/layout/Header.navigation-contract.test.ts
@@ -1,0 +1,24 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const currentDir = dirname(fileURLToPath(import.meta.url));
+const headerSource = readFileSync(join(currentDir, "Header.tsx"), "utf8");
+
+describe("Header navigation contract", () => {
+  it("hydrates the public header and routes ordinary clicks through the Next client router", () => {
+    expect(headerSource).toMatch(/^"use client";/);
+    expect(headerSource).toContain('import { useRouter } from "next/navigation"');
+    expect(headerSource).toContain("event.preventDefault()");
+    expect(headerSource).toContain("router.push(href)");
+  });
+
+  it("preserves native browser behaviour for modified and non-primary clicks", () => {
+    expect(headerSource).toContain("event.button !== 0");
+    expect(headerSource).toContain("event.metaKey");
+    expect(headerSource).toContain("event.ctrlKey");
+    expect(headerSource).toContain("event.shiftKey");
+    expect(headerSource).toContain("event.altKey");
+  });
+});

--- a/apps/web/app/components/layout/Header.tsx
+++ b/apps/web/app/components/layout/Header.tsx
@@ -1,5 +1,42 @@
+"use client";
+
 import { getMainNavItems } from "@champagne/manifests";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
+import type { MouseEvent, ReactNode } from "react";
+
+function StableNavigationLink({
+  href,
+  className,
+  children,
+}: {
+  href: string;
+  className: string;
+  children: ReactNode;
+}) {
+  const router = useRouter();
+  const handleClick = (event: MouseEvent<HTMLAnchorElement>) => {
+    if (
+      event.defaultPrevented ||
+      event.button !== 0 ||
+      event.metaKey ||
+      event.ctrlKey ||
+      event.shiftKey ||
+      event.altKey
+    ) {
+      return;
+    }
+
+    event.preventDefault();
+    router.push(href);
+  };
+
+  return (
+    <Link href={href} className={className} onClick={handleClick}>
+      {children}
+    </Link>
+  );
+}
 
 export function Header() {
   const navItems = getMainNavItems();
@@ -12,27 +49,30 @@ export function Header() {
     <header className="border-b" style={headerStyle}>
       <div className="mx-auto flex max-w-5xl flex-wrap items-center justify-between gap-4 px-6 py-4">
         <div className="min-w-0">
-          <Link href="/" className="text-lg font-semibold tracking-tight text-[var(--text-high)]">
+          <StableNavigationLink
+            href="/"
+            className="text-lg font-semibold tracking-tight text-[var(--text-high)]"
+          >
             St Mary&apos;s House Dental
-          </Link>
+          </StableNavigationLink>
           <p className="mt-1 text-xs text-[var(--text-medium)]">Private dental care in Shoreham-by-Sea</p>
         </div>
         <nav className="flex items-center gap-4 text-sm text-[var(--text-medium)]">
           {navItems.map((item) => (
-            <Link
+            <StableNavigationLink
               key={item.href}
               href={item.href}
               className="rounded px-2 py-1 transition-none hover:bg-[color-mix(in_srgb,var(--bg-ink)_82%,transparent)] hover:text-[var(--text-high)]"
             >
               {item.label}
-            </Link>
+            </StableNavigationLink>
           ))}
-          <Link
+          <StableNavigationLink
             href="/contact"
             className="rounded-full border border-[color:var(--border-subtle)] px-3 py-1.5 text-[var(--text-high)] transition-none hover:bg-[color-mix(in_srgb,var(--bg-ink)_82%,transparent)]"
           >
             Arrange a consultation
-          </Link>
+          </StableNavigationLink>
         </nav>
       </div>
     </header>

--- a/packages/champagne-sections/src/Section_TreatmentRoutingCards.tsx
+++ b/packages/champagne-sections/src/Section_TreatmentRoutingCards.tsx
@@ -1,5 +1,8 @@
+"use client";
+
 import Link from "next/link";
-import type { CSSProperties, ReactNode } from "react";
+import { useRouter } from "next/navigation";
+import type { CSSProperties, MouseEvent, ReactNode } from "react";
 import "@champagne/tokens";
 import type { SectionRegistryEntry } from "./SectionRegistry";
 
@@ -21,16 +24,36 @@ function RoutingCardLink({
   card: RoutingCard;
   children: ReactNode;
 }) {
+  const router = useRouter();
+  const internalAppHref = isInternalAppHref(card.href);
   const sharedProps = {
     href: card.href,
     style: cardStyle,
     "aria-label": `${card.title} pathway`,
     className: "champagne-routing-card",
   };
+  const handleClick = (event: MouseEvent<HTMLAnchorElement>) => {
+    if (
+      !internalAppHref ||
+      event.defaultPrevented ||
+      event.button !== 0 ||
+      event.metaKey ||
+      event.ctrlKey ||
+      event.shiftKey ||
+      event.altKey ||
+      event.currentTarget.hasAttribute("download") ||
+      (event.currentTarget.target && event.currentTarget.target !== "_self")
+    ) {
+      return;
+    }
 
-  if (isInternalAppHref(card.href)) {
+    event.preventDefault();
+    router.push(card.href);
+  };
+
+  if (internalAppHref) {
     return (
-      <Link {...sharedProps} prefetch={false}>
+      <Link {...sharedProps} prefetch={false} onClick={handleClick}>
         {children}
       </Link>
     );

--- a/packages/champagne-sections/src/Section_TreatmentRoutingCards.tsx
+++ b/packages/champagne-sections/src/Section_TreatmentRoutingCards.tsx
@@ -1,4 +1,5 @@
-import type { CSSProperties } from "react";
+import Link from "next/link";
+import type { CSSProperties, ReactNode } from "react";
 import "@champagne/tokens";
 import type { SectionRegistryEntry } from "./SectionRegistry";
 
@@ -7,6 +8,35 @@ interface RoutingCard {
   description?: string;
   href: string;
   tag?: string;
+}
+
+function isInternalAppHref(href: string) {
+  return href.startsWith("/") && !href.startsWith("//");
+}
+
+function RoutingCardLink({
+  card,
+  children,
+}: {
+  card: RoutingCard;
+  children: ReactNode;
+}) {
+  const sharedProps = {
+    href: card.href,
+    style: cardStyle,
+    "aria-label": `${card.title} pathway`,
+    className: "champagne-routing-card",
+  };
+
+  if (isInternalAppHref(card.href)) {
+    return (
+      <Link {...sharedProps} prefetch={false}>
+        {children}
+      </Link>
+    );
+  }
+
+  return <a {...sharedProps}>{children}</a>;
 }
 
 const containerStyle: CSSProperties = {
@@ -173,12 +203,9 @@ export function Section_TreatmentRoutingCards({ section }: { section?: SectionRe
       </div>
       <div style={gridStyle}>
         {cards.map((card) => (
-          <a
+          <RoutingCardLink
             key={`${card.title}-${card.href}`}
-            href={card.href}
-            style={cardStyle}
-            aria-label={`${card.title} pathway`}
-            className="champagne-routing-card"
+            card={card}
           >
             {card.tag && <span style={badgeStyle}>{card.tag}</span>}
             <div style={cardTitle}>{card.title}</div>
@@ -198,7 +225,7 @@ export function Section_TreatmentRoutingCards({ section }: { section?: SectionRe
                 →
               </span>
             </span>
-          </a>
+          </RoutingCardLink>
         ))}
       </div>
     </section>

--- a/tests/hero-v2-navigation-continuity.spec.ts
+++ b/tests/hero-v2-navigation-continuity.spec.ts
@@ -1,101 +1,228 @@
-import { expect, test } from "playwright/test";
+import { expect, test, type Page } from "playwright/test";
 
 const BASE_URL = process.env.PLAYWRIGHT_BASE_URL ?? "http://127.0.0.1:3000";
+const STACK_SELECTOR = "[data-v2-stack-instance]";
+const CONTENT_SELECTOR = '[data-v2-content-fade="true"]';
 
-test("Hero V2 survives public client navigation without a document reload", async ({ page }) => {
-  const routeRequests: Array<{ resourceType: string; rsc: string | undefined }> = [];
+type VideoSnapshot = {
+  id: string;
+  nodeMarker: string;
+  currentTime: number;
+  duration: number;
+  paused: boolean;
+};
+
+type ContinuitySnapshot = {
+  documentMarker: string | null;
+  stack: string | null;
+  sampledAt: number;
+  videos: VideoSnapshot[];
+};
+
+function attachRuntimeErrorCollectors(page: Page) {
   const pageErrors: string[] = [];
-  const hydrationErrors: string[] = [];
+  const relevantConsoleErrors: string[] = [];
 
-  page.on("request", (request) => {
-    if (request.url().includes("/treatments")) {
-      routeRequests.push({
-        resourceType: request.resourceType(),
-        rsc: request.headers().rsc,
-      });
-    }
-  });
   page.on("pageerror", (error) => pageErrors.push(error.message));
   page.on("console", (message) => {
     if (
       message.type() === "error" &&
-      /hydration|did not match|server rendered html/i.test(message.text())
+      /hydration|did not match|server rendered html|uncaught|runtime error/i.test(
+        message.text(),
+      )
     ) {
-      hydrationErrors.push(message.text());
+      relevantConsoleErrors.push(message.text());
     }
   });
 
-  await page.goto(`${BASE_URL}/?heroDebug=1`, { waitUntil: "networkidle" });
+  return { pageErrors, relevantConsoleErrors };
+}
+
+async function expectHealthyHero(page: Page) {
   await expect(page.locator('[data-hero-engine="v2"]')).toBeVisible();
-  await expect(page.locator("[data-v2-stack-instance]")).toHaveCount(1);
-  await page.waitForTimeout(500);
+  await expect(page.locator(STACK_SELECTOR)).toHaveCount(1);
+  await expect(page.locator(CONTENT_SELECTOR)).toHaveCSS("opacity", "1");
+}
 
-  const before = await page.evaluate(() => {
-    const marker = crypto.randomUUID();
+async function markContinuity(page: Page): Promise<ContinuitySnapshot> {
+  return page.evaluate(() => {
+    const documentMarker = crypto.randomUUID();
     const stack = document.querySelector<HTMLElement>("[data-v2-stack-instance]");
     const videos = Array.from(
       document.querySelectorAll<HTMLVideoElement>("[data-v2-stack-instance] video"),
     );
-    window.__heroStageBDocumentMarker = marker;
+
+    window.__heroStageBDocumentMarker = documentMarker;
     videos.forEach((video, index) => {
-      video.dataset.stageBNodeMarker = `video-${index}`;
+      video.dataset.stageBNodeMarker = `video-${index}-${crypto.randomUUID()}`;
     });
+
     return {
-      marker,
+      documentMarker,
       stack: stack?.dataset.v2StackInstance ?? null,
+      sampledAt: performance.now(),
       videos: videos.map((video) => ({
         id: video.dataset.surfaceId ?? "",
         nodeMarker: video.dataset.stageBNodeMarker ?? "",
         currentTime: video.currentTime,
+        duration: video.duration,
+        paused: video.paused,
       })),
     };
   });
+}
 
-  routeRequests.length = 0;
-  await page.locator('header a[href="/treatments"]').click();
-  await page.waitForURL("**/treatments");
-  await page.waitForLoadState("networkidle");
-  await expect(page.locator('[data-v2-content-fade="true"]')).toHaveCSS("opacity", "1");
-
-  const after = await page.evaluate(() => {
+async function readContinuity(page: Page): Promise<ContinuitySnapshot> {
+  return page.evaluate(() => {
     const stack = document.querySelector<HTMLElement>("[data-v2-stack-instance]");
     const videos = Array.from(
       document.querySelectorAll<HTMLVideoElement>("[data-v2-stack-instance] video"),
     );
+
     return {
-      marker: window.__heroStageBDocumentMarker ?? null,
+      documentMarker: window.__heroStageBDocumentMarker ?? null,
       stack: stack?.dataset.v2StackInstance ?? null,
+      sampledAt: performance.now(),
       videos: videos.map((video) => ({
         id: video.dataset.surfaceId ?? "",
         nodeMarker: video.dataset.stageBNodeMarker ?? "",
         currentTime: video.currentTime,
+        duration: video.duration,
+        paused: video.paused,
       })),
     };
   });
+}
 
-  expect(after.marker).toBe(before.marker);
+function expectLoopAwareContinuity(
+  before: ContinuitySnapshot,
+  after: ContinuitySnapshot,
+) {
+  expect(after.documentMarker).toBe(before.documentMarker);
   expect(after.stack).toBe(before.stack);
-  expect(routeRequests.some((request) => request.resourceType === "document")).toBe(false);
-  expect(routeRequests.some((request) => request.rsc === "1")).toBe(true);
-  expect(pageErrors).toEqual([]);
-  expect(hydrationErrors).toEqual([]);
 
   const sharedVideos = before.videos.filter((beforeVideo) =>
     after.videos.some((afterVideo) => afterVideo.id === beforeVideo.id),
   );
   expect(sharedVideos.length).toBeGreaterThan(0);
+
+  const elapsedSeconds = (after.sampledAt - before.sampledAt) / 1000;
   for (const beforeVideo of sharedVideos) {
     const afterVideo = after.videos.find((video) => video.id === beforeVideo.id);
     expect(afterVideo?.nodeMarker).toBe(beforeVideo.nodeMarker);
-    expect(afterVideo?.currentTime ?? 0).toBeGreaterThanOrEqual(
-      Math.max(0, beforeVideo.currentTime - 0.1),
-    );
+    expect(afterVideo?.duration).toBeCloseTo(beforeVideo.duration, 2);
+
+    if (
+      !beforeVideo.paused &&
+      afterVideo &&
+      Number.isFinite(beforeVideo.duration) &&
+      beforeVideo.duration > 0
+    ) {
+      const duration = beforeVideo.duration;
+      const actualProgress =
+        (afterVideo.currentTime - beforeVideo.currentTime + duration) % duration;
+      const expectedProgress = elapsedSeconds % duration;
+      const circularDistance = Math.min(
+        Math.abs(actualProgress - expectedProgress),
+        duration - Math.abs(actualProgress - expectedProgress),
+      );
+
+      // The same DOM node must advance as a looping clock. Allow scheduling and
+      // decoding tolerance without treating a natural loop wrap as a reset.
+      expect(circularDistance).toBeLessThan(1.5);
+    }
+  }
+}
+
+test("Hero V2 survives client navigation, a treatment child, back and forward", async ({
+  page,
+}) => {
+  const routeRequests: Array<{
+    url: string;
+    resourceType: string;
+    rsc: string | undefined;
+  }> = [];
+  const errors = attachRuntimeErrorCollectors(page);
+
+  page.on("request", (request) => {
+    if (request.url().includes("/treatments")) {
+      routeRequests.push({
+        url: request.url(),
+        resourceType: request.resourceType(),
+        rsc: request.headers().rsc,
+      });
+    }
+  });
+
+  await page.goto(`${BASE_URL}/?heroDebug=1`, { waitUntil: "networkidle" });
+  await expectHealthyHero(page);
+  await page.waitForTimeout(500);
+  const before = await markContinuity(page);
+
+  routeRequests.length = 0;
+  await page.locator('header a[href="/treatments"]').click();
+  await page.waitForURL("**/treatments");
+  await page.waitForLoadState("networkidle");
+  await expectHealthyHero(page);
+
+  await page.locator('a[href="/treatments/implants"]').first().click();
+  await page.waitForURL("**/treatments/implants");
+  await page.waitForLoadState("networkidle");
+  await expectHealthyHero(page);
+
+  await page.goBack({ waitUntil: "networkidle" });
+  await expect(page).toHaveURL(`${BASE_URL}/treatments`);
+  await expectHealthyHero(page);
+
+  await page.goForward({ waitUntil: "networkidle" });
+  await expect(page).toHaveURL(`${BASE_URL}/treatments/implants`);
+  await expectHealthyHero(page);
+
+  const after = await readContinuity(page);
+  expectLoopAwareContinuity(before, after);
+  expect(routeRequests.some((request) => request.resourceType === "document")).toBe(
+    false,
+  );
+  expect(routeRequests.some((request) => request.rsc === "1")).toBe(true);
+  expect(errors.pageErrors).toEqual([]);
+  expect(errors.relevantConsoleErrors).toEqual([]);
+});
+
+test("Hero V2 renders correctly on direct treatment routes", async ({ page }) => {
+  const errors = attachRuntimeErrorCollectors(page);
+
+  for (const route of ["/treatments", "/treatments/implants"]) {
+    await page.goto(`${BASE_URL}${route}`, { waitUntil: "networkidle" });
+    await expect(page).toHaveURL(`${BASE_URL}${route}`);
+    await expectHealthyHero(page);
   }
 
+  expect(errors.pageErrors).toEqual([]);
+  expect(errors.relevantConsoleErrors).toEqual([]);
+});
+
+test("Hero V2 remains visible with reduced motion on desktop and mobile", async ({
+  page,
+}) => {
+  const errors = attachRuntimeErrorCollectors(page);
   await page.emulateMedia({ reducedMotion: "reduce" });
-  await page.getByRole("navigation").getByRole("link", { name: "Home" }).click();
-  await page.waitForURL(`${BASE_URL}/`);
-  await expect(page.locator('[data-v2-content-fade="true"]')).toHaveCSS("opacity", "1");
+
+  for (const viewport of [
+    { width: 1440, height: 900 },
+    { width: 390, height: 844 },
+  ]) {
+    await page.setViewportSize(viewport);
+    await page.goto(`${BASE_URL}/?heroDebug=1`, { waitUntil: "networkidle" });
+    await expectHealthyHero(page);
+
+    await page.locator('header a[href="/treatments"]').click();
+    await page.waitForURL("**/treatments");
+    await page.waitForLoadState("networkidle");
+    await expectHealthyHero(page);
+  }
+
+  expect(errors.pageErrors).toEqual([]);
+  expect(errors.relevantConsoleErrors).toEqual([]);
 });
 
 declare global {

--- a/tests/hero-v2-navigation-continuity.spec.ts
+++ b/tests/hero-v2-navigation-continuity.spec.ts
@@ -1,0 +1,105 @@
+import { expect, test } from "playwright/test";
+
+const BASE_URL = process.env.PLAYWRIGHT_BASE_URL ?? "http://127.0.0.1:3000";
+
+test("Hero V2 survives public client navigation without a document reload", async ({ page }) => {
+  const routeRequests: Array<{ resourceType: string; rsc: string | undefined }> = [];
+  const pageErrors: string[] = [];
+  const hydrationErrors: string[] = [];
+
+  page.on("request", (request) => {
+    if (request.url().includes("/treatments")) {
+      routeRequests.push({
+        resourceType: request.resourceType(),
+        rsc: request.headers().rsc,
+      });
+    }
+  });
+  page.on("pageerror", (error) => pageErrors.push(error.message));
+  page.on("console", (message) => {
+    if (
+      message.type() === "error" &&
+      /hydration|did not match|server rendered html/i.test(message.text())
+    ) {
+      hydrationErrors.push(message.text());
+    }
+  });
+
+  await page.goto(`${BASE_URL}/?heroDebug=1`, { waitUntil: "networkidle" });
+  await expect(page.locator('[data-hero-engine="v2"]')).toBeVisible();
+  await expect(page.locator("[data-v2-stack-instance]")).toHaveCount(1);
+  await page.waitForTimeout(500);
+
+  const before = await page.evaluate(() => {
+    const marker = crypto.randomUUID();
+    const stack = document.querySelector<HTMLElement>("[data-v2-stack-instance]");
+    const videos = Array.from(
+      document.querySelectorAll<HTMLVideoElement>("[data-v2-stack-instance] video"),
+    );
+    window.__heroStageBDocumentMarker = marker;
+    videos.forEach((video, index) => {
+      video.dataset.stageBNodeMarker = `video-${index}`;
+    });
+    return {
+      marker,
+      stack: stack?.dataset.v2StackInstance ?? null,
+      videos: videos.map((video) => ({
+        id: video.dataset.surfaceId ?? "",
+        nodeMarker: video.dataset.stageBNodeMarker ?? "",
+        currentTime: video.currentTime,
+      })),
+    };
+  });
+
+  routeRequests.length = 0;
+  await page.locator('header a[href="/treatments"]').click();
+  await page.waitForURL("**/treatments");
+  await page.waitForLoadState("networkidle");
+  await expect(page.locator('[data-v2-content-fade="true"]')).toHaveCSS("opacity", "1");
+
+  const after = await page.evaluate(() => {
+    const stack = document.querySelector<HTMLElement>("[data-v2-stack-instance]");
+    const videos = Array.from(
+      document.querySelectorAll<HTMLVideoElement>("[data-v2-stack-instance] video"),
+    );
+    return {
+      marker: window.__heroStageBDocumentMarker ?? null,
+      stack: stack?.dataset.v2StackInstance ?? null,
+      videos: videos.map((video) => ({
+        id: video.dataset.surfaceId ?? "",
+        nodeMarker: video.dataset.stageBNodeMarker ?? "",
+        currentTime: video.currentTime,
+      })),
+    };
+  });
+
+  expect(after.marker).toBe(before.marker);
+  expect(after.stack).toBe(before.stack);
+  expect(routeRequests.some((request) => request.resourceType === "document")).toBe(false);
+  expect(routeRequests.some((request) => request.rsc === "1")).toBe(true);
+  expect(pageErrors).toEqual([]);
+  expect(hydrationErrors).toEqual([]);
+
+  const sharedVideos = before.videos.filter((beforeVideo) =>
+    after.videos.some((afterVideo) => afterVideo.id === beforeVideo.id),
+  );
+  expect(sharedVideos.length).toBeGreaterThan(0);
+  for (const beforeVideo of sharedVideos) {
+    const afterVideo = after.videos.find((video) => video.id === beforeVideo.id);
+    expect(afterVideo?.nodeMarker).toBe(beforeVideo.nodeMarker);
+    expect(afterVideo?.currentTime ?? 0).toBeGreaterThanOrEqual(
+      Math.max(0, beforeVideo.currentTime - 0.1),
+    );
+  }
+
+  await page.emulateMedia({ reducedMotion: "reduce" });
+  await page.getByRole("navigation").getByRole("link", { name: "Home" }).click();
+  await page.waitForURL(`${BASE_URL}/`);
+  await expect(page.locator('[data-v2-content-fade="true"]')).toHaveCSS("opacity", "1");
+});
+
+declare global {
+  interface Window {
+    __heroStageBDocumentMarker?: string;
+  }
+}

--- a/tests/hero-v2-navigation-continuity.spec.ts
+++ b/tests/hero-v2-navigation-continuity.spec.ts
@@ -134,6 +134,22 @@ function expectLoopAwareContinuity(
   }
 }
 
+async function expectDocumentAndStackContinuity(
+  page: Page,
+  before: ContinuitySnapshot,
+  checkpoint: string,
+) {
+  const current = await readContinuity(page);
+  expect(
+    current.documentMarker,
+    `${checkpoint}: the document marker must survive`,
+  ).toBe(before.documentMarker);
+  expect(
+    current.stack,
+    `${checkpoint}: the Hero V2 stack instance must survive`,
+  ).toBe(before.stack);
+}
+
 test("Hero V2 survives client navigation, a treatment child, back and forward", async ({
   page,
 }) => {
@@ -164,19 +180,27 @@ test("Hero V2 survives client navigation, a treatment child, back and forward", 
   await page.waitForURL("**/treatments");
   await page.waitForLoadState("networkidle");
   await expectHealthyHero(page);
+  await expectDocumentAndStackContinuity(page, before, "home -> treatments");
 
   await page.locator('a[href="/treatments/implants"]').first().click();
   await page.waitForURL("**/treatments/implants");
   await page.waitForLoadState("networkidle");
   await expectHealthyHero(page);
+  await expectDocumentAndStackContinuity(
+    page,
+    before,
+    "treatments -> treatment child",
+  );
 
   await page.goBack({ waitUntil: "networkidle" });
   await expect(page).toHaveURL(`${BASE_URL}/treatments`);
   await expectHealthyHero(page);
+  await expectDocumentAndStackContinuity(page, before, "browser back");
 
   await page.goForward({ waitUntil: "networkidle" });
   await expect(page).toHaveURL(`${BASE_URL}/treatments/implants`);
   await expectHealthyHero(page);
+  await expectDocumentAndStackContinuity(page, before, "browser forward");
 
   const after = await readContinuity(page);
   expectLoopAwareContinuity(before, after);


### PR DESCRIPTION
## Stage B — hydration and lifecycle stabilization

Founder implementation token: `CHAMPAGNE_STAGE_B_HYDRATION_AND_LIFECYCLE_STABILIZATION`

Main Directorate plan acceptance: `MAIN_DIRECTORATE_ACCEPTS_CHAMPAGNE_STAGE_B_HYDRATION_AND_LIFECYCLE_STABILIZATION_PLAN_V2`

Finalisation authority: `MAIN_AND_FOUNDER_AUTHORITY_ACTIVE_FOR_EXACT_FINALISATION_MERGE_AUTOMATIC_PRODUCTION_AND_BOUNDED_ROLLBACK`

### Exact identity

- base: `main` at `d7473be168343fd71918362bc71891575c5e6d39`
- exact review head: `615ecde2a3474c8e2a0a7e93d63476166a0a8609`
- exact review tree: `acbe5d3b4f26aef7eb1abf5f2ae229440950f520`
- branch: `codex/champagne-stage-b-hydration-lifecycle-stabilization-v2`

### Root cause

The public header rendered valid anchors, but ordinary clicks were not being intercepted by the client router. Each navigation therefore requested a new HTML document. Hero V2 was also assembled as a route-specific server snapshot, so the reload destroyed and recreated the layered surface stack and video elements.

### What changed

- hydrate the public header and route ordinary unmodified clicks through the Next client router
- apply the same supported internal-routing continuity to treatment routing cards
- preserve native behaviour for modified, non-primary, external and special-protocol clicks
- seed the persistent client renderer with the server-built Hero V2 model
- hand lifecycle ownership to the existing path-aware V2 client renderer
- cache the initial model and resolve page category from the live pathname after navigation
- force content visibility when reduced motion is preferred or content fading is disabled
- add static navigation/lifecycle contract tests
- add mandatory Chromium continuity coverage
- pin the three newly introduced Stage B GitHub Actions references to reviewed immutable commits

### Founder regression lock

The lifecycle contract and browser guard now fail verification if a future change silently removes:

- the server-model handoff into the persistent renderer
- the seeded initial V2 model and initial model cache
- the single memoized Hero V2 surface-stack owner
- `data-v2-persistent-stack` or stable `data-v2-stack-instance` identity
- initially visible content
- forced content visibility for reduced motion or disabled fading
- client-router navigation continuity
- shared video-node/currentTime continuity
- RSC navigation, hydration, page-error or relevant console-error assertions

### Exact nine-path scope

1. `.github/workflows/verify.yml`
2. `apps/web/app/_components/HeroMount.lifecycle-contract.test.ts`
3. `apps/web/app/_components/HeroMount.tsx`
4. `apps/web/app/components/hero/v2/HeroRendererV2.tsx`
5. `apps/web/app/components/hero/v2/HeroV2Client.tsx`
6. `apps/web/app/components/layout/Header.navigation-contract.test.ts`
7. `apps/web/app/components/layout/Header.tsx`
8. `packages/champagne-sections/src/Section_TreatmentRoutingCards.tsx`
9. `tests/hero-v2-navigation-continuity.spec.ts`

No tokens, colours, redesign, content, media, manifests, sacred Hero package, dependencies, lockfiles, environment values, chatbot, Hero V3, Stage C, Agent, Router or WEOS files changed.

### Exact-head evidence

- Champagne CI `30620630099`: passed
- stage-b-regression, Chromium matrix and verify: passed
- production build, TypeScript, lint and all guards: passed
- CodeQL `30620629928`: passed
- Semgrep `30620629836`: passed
- Gitleaks `30620629771`: passed
- Trivy `30620629926`: passed
- SBOM `30620629761`: passed
- Vercel preview `dpl_3nwMZTbZrMmSXq9imwivSo9KVfnU`: READY and bound to exact head
- independent exact-head review: `ACCEPT_WITH_DISCLOSED_LIMITATIONS`
- actionable findings: zero

### Evidence limitations

The earliest streamed capture can show the stable brand gradient before text and motion settle; the complete Hero V2 is visible by the 120ms evidence frame and remains visible at 1500ms. This is bounded and produced no hydration error.

Safari/WebKit remains untested and is not represented as passed. Chromium desktop, mobile and reduced-motion evidence passed.

### Production consequence and rollback

Merging to `main` triggers the Git-integrated Vercel production deployment. Exact finalisation, merge, automatic production, production validation and bounded rollback are separately authorised. If material production validation fails, rollback is through an auditable revert commit and restoration of the prior READY deployment; history must not be rewritten.
